### PR TITLE
Change network for protocol magic when signing tx on cardano

### DIFF
--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -21,7 +21,7 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `inputs` — *obligatory* `Array` of [CardanoInput](../../src/js/types/cardano.js#L31)
 * `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/cardano.js#L37)
 * `transactions` - *obligatory* `Array` of strings
-* `network` - *obligatory* `Integer` 1 for Testnet and 2 for Mainnet
+* `protcol magic` - *obligatory* `Integer` 764824073 for Mainnet, 1097911063 for Testnet
 
 ### Example
 ```javascript
@@ -52,7 +52,7 @@ TrezorConnect.cardanoSignTransaction({
         "839f8200d818582482582008abb575fac4c39d5bf80683f7f0c37e48f4e3d96e37d1f6611919a7241b456600ff9f8282d818582183581cda4da43db3fca93695e71dab839e72271204d28b9d964d306b8800a8a0001a7a6916a51a00305becffa0",
         "839f8200d818582482582008abb575fac4c39d5bf80683f7f0c37e48f4e3d96e37d1f6611919a7241b456600ff9f8282d818582183581cda4da43db3fca93695e71dab839e72271204d28b9d964d306b8800a8a0001a7a6916a51a00305becffa0",
     ],
-    network: 1
+    protocol_magic: 764824073
 });
 ```
 

--- a/src/__tests__/core/cardanoSignTransaction.spec.js
+++ b/src/__tests__/core/cardanoSignTransaction.spec.js
@@ -35,7 +35,7 @@ export const cardanoSignTransaction = (): TestFunction => {
             inputs,
             outputs,
             transactions,
-            network: 2,
+            protocol_magic: 764824073,
         },
     ];
 

--- a/src/data/messages.json
+++ b/src/data/messages.json
@@ -1021,8 +1021,8 @@
                     "rule": "optional",
                     "options": {},
                     "type": "uint32",
-                    "name": "network",
-                    "id": 4
+                    "name": "protocol_magic",
+                    "id": 5
                 }
             ],
             "enums": [],

--- a/src/flowtype/tests/cardano-sign-transaction.js
+++ b/src/flowtype/tests/cardano-sign-transaction.js
@@ -19,7 +19,7 @@ declare module 'flowtype/tests/cardano-sign-transaction' {
         inputs: Array<CardanoInput>,
         outputs: Array<CardanoOutput>,
         transactions: Array<string>,
-        network: number,
+        protocol_magic: number,
     };
 
     declare export type ExpectedCardanoSignTransactionResponse = {

--- a/src/js/core/methods/CardanoGetAddress.js
+++ b/src/js/core/methods/CardanoGetAddress.js
@@ -28,7 +28,7 @@ export default class CardanoGetAddress extends AbstractMethod {
         super(message);
 
         this.requiredPermissions = ['read'];
-        this.requiredFirmware = ['0', '2.0.8'];
+        this.requiredFirmware = ['0', '2.0.11'];
 
         // create a bundle with only one batch if bundle doesn't exists
         const payload: Object = !message.payload.hasOwnProperty('bundle') ? { ...message.payload, bundle: [ ...message.payload ] } : message.payload;

--- a/src/js/core/methods/CardanoGetPublicKey.js
+++ b/src/js/core/methods/CardanoGetPublicKey.js
@@ -31,14 +31,14 @@ export default class CardanoGetPublicKey extends AbstractMethod {
         super(message);
 
         this.requiredPermissions = ['read'];
-        this.requiredFirmware = ['0', '2.0.8'];
+        this.requiredFirmware = ['0', '2.0.11'];
         this.info = 'Export Cardano public key';
 
         const payload: Object = message.payload;
         let bundledResponse: boolean = true;
         // create a bundle with only one batch
         if (!payload.hasOwnProperty('bundle')) {
-            payload.bundle = [ ...payload ];
+            payload.bundle = [...payload];
             bundledResponse = false;
         }
 
@@ -85,7 +85,7 @@ export default class CardanoGetPublicKey extends AbstractMethod {
         if (this.params.bundle.length > 1) {
             label = 'Export multiple Cardano public keys';
         } else {
-            label = `Export Cardano public key for account #${ (fromHardened(this.params.bundle[0].path[2]) + 1) }`;
+            label = `Export Cardano public key for account #${(fromHardened(this.params.bundle[0].path[2]) + 1)}`;
         }
 
         // request confirmation view

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -14,7 +14,7 @@ type Params = {
     inputs: Array<CardanoTxInput>,
     outputs: Array<CardanoTxOutput>,
     transactions: Array<string>,
-    network: number,
+    protocol_magic: number,
 }
 
 export default class CardanoSignTransaction extends AbstractMethod {
@@ -23,7 +23,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['read', 'write'];
-        this.requiredFirmware = ['0', '2.0.8'];
+        this.requiredFirmware = ['0', '2.0.11'];
         this.info = 'Sign Cardano transaction';
 
         const payload: Object = message.payload;
@@ -32,7 +32,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             { name: 'inputs', type: 'array', obligatory: true },
             { name: 'outputs', type: 'array', obligatory: true },
             { name: 'transactions', type: 'array', obligatory: true },
-            { name: 'network', type: 'number', obligatory: true },
+            { name: 'protocol_magic', type: 'number', obligatory: true },
         ]);
 
         const inputs: Array<CardanoTxInput> = payload.inputs.map(input => {
@@ -73,7 +73,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             inputs,
             outputs,
             transactions: payload.transactions,
-            network: payload.network,
+            protocol_magic: payload.protocol_magic,
         };
     }
 
@@ -83,7 +83,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             this.params.inputs,
             this.params.outputs,
             this.params.transactions,
-            this.params.network,
+            this.params.protocol_magic,
         );
 
         return {

--- a/src/js/core/methods/helpers/cardanoSignTx.js
+++ b/src/js/core/methods/helpers/cardanoSignTx.js
@@ -27,13 +27,13 @@ export const cardanoSignTx = async (typedCall: (type: string, resType: string, m
     inputs: Array<CardanoTxInput>,
     outputs: Array<CardanoTxOutput>,
     transactions: Array<string>,
-    network: number,
+    protocol_magic: number,
 ): Promise<CardanoSignedTx> => {
     const response: MessageResponse<CardanoTxRequest> = await typedCall('CardanoSignTx', 'CardanoTxRequest', {
         inputs: inputs,
         outputs: outputs,
         transactions_count: transactions.length,
-        network: network,
+        protocol_magic: protocol_magic,
     });
     return await processTxRequest(typedCall, response.message, transactions);
 };

--- a/src/js/types/cardano.js
+++ b/src/js/types/cardano.js
@@ -73,7 +73,7 @@ export type $CardanoSignTransaction = $Common & {
     inputs: Array<CardanoInput>,
     outputs: Array<CardanoOutput>,
     transactions: Array<string>,
-    network: number,
+    protocol_magic: number,
 }
 
 export type CardanoSignedTx = {


### PR DESCRIPTION
We revisited the "network" attribute that was sent in the cardanoSignTransaction call and we suggest replacing it directly with the protocol magic, which makes it more flexible, since it allows you to sign a transaction for any cardano blockchain. This proves useful for custom cardano testnets.

Related to https://github.com/trezor/trezor-core/pull/417 and https://github.com/trezor/trezor-common/pull/244