### PR TITLE
stellar plugin: support empty manageData value

### DIFF
--- a/src/js/plugins/stellar/plugin.js
+++ b/src/js/plugins/stellar/plugin.js
@@ -30,16 +30,6 @@ const transformSigner = (signer) => {
 };
 
 /**
- * Transforms StellarSdk.Asset array to TrezorConnect.StellarTransaction.Asset
- * array
- * @param {...StellarSdk.Asset} path
- * @returns { ... type: 0 | 1 | 2, code: string, issuer?: string }
- */
-const transformPath = (path) => {
-  return path.map(transformAsset);
-};
-
-/**
  * Transforms StellarSdk.Asset to TrezorConnect.StellarTransaction.Asset
  * @param {StellarSdk.Asset} asset
  * @returns { type: 0 | 1 | 2, code: string, issuer?: string }
@@ -146,7 +136,7 @@ const transformTransaction = (path, transaction) => {
 
         // transform asset path
         if (operation.path) {
-          operation.path = transformPath(operation.path);
+          operation.path = operation.path.map(transformAsset);
         }
 
         // transform "price" field to { n: number, d: number }

--- a/src/js/plugins/stellar/plugin.js
+++ b/src/js/plugins/stellar/plugin.js
@@ -163,7 +163,7 @@ const transformTransaction = (path, transaction) => {
             operation.assetType = transformAsset(allowTrustAsset).type;
         }
 
-        if (operation.type === 'manageData') {
+        if (operation.type === 'manageData' && operation.value) {
             // stringify is not necessary, Buffer is also accepted
             operation.value = operation.value.toString('hex');
         }

--- a/src/js/plugins/stellar/plugin.js
+++ b/src/js/plugins/stellar/plugin.js
@@ -30,6 +30,16 @@ const transformSigner = (signer) => {
 };
 
 /**
+ * Transforms StellarSdk.Asset array to TrezorConnect.StellarTransaction.Asset
+ * array
+ * @param {...StellarSdk.Asset} path
+ * @returns { ... type: 0 | 1 | 2, code: string, issuer?: string }
+ */
+const transformPath = (path) => {
+  return path.map(transformAsset);
+};
+
+/**
  * Transforms StellarSdk.Asset to TrezorConnect.StellarTransaction.Asset
  * @param {StellarSdk.Asset} asset
  * @returns { type: 0 | 1 | 2, code: string, issuer?: string }
@@ -132,6 +142,11 @@ const transformTransaction = (path, transaction) => {
         // transform StellarSdk.Signer
         if (operation.signer) {
             operation.signer = transformSigner(operation.signer);
+        }
+
+        // transform asset path
+        if (operation.path) {
+          operation.path = transformPath(operation.path);
         }
 
         // transform "price" field to { n: number, d: number }


### PR DESCRIPTION
While this is not part of the API documentation, manageData value may happen to be `undefined` for the purpose of deleting the account data entry from the ledger.

**Edit:** Added support for assets path