### PR TITLE
Convert a negative number in path into an unsigned integer

### DIFF
--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -33,11 +33,13 @@ export const validatePath = (path: string | Array<number>): Array<number> => {
         valid = getHDPath(path);
     } else if (Array.isArray(path)) {
         valid = path.map((p: any) => {
-            const n: number = parseInt(p);
+            let n: number = parseInt(p);
             if (isNaN(p)) {
                 throw new Error('Not a valid path.');
+            } else if (n < 0) {
+                n *= -1;
+                return (n | HD_HARDENED) >>> 0;
             }
-            // return (n | HD_HARDENED) >>> 0;
             return n;
         });
     }


### PR DESCRIPTION
When validating wallet's path with negative numbers convert those numbers into unsigned integers.