### PR TITLE
Fix Flow error

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "file-loader": "^3.0.1",
-    "flow-bin": "0.91.0",
+    "flow-bin": "0.103.0",
     "fs-extra": "^7.0.1",
     "hd-wallet": "8.2.3",
     "html-webpack-plugin": "^3.2.0",

--- a/src/js/data/CoinInfo.js
+++ b/src/js/data/CoinInfo.js
@@ -7,9 +7,15 @@ const bitcoinNetworks: Array<BitcoinNetworkInfo> = [];
 const ethereumNetworks: Array<EthereumNetworkInfo> = [];
 const miscNetworks: Array<MiscNetworkInfo> = [];
 
-export const cloneCoinInfo: <T>(info: T) => T = (ci) => {
-    return JSON.parse(JSON.stringify(ci));
-};
+export function cloneCoinInfo<T>(info: T): T {
+    const jsonString = JSON.stringify(info);
+    if (jsonString === undefined) {
+        // jsonString === undefined IF and only IF obj === undefined
+        // therefore no need to clone
+        return info;
+    }
+    return JSON.parse(jsonString);
+}
 
 export const getBitcoinNetwork = (pathOrName: Array<number> | string): ?BitcoinNetworkInfo => {
     const networks: Array<BitcoinNetworkInfo> = cloneCoinInfo(bitcoinNetworks);

--- a/src/js/iframe/builder.js
+++ b/src/js/iframe/builder.js
@@ -35,8 +35,10 @@ export const init = async (settings: ConnectSettings): Promise<void> => {
         instance.id = 'trezorconnect';
     }
 
-    const manifest = `&version=${settings.version}&manifest=${encodeURIComponent(btoa(JSON.stringify(settings.manifest)))}`;
-    const src: string = `${settings.iframeSrc}?${ Date.now() }${ manifest }`;
+    const manifestParam = settings.manifest
+        ? JSON.stringify(settings.manifest)
+        : 'undefined'; // note: btoa(undefined) === btoa('undefined') === "dW5kZWZpbmVk"
+    const src: string = `${settings.iframeSrc}?${ Date.now() }${ manifestParam }`;
     instance.setAttribute('src', src);
     if (settings.webusb) {
         instance.setAttribute('allow', 'usb');

--- a/src/js/popup/PopupManager.js
+++ b/src/js/popup/PopupManager.js
@@ -131,7 +131,7 @@ export default class PopupManager extends EventEmitter {
         if (this.extension) {
             // $FlowIssue chrome not declared outside
             chrome.windows.getCurrent(null, currentWindow => {
-                // Request comming from extension popup,
+                // Request coming from extension popup,
                 // create new window above instead of opening new tab
                 if (currentWindow.type !== 'normal') {
                     // $FlowIssue chrome not declared outside
@@ -176,6 +176,7 @@ export default class PopupManager extends EventEmitter {
                 return;
             }
             this.extensionPort = port;
+            // $FlowIssue need to update ChromePort definition
             this.extensionPort.onMessage.addListener(this.handleExtensionMessage);
         } else if (port.name === 'trezor-usb-permissions') {
             port.postMessage({ broadcast: this.broadcast });

--- a/src/js/utils/objectUtils.js
+++ b/src/js/utils/objectUtils.js
@@ -2,7 +2,13 @@
 'use strict';
 
 export function clone<T>(obj: T): T {
-    return JSON.parse(JSON.stringify(obj));
+    const jsonString = JSON.stringify(obj);
+    if (jsonString === undefined) {
+        // jsonString === undefined IF and only IF obj === undefined
+        // therefore no need to clone
+        return obj;
+    }
+    return JSON.parse(jsonString);
 }
 
 export function entries<T>(obj: { [string]: T }): Array<[string, T]> {


### PR DESCRIPTION
In later versions of Flow, the return type of `JSON.stringify` changed from `string` to `string | typeof undefinied` because `JSON.stringify(undefinied) === undefined`.

This PR simply gets rid of these Flow errors and at the same time upgrades to Flow `0.103.0`

Note: to upgrade, either [this PR](https://github.com/trezor/hd-wallet/pull/39) needs to be merged or we need to ignore this file in `.flowconfig`

## Notes about the fixes

1) The type of `ChromePort` is wrong but I didn't really want to spend time on this so I added `// $FlowIssue need to update ChromePort definition`
1) I had to change `cloneCoinInfo` into a function instead of a variable. This is because Flow inference for generics is not good -- especially in this case. You can see [here](https://flow.org/try/#0KYDwDg9gTgLgBAYwgOwM7wGYQgLjgHgBUA+ACgCMBDKPQgSjgF5i5Cm5SQmWQ6BuIA) Flow even fails to infer the type of an identity function when it uses a generic. You can verify my change [here](https://flow.org/try/#0KYDwDg9gTgLgBAMwK4DsDGMCWEVzQGx2AGEJMUBJFBCAHgBUA+ACnJoC456BKT+uAN4AoOKLw4AzvABWEnAGUYUcgHM4AXjgApeQHkAcgDopylCswIAnq2oRuAbhFiLcZrIVLVG9ZtQATYARyYD9uQScxMQB6KLh3FEVTNR9fFACglBC4CgAxOABDNLgcfEtsvIgAI2lvVPTgvwjIuBi4GAALYChA6GA4FAh+4CyYQYIiJsjumCQoXDYIR0iAXybp2dwdA0MwfKgJYDc5BM8zByFVoTRJeHzOFCQAW0qujTgAVkdrlCk4Svuni8oG9xplSOQqDRmPkHC1YrsJBICkjQGBgBgQkIrjc8JwAPwPZ6vTSfbE-eB+AFE4GaUEkMiUWzMNCw1oIfKYfBI-Io8DomCYsm-YD4wlAt6k76-BCiwHEvCEMEMyEQZms+E87m8tEYvxAA)