### PR TITLE
Update connect.js license to match the rest of the repo

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -1,7 +1,7 @@
 /**
  * (C) 2017 SatoshiLabs
  *
- * GPLv3
+ * LGPLv3
  */
 var TREZOR_CONNECT_VERSION = 4;
 


### PR DESCRIPTION
Hi guys!

It looks like at some point you updated the license to LGPLv3  ([here](https://github.com/trezor/connect/commit/6165a94bff8ad83bced00e4e7d84cbc8f7840abf)) but the connect.js file is still mentioning GPLv3

If there is a reason for that could you please clarify?

Thanks!