### PR TITLE
disable "getJoinSplitData" from non-zcash transactions

### DIFF
--- a/src/flowtype/npm/bitcoinjs-lib.js
+++ b/src/flowtype/npm/bitcoinjs-lib.js
@@ -261,6 +261,9 @@ declare module 'bitcoinjs-lib-zcash' {
         timestamp?: number,
         ins: Array<Input>,
         outs: Array<Output>,
+        zcash: boolean,
+        versionGroupId: string,
+        expiry: number,
 
         constructor(): void,
         static fromHex(hex: string, zcash: boolean, hasTimestamp?: boolean): Transaction,

--- a/src/js/core/methods/tx/refTx.js
+++ b/src/js/core/methods/tx/refTx.js
@@ -56,7 +56,7 @@ export const transformReferencedTransactions = (txs: Array<BitcoinJsTransaction>
 };
 
 const getJoinSplitData = (transaction: BitcoinJsTransaction): ?Buffer => {
-    if (transaction.version < 2) {
+    if (transaction.version < 2 || !transaction.zcash) {
         return null;
     }
     const buffer = transaction.toBuffer();


### PR DESCRIPTION
zcash condition was removed from bitcoinjs-lib-zcash, in commit: https://github.com/karel-3d/bitcoinjs-lib/commit/91b78266163f745c7053fae683f9a66a474a42b1, line 331-333

fixes: #345