### PR TITLE
ethereumSignMessage - Skip hex conversion if message is already hex

### DIFF
--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -6,6 +6,7 @@ import { validateParams } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
 import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
+import { makeHexEven } from '../../utils/formatUtils';
 
 import type { MessageSignature } from '../../types/trezor';
 import type { CoreMessage } from '../../types';
@@ -39,11 +40,15 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         this.info = getNetworkLabel('Sign #NETWORK message', network);
 
-        const messageHex: string = Buffer.from(payload.message, 'utf8').toString('hex');
+        let messageHex = payload.message;
+        if (!payload.message.startsWith('0x')) {
+            messageHex = Buffer.from(payload.message, 'utf8').toString('hex');
+        }
+
         this.params = {
             path,
             network,
-            message: messageHex,
+            message: makeHexEven(messageHex)
         };
     }
 

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -42,7 +42,7 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         let messageHex;
         if (payload.message.startsWith('0x')) {
-            messageHex = makeHexEven(messageHex);
+            messageHex = makeHexEven(payload.message);
         } else {
             messageHex = Buffer.from(payload.message, 'utf8').toString('hex');
         }

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -5,8 +5,7 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
-import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
-import { makeHexEven } from '../../utils/formatUtils';
+import { toChecksumAddress, getNetworkLabel, messageToHex } from '../../utils/ethereumUtils';
 
 import type { MessageSignature } from '../../types/trezor';
 import type { CoreMessage } from '../../types';
@@ -40,13 +39,7 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         this.info = getNetworkLabel('Sign #NETWORK message', network);
 
-        let messageHex;
-        if (payload.message.startsWith('0x')) {
-            messageHex = makeHexEven(payload.message);
-        } else {
-            messageHex = Buffer.from(payload.message, 'utf8').toString('hex');
-        }
-
+        const messageHex = messageToHex(payload.message);
         this.params = {
             path,
             network,

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -40,15 +40,17 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         this.info = getNetworkLabel('Sign #NETWORK message', network);
 
-        let messageHex = payload.message;
-        if (!payload.message.startsWith('0x')) {
+        let messageHex;
+        if (payload.message.startsWith('0x')) {
+            messageHex = makeHexEven(messageHex);
+        } else {
             messageHex = Buffer.from(payload.message, 'utf8').toString('hex');
         }
 
         this.params = {
             path,
             network,
-            message: makeHexEven(messageHex)
+            message: messageHex
         };
     }
 

--- a/src/js/utils/ethereumUtils.js
+++ b/src/js/utils/ethereumUtils.js
@@ -38,7 +38,7 @@ export const getNetworkLabel = (label: string, network: ?EthereumNetworkInfo): s
 
 // from (isHexString) https://github.com/ethjs/ethjs-util/blob/master/src/index.js
 const isHexString = (value: string, length?: number) => {
-    if (typeof value !== 'string' || !value.match(/^0x[0-9A-Fa-f]*$/)) {
+    if (typeof value !== 'string' || !value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {
         return false;
     }
     if (length && value.length !== 2 + 2 * length) { return false; }

--- a/src/js/utils/formatUtils.js
+++ b/src/js/utils/formatUtils.js
@@ -39,19 +39,3 @@ export const formatTime = (n: number): string => {
 export const btckb2satoshib = (n: number): number => {
     return Math.round(n * 1e5);
 };
-
-/**
- * Prepend 0 in case of uneven hex char count
- * @param input The hex input
- */
-export function makeHexEven(input: string): string {
-    if (!input) return undefined;
-
-    let output;
-    if (input.length % 2 !== 0) {
-      output = `0${input.slice(2)}`;
-    } else {
-      output = input.slice(2);
-    }
-    return output;
-}

--- a/src/js/utils/formatUtils.js
+++ b/src/js/utils/formatUtils.js
@@ -39,3 +39,19 @@ export const formatTime = (n: number): string => {
 export const btckb2satoshib = (n: number): number => {
     return Math.round(n * 1e5);
 };
+
+/**
+ * Prepend 0 in case of uneven hex char count
+ * @param input The hex input
+ */
+export function makeHexEven(input: string): string {
+    if (!input) return undefined;
+
+    let output;
+    if (input.length % 2 !== 0) {
+      output = `0${input.slice(2)}`;
+    } else {
+      output = input.slice(2);
+    }
+    return output;
+}


### PR DESCRIPTION
To prevent the data loss issue explained in https://github.com/trezor/connect/issues/216, Trezor Connect should check if the data passed into `ethereumSignMessage` is already hex and only convert if necessary.