### PR TITLE
version 5.0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.0.33
 __fixed__
 - `TrezorConnect.ethereumSignMessage` and `TrezorConnect.ethereumVerifyMessage` methods with "hex" parameter
+- flowtype for `TrezorConnect.cardanoGetPublicKey` in `TrezorConnect.cardanoSignTransaction` methods
 
 # 5.0.32
 __added__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.33
+__fixed__
+- `TrezorConnect.ethereumSignMessage` and `TrezorConnect.ethereumVerifyMessage` methods with "hex" parameter
+
 # 5.0.32
 __added__
 - Added `TrezorConnect.cardanoGetPublicKey` method

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TREZOR Connect API version 5.0.32
+# TREZOR Connect API version 5.0.33
 
 TREZOR Connect is a platform for easy integration of TREZOR into 3rd party services. It provides API with functionality to access public keys, sign transactions and authenticate users. User interface is presented in a secure popup window served from `https://connect.trezor.io/5/popup.html`
 

--- a/docs/methods/ethereumSignMessage.md
+++ b/docs/methods/ethereumSignMessage.md
@@ -19,6 +19,7 @@ TrezorConnect.ethereumSignMessage(params).then(function(result) {
 ###### [flowtype](../../src/js/types/params.js#L64-L67)
 * `path` — *obligatory* `string | Array<number>` minimum length is `3`. [read more](path.md)
 * `message` - *obligatory* `string` message to sign in plain text
+* `hex` - *optional* `boolean` convert message from hex
 
 ### Example
 ```javascript

--- a/docs/methods/ethereumVerifyMessage.md
+++ b/docs/methods/ethereumVerifyMessage.md
@@ -20,6 +20,7 @@ TrezorConnect.ethereumVerifyMessage(params).then(function(result) {
 ###### [flowtype](../../src/js/types/params.js#L74-L78)
 * `address` - *obligatory* `string` signer address. "0x" prefix is optional
 * `message` - *obligatory* `string` signed message in plain text
+* `hex` - *optional* `boolean` convert message from hex
 * `signature` - *obligatory* `string` signature in hexadecimal format. "0x" prefix is optional
 
 ### Example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trezor-connect",
-  "version": "5.0.32",
+  "version": "5.0.33",
   "author": "TREZOR <info@trezor.io>",
   "homepage": "https://github.com/trezor/connect",
   "description": "High-level javascript interface for TREZOR hardware wallet.",

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -14,6 +14,7 @@ type Params = {
     inputs: Array<CardanoTxInput>,
     outputs: Array<CardanoTxOutput>,
     transactions: Array<string>,
+    network: number,
 }
 
 export default class CardanoSignTransaction extends AbstractMethod {

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -32,6 +32,7 @@ export default class EthereumSignMessage extends AbstractMethod {
         validateParams(payload, [
             { name: 'path', obligatory: true },
             { name: 'message', type: 'string', obligatory: true },
+            { name: 'hex', type: 'boolean' },
         ]);
 
         const path: Array<number> = validatePath(payload.path, 3);
@@ -39,7 +40,7 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         this.info = getNetworkLabel('Sign #NETWORK message', network);
 
-        const messageHex = messageToHex(payload.message);
+        const messageHex = payload.hex ? messageToHex(payload.message) : Buffer.from(payload.message, 'utf8').toString('hex');
         this.params = {
             path,
             network,

--- a/src/js/core/methods/EthereumVerifyMessage.js
+++ b/src/js/core/methods/EthereumVerifyMessage.js
@@ -31,9 +31,10 @@ export default class EthereumVerifyMessage extends AbstractMethod {
             { name: 'address', type: 'string', obligatory: true },
             { name: 'signature', type: 'string', obligatory: true },
             { name: 'message', type: 'string', obligatory: true },
+            { name: 'hex', type: 'boolean' },
         ]);
 
-        const messageHex: string = messageToHex(payload.message);
+        const messageHex = payload.hex ? messageToHex(payload.message) : Buffer.from(payload.message, 'utf8').toString('hex');
         this.params = {
             address: stripHexPrefix(payload.address),
             signature: stripHexPrefix(payload.signature),

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -27,7 +27,7 @@ export type ConnectSettings = {
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION: string = '5.0.32';
+const VERSION: string = '5.0.33';
 const versionN: Array<number> = VERSION.split('.').map(s => parseInt(s));
 const DIRECTORY: string = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DEFAULT_DOMAIN: string = `https://connect.trezor.io/${ DIRECTORY }`;

--- a/src/js/types/cardano.js
+++ b/src/js/types/cardano.js
@@ -21,7 +21,6 @@ export type CardanoPublicKey = {
     serializedPath: string,
     publicKey: string,
     node: HDPubNode,
-    hdPassphrase: string,
 }
 
 export type CardanoGetPublicKey$ = $Common & {

--- a/src/js/types/ethereum.js
+++ b/src/js/types/ethereum.js
@@ -64,7 +64,8 @@ export type EthereumSignTransaction$ = {
 export type $EthereumSignMessage = $Common & {
     path: $Path,
     message: string,
-}
+    hex?: boolean,
+};
 
 export type EthereumSignMessage$ = {
     success: true,
@@ -76,6 +77,7 @@ export type EthereumSignMessage$ = {
 export type $EthereumVerifyMessage = $Common & {
     address: string,
     message: string,
+    hex?: boolean,
     signature: string,
 }
 
@@ -83,4 +85,3 @@ export type EthereumVerifyMessage$ = {
     success: true,
     payload: Success,
 } | Unsuccessful$;
-


### PR DESCRIPTION
hotfix for https://github.com/trezor/connect/issues/222

# 5.0.33
__fixed__
- `TrezorConnect.ethereumSignMessage` and `TrezorConnect.ethereumVerifyMessage` methods with "hex" parameter
