### PR TITLE
Add prefix to global VERSION variable

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -3,7 +3,7 @@
  *
  * GPLv3
  */
-var VERSION = 4;
+var TREZOR_CONNECT_VERSION = 4;
 
 if (!Array.isArray) {
     Array.isArray = function(arg) {
@@ -36,7 +36,7 @@ this.TrezorConnect = (function () {
     var DISABLE_LOGIN_BUTTONS = window.TREZOR_DISABLE_LOGIN_BUTTONS || false;
     var CHROME_URL = window.TREZOR_CHROME_URL || './chrome/wrapper.html';
     var POPUP_ORIGIN = window.TREZOR_POPUP_ORIGIN || 'https://connect.trezor.io';
-    var POPUP_PATH = window.TREZOR_POPUP_PATH || POPUP_ORIGIN + '/' + VERSION;
+    var POPUP_PATH = window.TREZOR_POPUP_PATH || POPUP_ORIGIN + '/' + TREZOR_CONNECT_VERSION;
     if (window.location.hostname === 'localhost' && !window.TREZOR_POPUP_ORIGIN) {
         // development settings
         POPUP_ORIGIN = window.location.origin;


### PR DESCRIPTION
Hi there!

First of all, thank you for keeping all your software open and enabling others to tinker with it!

While getting my feet wet with this lib, I realised that the `VERSION` variable is leaking into the global namespace. It is a very generic name so this could lead to problems with other libraries.

This is a first small fix that adds a prefix to the variable, I tried to do this according to the naming of the other global vars.

I think another solution could be to move the variable into the scope of [window.TrezorConnect](https://github.com/trezor/connect/blob/master/connect.js#L24) as it does not seem to be used anywhere else. This would mean that the version and the URL of the popup can not be determined from the outside. I am not sure if this is a valid use case: to load connect.js v4 but require the popup of another version?

Keep up the good work!

Best,
Christian