### PR TITLE
Change URL for Bitcore (Monacoin).

### DIFF
--- a/popup/coins.json
+++ b/popup/coins.json
@@ -430,7 +430,7 @@
 	"min_address_length": 27,
 	"max_address_length": 34,
 	"bitcore": [
-		"https://mona.chainsight.info"
+		"https://mona.insight.monaco-ex.org"
 	]
 },
 {


### PR DESCRIPTION
mona.chainsight.info is not maintained well and it cannot handle SegWit transactions.
Newer URL can handle them.