### PR TITLE
Fix Signing of Multisig Testnet Transactions

### DIFF
--- a/popup/src/backend/ComposingTransaction.js
+++ b/popup/src/backend/ComposingTransaction.js
@@ -64,10 +64,10 @@ export default class ComposingTransaction {
     }
 }
 
-// signTX validation 
-export const validateInputs = (inputs) => {
+// signTX validation
+export const validateInputs = (inputs, network) => {
     const bitcoreInputs = [];
-    const trezorInputs = inputs.map(fixPath).map(convertXpub);
+    const trezorInputs = inputs.map(fixPath).map(convertXpub.bind(null, network));
 
     for (let utxo of trezorInputs) {
         let segwit = (utxo.address_n[0] >>> 0) === ((49 | HD_HARDENED) >>> 0);
@@ -89,9 +89,9 @@ export const validateInputs = (inputs) => {
     return { trezorInputs, bitcoreInputs };
 }
 
-// signTX validation 
-export const validateOutputs = (outputs) => {
-    const trezorOutputs = outputs.map(fixPath).map(convertXpub);
+// signTX validation
+export const validateOutputs = (outputs, network) => {
+    const trezorOutputs = outputs.map(fixPath).map(convertXpub.bind(null, network));
     for (let output of trezorOutputs) {
         if (output.address_n) {
             let segwit = (output.address_n[0] >>> 0) === ((49 | HD_HARDENED) >>> 0);

--- a/popup/src/popup.js
+++ b/popup/src/popup.js
@@ -986,16 +986,15 @@ function handleEthereumSignTx(event) {
  */
 
 function handleSignTx(event) {
-    
+
     show('#operation_signtx');
 
     initDevice()
 
         .then((device) => {
-            const { trezorInputs, bitcoreInputs } = validateInputs(event.data.inputs);
-            const outputs = validateOutputs(event.data.outputs);
             return getBitcoreBackend().then(() => {
-
+                const { trezorInputs, bitcoreInputs } = validateInputs(event.data.inputs, backend.coinInfo.network);
+                const outputs = validateOutputs(event.data.outputs, backend.coinInfo.network);
                 let total = outputs.reduce((t, r) => t + r.amount, 0);
                 if (total <= backend.coinInfo.dustLimit) {
                     throw AMOUNT_TOO_LOW;

--- a/popup/src/utils/path.js
+++ b/popup/src/utils/path.js
@@ -12,8 +12,8 @@ export const serializePath = (path) => {
     }).join('/');
 }
 
-export const xpubToHDNodeType = (xpub) => {
-    let hd = bitcoin.HDNode.fromBase58(xpub);
+export const xpubToHDNodeType = (xpub, network) => {
+    let hd = bitcoin.HDNode.fromBase58(xpub, network);
     return {
         depth: hd.depth,
         child_num: hd.index,
@@ -31,12 +31,12 @@ export const fixPath = (o) => {
     return o;
 };
 
-export const convertXpub = (o) => {
+export const convertXpub = (network, o) => {
     if (o.multisig && o.multisig.pubkeys) {
         // convert xpubs to HDNodeTypes
         o.multisig.pubkeys.forEach(pk => {
             if (typeof pk.node === 'string') {
-                pk.node = xpubToHDNodeType(pk.node);
+                pk.node = xpubToHDNodeType(pk.node, network);
             }
         });
     }


### PR DESCRIPTION
This addresses the "Invalid network value" error described in https://github.com/trezor/connect/issues/81#issuecomment-356499200. 

When using https://connect.trezor.io/4/connect.js and attempting to sign a multisig testnet transaction, `HDNode.fromBase58()` isn't passed any network data and defaults to mainnet. 

![34756250-84eafc9a-f597-11e7-91f1-fd2ae52ea757](https://user-images.githubusercontent.com/3699124/34759949-c7910c1a-f5ab-11e7-9040-d6ee7963835d.gif)
  