### PR TITLE
Removed 2 hidden unicode characters in regex

### DIFF
--- a/src/js/iframe/builder.js
+++ b/src/js/iframe/builder.js
@@ -42,7 +42,7 @@ export const init = async (settings: ConnectSettings): Promise<void> => {
     }
 
     // eslint-disable-next-line no-irregular-whitespace, no-useless-escape
-    const iframeSrcHost: ?Array<string> = instance.src.match(/^.+\:\/\/[^\‌​/]+/);
+    const iframeSrcHost: ?Array<string> = instance.src.match(/^.+\:\/\/[^\/]+/);
     if (iframeSrcHost && iframeSrcHost.length > 0) { origin = iframeSrcHost[0]; }
 
     timeout = window.setTimeout(() => {

--- a/src/js/utils/networkUtils.js
+++ b/src/js/utils/networkUtils.js
@@ -30,6 +30,6 @@ export const httpRequest = async (url: string, type: string = 'text'): any => {
 
 export const getOrigin = (url: string) => {
     // eslint-disable-next-line no-irregular-whitespace, no-useless-escape
-    const parts: ?Array<string> = url.match(/^.+\:\/\/[^\‌​/]+/);
+    const parts: ?Array<string> = url.match(/^.+\:\/\/[^\/]+/);
     return (Array.isArray(parts) && parts.length > 0) ? parts[0] : 'unknown';
 };


### PR DESCRIPTION
Fixes #227 
these characters will turn into unicode format in production builds, something like these:
/^.+\:\/\/[^\\u200c\u200b/]+/

so the library won't work in production builds with an iframe timeout.