### PR TITLE
Hotfix/v7/requestlogin error handler

### DIFF
--- a/src/js/core/methods/RequestLogin.js
+++ b/src/js/core/methods/RequestLogin.js
@@ -68,6 +68,11 @@ export default class RequestLogin extends AbstractMethod {
             const uiResp: UiPromiseResponse = await this.createUiPromise(UI.LOGIN_CHALLENGE_RESPONSE, this.device).promise;
             const payload: Object = uiResp.payload;
 
+            // error handler
+            if (typeof payload === 'string') {
+                throw new Error(`TrezorConnect.requestLogin callback error: ${payload}`);
+            }
+
             // validate incoming parameters
             validateParams(payload, [
                 { name: 'challengeHidden', type: 'string', obligatory: true },

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -116,7 +116,7 @@ export const parse = (input: ?Object): ConnectSettings => {
 
     // local files
     if (typeof window !== 'undefined' && window.location.protocol === 'file:') {
-        settings.origin = window.location.origin + window.location.pathname;
+        settings.origin = `file://${window.location.pathname}`;
         settings.webusb = false;
     }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -303,12 +303,21 @@ class TrezorConnect {
             const loginChallengeListener = async (event: $T.PostMessageEvent) => {
                 const data = event.data;
                 if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
-                    const payload = await callback();
-                    iframe.postMessage({
-                        event: UI_EVENT,
-                        type: UI.LOGIN_CHALLENGE_RESPONSE,
-                        payload,
-                    });
+                    try {
+                        const payload = await callback();
+                        iframe.postMessage({
+                            event: UI_EVENT,
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload,
+                        });
+                    } catch (error) {
+                        console.warn('TrezorConnect.requestLogin: callback error', error);
+                        iframe.postMessage({
+                            event: UI_EVENT,
+                            type: UI.LOGIN_CHALLENGE_RESPONSE,
+                            payload: error.message,
+                        });
+                    }
                 }
             };
 


### PR DESCRIPTION
RequestLogin hotfix:
- catch error from callback function
- hardcoded protocol for "file://" origin, fix for Firefox issue where window.location.origin === "null" (string)