### PR TITLE
Export input / output types for Cardano

### DIFF
--- a/src/js/types/cardano.js
+++ b/src/js/types/cardano.js
@@ -55,13 +55,13 @@ export type CardanoGetAddress$$ = $Common & {
 
 // Sign transaction
 
-type CardanoInput = {
+export type CardanoInput = {
     path: $Path,
     prev_hash: string,
     prev_index: number,
     type: number,
 }
-type CardanoOutput = {
+export type CardanoOutput = {
     path: $Path,
     amount: string,
 } | {


### PR DESCRIPTION
I can't think of any reason why these should not be exported (I assume it was just an oversight). 