### PR TITLE
Allow to sign transactions without backend (#369)

### DIFF
--- a/src/js/backend/BlockBook.js
+++ b/src/js/backend/BlockBook.js
@@ -51,9 +51,6 @@ export default class BlockBook {
     discovery: Discovery;
 
     constructor(options: Options) {
-        if (options.urls.length < 1) {
-            throw ERROR.BACKEND_NO_URL;
-        }
         this.options = options;
 
         const worker: FastXpubWorker = new FastXpubWorker();


### PR DESCRIPTION
Allow to sign self-contained transactions even if the coin has no backend