### PR TITLE
Enable access to unsupported browsers

### DIFF
--- a/src/__tests__/core/core.test.js
+++ b/src/__tests__/core/core.test.js
@@ -3,7 +3,6 @@
 
 import { testFunctions } from './index.js';
 import { Core, init as initCore, initTransport } from '../../js/core/Core.js';
-import { checkBrowser } from '../../js/utils/browser';
 import { settings, testReporter } from './common.js';
 import { CoreEventHandler } from './CoreEventHandler.js';
 
@@ -62,7 +61,6 @@ const MNEMONICS_SECRET = {
 
 const onBeforeEach = async (test: TestFunction, done: Function): Promise<any> => {
     core = await initCore(settings);
-    checkBrowser();
 
     const mnemonics = Array.isArray(test.mnemonic) ? test.mnemonic : MNEMONICS[test.mnemonic];
     const mnemonicsSecret = typeof test.mnemonic_secret === 'string' ? test.mnemonic_secret : typeof test.mnemonic === 'string' ? MNEMONICS_SECRET[test.mnemonic] : null;

--- a/src/__tests__/core/stellarGetPublicKey.spec.js
+++ b/src/__tests__/core/stellarGetPublicKey.spec.js
@@ -2,7 +2,6 @@
 /* eslint-disable */
 
 import { Core, init as initCore, initTransport } from '../../js/core/Core.js';
-import { checkBrowser } from '../../js/utils/browser';
 import { settings, CoreEventHandler } from './common.js';
 
 export const stellarGetPublicKeyTests = (): void => {
@@ -11,7 +10,6 @@ export const stellarGetPublicKeyTests = (): void => {
 
         beforeEach(async (done) => {
             core = await initCore(settings);
-            checkBrowser();
             done();
         });
         afterEach(() => {

--- a/src/__tests__/core/stellarSignTransaction.spec.js
+++ b/src/__tests__/core/stellarSignTransaction.spec.js
@@ -5,7 +5,6 @@
 // https://github.com/trezor/trezor-firmware/blob/master/tests/device_tests/test_msg_stellar_sign_transaction.py
 
 import { Core, init as initCore, initTransport } from '../../js/core/Core.js';
-import { checkBrowser } from '../../js/utils/browser';
 import { settings, CoreEventHandler } from './common.js';
 
 const header = {

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -87,18 +87,6 @@
             "version": 54,
             "download": "https://www.mozilla.org/en-US/firefox/new/",
             "update": "https://support.mozilla.org/en-US/kb/update-firefox-latest-version"
-        },
-        "safari": {
-            "version": 13,
-            "download": "https://support.apple.com/downloads/safari",
-            "update": "https://support.apple.com/downloads/safari",
-            "experimental": true
-        },
-        "opera": {
-            "version": 64,
-            "download": "https://www.opera.com/download",
-            "update": "https://www.opera.com/download",
-            "experimental": true
         }
     },
     "supportedFirmware": [

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -91,12 +91,14 @@
         "safari": {
             "version": 13,
             "download": "https://support.apple.com/downloads/safari",
-            "update": "https://support.apple.com/downloads/safari"
+            "update": "https://support.apple.com/downloads/safari",
+            "experimental": true
         },
         "opera": {
             "version": 64,
             "download": "https://www.opera.com/download",
-            "update": "https://www.opera.com/download"
+            "update": "https://www.opera.com/download",
+            "experimental": true
         }
     },
     "supportedFirmware": [

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -1324,7 +1324,7 @@
                 </svg>
             </div>
 
-            <button class="cancel">Close</button>
+            <button class="cancel" onclick="window.closeWindow();">Close</button>
         </div>
         <!-- Smartphones not supported: END -->
 

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -1136,17 +1136,17 @@
         <!-- Firmware not compatible: END -->
 
         <!-- Browser not supported -->
-        <div class="browser">
+        <div class="browser-not-supported">
             <div>
-                <h3></h3>
-                <p></p>
+                <h3>Unsupported browser</h3>
+                <p>The web browser you're using has not been tested, and you may experience limited functionality.</p>
+                <p>We recommend that you use one of the officially supported web browsers.</p>
             </div>
 
             <div class="wrapper">
                 <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer noopener" onclick="window.closeWindow();">
                     <div class="icon">
                         <svg width="42px" height="42px" viewBox="0 0 42 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                            <title>Chrome</title>
                             <defs>
                                 <path d="M18.0935073,41.2980057 C7.88534838,39.979161 0,31.2757197 0,20.7354476 C0,16.5738044 1.22926896,12.69851 3.345424,9.45103782 L12.1228849,24.6540461 C13.6185445,27.9396056 16.9370531,30.2245507 20.7906603,30.2245507 C22.3303089,30.2245507 23.7845408,29.8598101 25.0712277,29.2122395 L18.0935073,41.2980057 Z M19.6351374,41.4394102 L28.0406785,26.8805858 C29.452872,25.2249418 30.3050303,23.0794465 30.3050303,20.7354476 C30.3050303,17.3181925 28.4938559,14.3228365 25.7766688,12.6521375 L39.9423353,12.6521375 C40.9976526,15.1361324 41.5813207,17.8678095 41.5813207,20.7354476 C41.5813207,32.1873191 32.273025,41.4708952 20.7906603,41.4708952 C20.4029153,41.4708952 20.0176494,41.4603088 19.6351374,41.4394102 Z M4.23845803,8.18623351 C8.03623185,3.21125967 14.0374326,0 20.7906603,0 C28.8444148,0 35.8286037,4.56719338 39.2814537,11.2463444 L20.4382763,11.2463444 L20.4382763,11.2527322 C15.4628168,11.4334027 11.4621873,15.4243778 11.2825853,20.3870184 L4.23845892,8.18623355 Z M20.7906603,28.1158611 C16.703717,28.1158611 13.3905948,24.8115374 13.3905948,20.7354476 C13.3905948,16.6593577 16.703717,13.355034 20.7906603,13.355034 C24.8776037,13.355034 28.1907259,16.6593577 28.1907259,20.7354476 C28.1907259,24.8115374 24.8776037,28.1158611 20.7906603,28.1158611 Z"
                                     id="path-1"></path>
@@ -1192,7 +1192,6 @@
                 <a href="https://www.mozilla.org/firefox/new/" target="_blank" rel="noreferrer noopener" onclick="window.closeWindow();">
                     <div class="icon">
                         <svg width="43px" height="43px" viewBox="0 0 43 43" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                            <title>Firefox</title>
                             <defs>
                                 <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
                                     <stop stop-color="#FACC31" offset="0%"></stop>
@@ -1223,6 +1222,14 @@
                         <p>Firefox</p>
                     </div>
                 </a>
+            </div>
+            <div class="buttons">
+                <button class="cancel">I acknowledge and wish to continue</button>
+                <label class="custom-checkbox">
+                    <input class="remember-permissions" type="checkbox" />
+                    <span class="indicator"></span>
+                    Don't warn me again
+                </label>
             </div>
         </div>
         <!-- Browser not supported: END -->

--- a/src/js/constants/popup.js
+++ b/src/js/constants/popup.js
@@ -10,7 +10,7 @@ export const INIT: 'popup-init' = 'popup-init';
 export const ERROR: 'popup-error' = 'popup-error';
 // Message to webextensions, opens "trezor-usb-permission.html" within webextension
 export const EXTENSION_USB_PERMISSIONS: 'open-usb-permissions' = 'open-usb-permissions';
-// Message called from both [popup > iframe] then [popup > iframe > popup] in this exact order.
+// Message called from both [popup > iframe] then [iframe > popup] in this exact order.
 // Firstly popup call iframe to resolve popup promise in Core
 // Then iframe reacts to POPUP.HANDSHAKE message and sends ConnectSettings, transport information and requested method details back to popup
 export const HANDSHAKE: 'popup-handshake' = 'popup-handshake';

--- a/src/js/constants/ui.js
+++ b/src/js/constants/ui.js
@@ -12,10 +12,6 @@ export const FIRMWARE_NOT_SUPPORTED: 'ui-device_firmware_unsupported' = 'ui-devi
 export const FIRMWARE_NOT_COMPATIBLE: 'ui-device_firmware_not_compatible' = 'ui-device_firmware_not_compatible';
 export const FIRMWARE_NOT_INSTALLED: 'ui-device_firmware_not_installed' = 'ui-device_firmware_not_installed';
 export const DEVICE_NEEDS_BACKUP: 'ui-device_needs_backup' = 'ui-device_needs_backup';
-export const BROWSER_NOT_SUPPORTED: 'ui-browser_not_supported' = 'ui-browser_not_supported';
-export const BROWSER_OUTDATED: 'ui-browser_outdated' = 'ui-browser_outdated';
-export const BROWSER_EXPERIMENTAL: 'ui-browser_experimental' = 'ui-browser_experimental';
-export const RECEIVE_BROWSER: 'ui-receive_browser' = 'ui-receive_browser';
 
 export const REQUEST_UI_WINDOW: 'ui-request_window' = 'ui-request_window';
 export const CLOSE_UI_WINDOW: 'ui-close_window' = 'ui-close_window';

--- a/src/js/constants/ui.js
+++ b/src/js/constants/ui.js
@@ -14,6 +14,7 @@ export const FIRMWARE_NOT_INSTALLED: 'ui-device_firmware_not_installed' = 'ui-de
 export const DEVICE_NEEDS_BACKUP: 'ui-device_needs_backup' = 'ui-device_needs_backup';
 export const BROWSER_NOT_SUPPORTED: 'ui-browser_not_supported' = 'ui-browser_not_supported';
 export const BROWSER_OUTDATED: 'ui-browser_outdated' = 'ui-browser_outdated';
+export const BROWSER_EXPERIMENTAL: 'ui-browser_experimental' = 'ui-browser_experimental';
 export const RECEIVE_BROWSER: 'ui-receive_browser' = 'ui-receive_browser';
 
 export const REQUEST_UI_WINDOW: 'ui-request_window' = 'ui-request_window';

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -300,7 +300,8 @@ export const onCall = async (message: CoreMessage): Promise<void> => {
         postMessage(new UiMessage(UI.BROWSER_NOT_SUPPORTED, browserState));
         postMessage(new ResponseMessage(responseID, false, { error: ERROR.BROWSER_NOT_SUPPORTED.message }));
         throw ERROR.BROWSER_NOT_SUPPORTED;
-    } else if (browserState.outdated) {
+    }
+    if (browserState.outdated) {
         if (isUsingPopup) {
             // wait for popup handshake
             await getPopupPromise().promise;
@@ -311,6 +312,13 @@ export const onCall = async (message: CoreMessage): Promise<void> => {
             // just show message about browser
             postMessage(new UiMessage(UI.BROWSER_OUTDATED, browserState));
         }
+    }
+    if (browserState.experimental) {
+        if (isUsingPopup) {
+            // wait for popup handshake
+            await getPopupPromise().promise;
+        }
+        postMessage(new UiMessage(UI.BROWSER_EXPERIMENTAL, browserState));
     }
 
     if (isUsingPopup && method.requiredPermissions.includes('management') && !DataManager.isManagementAllowed()) {

--- a/src/js/core/methods/AbstractMethod.js
+++ b/src/js/core/methods/AbstractMethod.js
@@ -7,7 +7,7 @@ import DataManager from '../../data/DataManager';
 import * as UI from '../../constants/ui';
 import * as DEVICE from '../../constants/device';
 import * as ERROR from '../../constants/errors';
-import { load as loadStorage, save as saveStorage, PERMISSIONS_KEY } from '../../iframe/storage';
+import { load as loadStorage, save as saveStorage, PERMISSIONS_KEY } from '../../storage';
 
 import { UiMessage, DeviceMessage } from '../../message/builder';
 import type { Deferred, CoreMessage, UiPromiseResponse, FirmwareRange } from '../../types';

--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -28,6 +28,7 @@ type Browser = {
     +version: number,
     +download: string,
     +update: string,
+    +experimental?: boolean,
 }
 type Resources = {
     bridge: string,

--- a/src/js/env/node/index.js
+++ b/src/js/env/node/index.js
@@ -4,7 +4,6 @@ import EventEmitter from 'events';
 import { parse as parseSettings } from '../../data/ConnectSettings';
 import Log, { init as initLog } from '../../utils/debug';
 
-import { state as browserState } from '../../utils/browser';
 import { Core, init as initCore, initTransport } from '../../core/Core';
 import { create as createDeferred } from '../../utils/deferred';
 
@@ -122,10 +121,6 @@ export const init = async (settings: Object = {}): Promise<void> => {
         throw ERROR.MANIFEST_NOT_SET;
     }
 
-    if (!_settings.supportedBrowser) {
-        throw ERROR.BROWSER_NOT_SUPPORTED;
-    }
-
     if (_settings.lazyLoad) {
         // reset "lazyLoad" after first use
         _settings.lazyLoad = false;
@@ -133,10 +128,6 @@ export const init = async (settings: Object = {}): Promise<void> => {
     }
 
     _log.enabled = _settings.debug;
-
-    // instead of "checkBrowser"
-    browserState.name = 'nodejs';
-    browserState.supported = true;
 
     _core = await initCore(_settings);
     _core.on(CORE_EVENT, handleMessage);

--- a/src/js/env/react-native/index.js
+++ b/src/js/env/react-native/index.js
@@ -4,7 +4,6 @@ import EventEmitter from 'events';
 import { parse as parseSettings } from '../../data/ConnectSettings';
 import Log, { init as initLog } from '../../utils/debug';
 
-import { state as browserState } from '../../utils/browser';
 import { Core, init as initCore, initTransport } from '../../core/Core';
 import { create as createDeferred } from '../../utils/deferred';
 
@@ -122,10 +121,6 @@ export const init = async (settings: Object = {}): Promise<void> => {
         throw ERROR.MANIFEST_NOT_SET;
     }
 
-    if (!_settings.supportedBrowser) {
-        throw ERROR.BROWSER_NOT_SUPPORTED;
-    }
-
     if (_settings.lazyLoad) {
         // reset "lazyLoad" after first use
         _settings.lazyLoad = false;
@@ -133,10 +128,6 @@ export const init = async (settings: Object = {}): Promise<void> => {
     }
 
     _log.enabled = _settings.debug;
-
-    // instead of "checkBrowser"
-    browserState.name = 'nodejs';
-    browserState.supported = true;
 
     _core = await initCore(_settings);
     _core.on(CORE_EVENT, handleMessage);

--- a/src/js/iframe/iframe.js
+++ b/src/js/iframe/iframe.js
@@ -17,9 +17,8 @@ import type { CoreMessage, PostMessageEvent } from '../types';
 
 import Log, { init as initLog } from '../utils/debug';
 import { sendMessage } from '../utils/windowsUtils';
-import { checkBrowser, state as browserState } from '../utils/browser';
 import { getOrigin } from '../env/browser/networkUtils';
-import { load as loadStorage, PERMISSIONS_KEY } from './storage';
+import { load as loadStorage, PERMISSIONS_KEY } from '../storage';
 let _core: Core;
 
 // custom log
@@ -195,19 +194,12 @@ const init = async (payload: any, origin: string) => {
         _core = await initCore(parsedSettings);
         _core.on(CORE_EVENT, postMessage);
 
-        // check if browser is supported
-        checkBrowser();
-        if (browserState.supported) {
-            // initialize transport and wait for the first transport event (start or error)
-            await initTransport(parsedSettings);
-        }
+        // initialize transport and wait for the first transport event (start or error)
+        await initTransport(parsedSettings);
 
-        postMessage(new UiMessage(IFRAME.LOADED, {
-            browser: browserState,
-        }));
+        postMessage(new UiMessage(IFRAME.LOADED));
     } catch (error) {
         postMessage(new UiMessage(IFRAME.ERROR, {
-            browser: browserState,
             error: error.message,
         }));
     }

--- a/src/js/iframe/iframe.js
+++ b/src/js/iframe/iframe.js
@@ -7,7 +7,6 @@ import * as UI from '../constants/ui';
 
 import { parse as parseSettings } from '../data/ConnectSettings';
 import DataManager from '../data/DataManager';
-import type { ConnectSettings } from '../data/ConnectSettings';
 
 import { Core, init as initCore, initTransport } from '../core/Core';
 import { parseMessage } from '../message';
@@ -23,7 +22,6 @@ let _core: Core;
 
 // custom log
 const _log: Log = initLog('IFrame');
-
 let _popupMessagePort: ?(MessagePort | BroadcastChannel);
 
 // Wrapper which listen events from Core
@@ -177,7 +175,7 @@ const filterDeviceEvent = (message: CoreMessage): boolean => {
 
 const init = async (payload: any, origin: string) => {
     if (DataManager.getSettings('origin')) return; // already initialized
-    const parsedSettings: ConnectSettings = parseSettings({ ...payload.settings, extension: payload.extension });
+    const parsedSettings = parseSettings({ ...payload.settings, extension: payload.extension });
     // set origin manually
     parsedSettings.origin = !origin || origin === 'null' ? payload.settings.origin : origin;
 

--- a/src/js/popup/PopupManager.js
+++ b/src/js/popup/PopupManager.js
@@ -13,7 +13,7 @@ import { create as createDeferred } from '../utils/deferred';
 // const POPUP_REQUEST_TIMEOUT: number = 602;
 const POPUP_REQUEST_TIMEOUT: number = 850;
 const POPUP_CLOSE_INTERVAL: number = 500;
-const POPUP_OPEN_TIMEOUT: number = 2000;
+const POPUP_OPEN_TIMEOUT: number = 3000;
 
 export default class PopupManager extends EventEmitter {
     _window: any; // Window
@@ -23,7 +23,7 @@ export default class PopupManager extends EventEmitter {
     requestTimeout: number = 0;
     openTimeout: number;
     closeInterval: number = 0;
-    iframeHandshake: Deferred<boolean>;
+    iframeHandshake: Deferred<void>;
     handleMessage: (event: MessageEvent) => void;
     handleExtensionConnect: () => void;
     handleExtensionMessage: () => void;
@@ -188,7 +188,7 @@ export default class PopupManager extends EventEmitter {
             this.emit(POPUP.CLOSED, errorMessage ? `Popup error: ${errorMessage}` : null);
             this.close();
         } else if (data.type === POPUP.LOADED) {
-            this.iframeHandshake.promise.then(resolve => {
+            this.iframeHandshake.promise.then(() => {
                 this.extensionPort.postMessage({
                     type: POPUP.INIT,
                     payload: {
@@ -222,7 +222,7 @@ export default class PopupManager extends EventEmitter {
         if (getOrigin(message.origin) !== this.origin || !data || typeof data !== 'object') return;
 
         if (data.type === IFRAME.LOADED) {
-            this.iframeHandshake.resolve(true);
+            this.iframeHandshake.resolve();
         } else if (data.type === POPUP.BOOTSTRAP) {
             // popup is opened properly, now wait for POPUP.LOADED message
             window.clearTimeout(this.openTimeout);
@@ -232,7 +232,7 @@ export default class PopupManager extends EventEmitter {
             this.close();
         } else if (data.type === POPUP.LOADED) {
             // popup is successfully loaded
-            this.iframeHandshake.promise.then(resolve => {
+            this.iframeHandshake.promise.then(() => {
                 this._window.postMessage({
                     type: POPUP.INIT,
                     payload: {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -137,7 +137,8 @@ const init = async (payload: $PropertyType<PopupInit, 'payload'>) => {
     const { settings } = payload;
 
     try {
-        // load assets
+        // load config only to get supported browsers list.
+        // local settings will be replaced after POPUP.HANDSHAKE event from iframe
         await DataManager.load(settings, false);
         // initialize message channel
         const broadcastID = `${settings.env}-${settings.timestamp}`;
@@ -154,11 +155,12 @@ const init = async (payload: $PropertyType<PopupInit, 'payload'>) => {
 // handle POPUP.HANDSHAKE message from iframe
 const handshake = async (payload: $PropertyType<PopupHandshake, 'payload'>) => {
     if (!payload) return;
+    // replace local settings with values from iframe (parent origin etc.)
+    DataManager.settings = payload.settings;
     setOperation(payload.method || '');
     if (payload.transport && payload.transport.outdated) {
         showBridgeUpdateNotification();
     }
-    // postMessage(new UiMessage(POPUP.HANDSHAKE));
 };
 
 const onLoad = () => {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -10,7 +10,12 @@ import { getOrigin } from '../env/browser/networkUtils';
 
 import * as view from './view';
 import { showView, postMessage, setOperation, initMessageChannel, postMessageToParent } from './view/common';
-import { showFirmwareUpdateNotification, showBridgeUpdateNotification, showBackupNotification } from './view/notification';
+import {
+    showFirmwareUpdateNotification,
+    showBridgeUpdateNotification,
+    showBackupNotification,
+    showBrowserExperimentalNotification,
+} from './view/notification';
 
 import type { CoreMessage, PostMessageEvent } from '../types';
 import type { PopupInit, PopupHandshake } from '../types/uiRequest';
@@ -104,7 +109,9 @@ const handleMessage = (event: PostMessageEvent): void => {
         case UI.BROWSER_OUTDATED :
             view.initBrowserView(message.payload);
             break;
-
+        case UI.BROWSER_EXPERIMENTAL :
+            showBrowserExperimentalNotification(message.payload);
+            break;
         case UI.REQUEST_PERMISSION :
             view.initPermissionsView(message.payload);
             break;

--- a/src/js/popup/view/browser.js
+++ b/src/js/popup/view/browser.js
@@ -29,7 +29,7 @@ export const initBrowserView = (validation: boolean = true) => {
         postMessage(new UiMessage(POPUP.HANDSHAKE));
         return;
     }
-    if (!state.mobile) {
+    if (state.mobile) {
         showView('smartphones-not-supported');
         return;
     }

--- a/src/js/popup/view/browser.js
+++ b/src/js/popup/view/browser.js
@@ -1,18 +1,55 @@
 /* @flow */
+import { container, showView, postMessage } from './common';
+import { UiMessage } from '../../message/builder';
+import DataManager from '../../data/DataManager';
+import * as POPUP from '../../constants/popup';
+import { load as loadStorage, save as saveStorage, BROWSER_KEY } from '../../storage';
+import { getBrowserState } from '../../utils/browser';
 
-import { container, showView } from './common';
-import type { BrowserMessage } from '../../types/uiRequest';
+const validateBrowser = () => {
+    const state = getBrowserState(DataManager.getConfig().supportedBrowsers);
+    if (!state.supported) {
+        const permitted = loadStorage(BROWSER_KEY);
+        return !permitted ? state : null;
+    }
+    return;
+};
 
-export const initBrowserView = (payload: $PropertyType<BrowserMessage, 'payload'>): void => {
-    showView(!payload.supported && payload.mobile ? 'smartphones-not-supported' : 'browser');
+export const initBrowserView = (validation: boolean = true) => {
+    if (!validation) {
+        showView('browser-not-supported');
+        const buttons: HTMLElement = container.getElementsByClassName('buttons')[0];
+        if (buttons && buttons.parentNode) {
+            buttons.parentNode.removeChild(buttons);
+        }
+        return;
+    }
+    const state = validateBrowser();
+    if (!state) {
+        postMessage(new UiMessage(POPUP.HANDSHAKE));
+        return;
+    }
+    if (!state.mobile) {
+        showView('smartphones-not-supported');
+        return;
+    }
+
+    showView('browser-not-supported');
 
     const h3: HTMLElement = container.getElementsByTagName('h3')[0];
-    const p: HTMLElement = container.getElementsByTagName('p')[0];
-    if (!payload.supported && !payload.mobile) {
-        h3.innerText = 'Unsupported browser';
-        p.innerText = 'Please use one of the supported browsers.';
-    } else if (payload.outdated) {
+    const ackButton: HTMLElement = container.getElementsByClassName('cancel')[0];
+    const rememberCheckbox: HTMLInputElement = (container.getElementsByClassName('remember-permissions')[0]: any);
+
+    if (state.outdated) {
         h3.innerText = 'Outdated browser';
-        p.innerText = 'Please update your browser.';
     }
+
+    ackButton.onclick = () => {
+        if (rememberCheckbox && rememberCheckbox.checked) {
+            saveStorage(BROWSER_KEY, true);
+        }
+
+        postMessage(new UiMessage(POPUP.HANDSHAKE));
+        showView('loader');
+    };
 };

--- a/src/js/popup/view/notification.js
+++ b/src/js/popup/view/notification.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { views } from './common';
-import type { UnexpectedDeviceMode, BrowserMessage } from '../../types/uiRequest';
+import type { UnexpectedDeviceMode } from '../../types/uiRequest';
 
 export const showFirmwareUpdateNotification = (device: $PropertyType<UnexpectedDeviceMode, 'payload'>): void => {
     const container: HTMLElement = document.getElementsByClassName('notification')[0];
@@ -74,32 +74,6 @@ export const showBackupNotification = (device: $PropertyType<UnexpectedDeviceMod
     const view = views.getElementsByClassName('backup-notification');
     const notification = document.createElement('div');
     notification.className = 'backup-notification notification-item';
-    const viewItem = view.item(0);
-    if (viewItem) {
-        notification.innerHTML = viewItem.innerHTML;
-    }
-
-    container.appendChild(notification);
-
-    const close = notification.querySelector('.close-icon');
-    if (close) {
-        close.addEventListener('click', () => {
-            container.removeChild(notification);
-        });
-    }
-};
-
-export const showBrowserExperimentalNotification = (device: $PropertyType<BrowserMessage, 'payload'>): void => {
-    const container: HTMLElement = document.getElementsByClassName('notification')[0];
-    const warning: ?HTMLElement = container.querySelector('.browser-experimental-notification');
-    if (warning) {
-        // already exists
-        return;
-    }
-
-    const view = views.getElementsByClassName('browser-experimental-notification');
-    const notification = document.createElement('div');
-    notification.className = 'browser-experimental-notification notification-item';
     const viewItem = view.item(0);
     if (viewItem) {
         notification.innerHTML = viewItem.innerHTML;

--- a/src/js/popup/view/notification.js
+++ b/src/js/popup/view/notification.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { views } from './common';
-import type { UnexpectedDeviceMode } from '../../types/uiRequest';
+import type { UnexpectedDeviceMode, BrowserMessage } from '../../types/uiRequest';
 
 export const showFirmwareUpdateNotification = (device: $PropertyType<UnexpectedDeviceMode, 'payload'>): void => {
     const container: HTMLElement = document.getElementsByClassName('notification')[0];
@@ -74,6 +74,32 @@ export const showBackupNotification = (device: $PropertyType<UnexpectedDeviceMod
     const view = views.getElementsByClassName('backup-notification');
     const notification = document.createElement('div');
     notification.className = 'backup-notification notification-item';
+    const viewItem = view.item(0);
+    if (viewItem) {
+        notification.innerHTML = viewItem.innerHTML;
+    }
+
+    container.appendChild(notification);
+
+    const close = notification.querySelector('.close-icon');
+    if (close) {
+        close.addEventListener('click', () => {
+            container.removeChild(notification);
+        });
+    }
+};
+
+export const showBrowserExperimentalNotification = (device: $PropertyType<BrowserMessage, 'payload'>): void => {
+    const container: HTMLElement = document.getElementsByClassName('notification')[0];
+    const warning: ?HTMLElement = container.querySelector('.browser-experimental-notification');
+    if (warning) {
+        // already exists
+        return;
+    }
+
+    const view = views.getElementsByClassName('browser-experimental-notification');
+    const notification = document.createElement('div');
+    notification.className = 'browser-experimental-notification notification-item';
     const viewItem = view.item(0);
     if (viewItem) {
         notification.innerHTML = viewItem.innerHTML;

--- a/src/js/storage/index.js
+++ b/src/js/storage/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+export const BROWSER_KEY: string = 'trezorconnect_browser';
 export const PERMISSIONS_KEY: string = 'trezorconnect_permissions';
 export const CONFIRMATION_KEY: string = 'trezorconnect_confirmations';
 

--- a/src/js/types/uiRequest.js
+++ b/src/js/types/uiRequest.js
@@ -157,7 +157,7 @@ export type SelectDevice = {
 }
 
 export type BrowserMessage = {
-    +type: typeof UI.BROWSER_NOT_SUPPORTED | typeof UI.BROWSER_OUTDATED,
+    +type: typeof UI.BROWSER_NOT_SUPPORTED | typeof UI.BROWSER_OUTDATED | typeof UI.BROWSER_EXPERIMENTAL,
     payload: BrowserState,
 }
 

--- a/src/js/types/uiRequest.js
+++ b/src/js/types/uiRequest.js
@@ -19,14 +19,6 @@ export type TransportInfo = {
     outdated: boolean,
 }
 
-export type BrowserState = {
-    name: string,
-    osname: string,
-    supported: boolean,
-    outdated: boolean,
-    mobile: boolean,
-}
-
 /*
 * Messages without payload
 */
@@ -34,9 +26,9 @@ export type BrowserState = {
 export type MessageWithoutPayload = {
     +type: typeof UI.REQUEST_UI_WINDOW |
         typeof POPUP.CANCEL_POPUP_REQUEST |
+        typeof IFRAME.LOADED |
         typeof POPUP.LOADED |
         typeof UI.TRANSPORT |
-        typeof UI.RECEIVE_BROWSER |
         typeof UI.CHANGE_ACCOUNT |
         typeof UI.INSUFFICIENT_FUNDS |
         typeof UI.CLOSE_UI_WINDOW |
@@ -86,17 +78,9 @@ export type AddressValidationMessage = {
 * Messages to UI
 */
 
-export type IFrameLoaded = {
-    +type: typeof IFRAME.LOADED,
-    payload: {
-        browser: BrowserState,
-    },
-}
-
 export type IFrameError = {
     type: typeof IFRAME.ERROR,
     payload: {
-        browser: BrowserState,
         error: string,
     },
 }
@@ -154,11 +138,6 @@ export type SelectDevice = {
         devices: Array<Device>,
         webusb: boolean,
     },
-}
-
-export type BrowserMessage = {
-    +type: typeof UI.BROWSER_NOT_SUPPORTED | typeof UI.BROWSER_OUTDATED | typeof UI.BROWSER_EXPERIMENTAL,
-    payload: BrowserState,
 }
 
 export type UnexpectedDeviceMode = {
@@ -221,12 +200,10 @@ export type FirmwareProgress = {
 export type UiRequest =
     MessageWithoutPayload
     | DeviceMessage
-    | IFrameLoaded
     | PopupHandshake
     | RequestPermission
     | RequestConfirmation
     | SelectDevice
-    | BrowserMessage
     | UnexpectedDeviceMode
     | SelectAccount
     | SelectFee
@@ -238,14 +215,12 @@ declare function MessageFactory(type: $PropertyType<MessageWithoutPayload, 'type
 declare function MessageFactory(type: $PropertyType<DeviceMessage, 'type'>, payload: $PropertyType<DeviceMessage, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<ButtonRequestMessage, 'type'>, payload: $PropertyType<ButtonRequestMessage, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<AddressValidationMessage, 'type'>, payload: $PropertyType<AddressValidationMessage, 'payload'>): CoreMessage;
-declare function MessageFactory(type: $PropertyType<IFrameLoaded, 'type'>, payload: $PropertyType<IFrameLoaded, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<IFrameError, 'type'>, payload: $PropertyType<IFrameError, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<PopupError, 'type'>, payload: $PropertyType<PopupError, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<PopupHandshake, 'type'>, payload: $PropertyType<PopupHandshake, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<RequestPermission, 'type'>, payload: $PropertyType<RequestPermission, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<RequestConfirmation, 'type'>, payload: $PropertyType<RequestConfirmation, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<SelectDevice, 'type'>, payload: $PropertyType<SelectDevice, 'payload'>): CoreMessage;
-declare function MessageFactory(type: $PropertyType<BrowserMessage, 'type'>, payload: $PropertyType<BrowserMessage, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<UnexpectedDeviceMode, 'type'>, payload: $PropertyType<UnexpectedDeviceMode, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<FirmwareException, 'type'>, payload: $PropertyType<FirmwareException, 'payload'>): CoreMessage;
 declare function MessageFactory(type: $PropertyType<SelectAccount, 'type'>, payload: $PropertyType<SelectAccount, 'payload'>): CoreMessage;

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -8,6 +8,7 @@ type State = {
     osname: string,
     supported: boolean,
     outdated: boolean,
+    experimental: boolean,
     mobile: boolean,
 }
 
@@ -16,6 +17,7 @@ export const state: State = {
     osname: 'unknown',
     supported: false,
     outdated: false,
+    experimental: false,
     mobile: false,
 };
 
@@ -33,10 +35,11 @@ export const checkBrowser = (): State => {
     if (state.mobile && typeof navigator.usb === 'undefined') {
         state.supported = false;
     } else {
-        const isSupported: any = supported[browser.name.toLowerCase()];
-        if (isSupported) {
+        const supportedBrowser = supported[browser.name.toLowerCase()];
+        if (supportedBrowser) {
             state.supported = true;
-            state.outdated = isSupported.version > parseInt(browser.version, 10);
+            state.outdated = supportedBrowser.version > parseInt(browser.version, 10);
+            state.experimental = supportedBrowser.experimental;
         }
     }
 

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -1,49 +1,51 @@
 /* @flow */
-
 import Bowser from 'bowser';
-import DataManager from '../data/DataManager';
 
-type State = {
+export type BrowserState = {
     name: string,
     osname: string,
     supported: boolean,
     outdated: boolean,
-    experimental: boolean,
     mobile: boolean,
 }
 
-export const state: State = {
+export const state: BrowserState = {
     name: 'unknown',
     osname: 'unknown',
     supported: false,
     outdated: false,
-    experimental: false,
     mobile: false,
 };
 
-export const checkBrowser = (): State => {
-    if (typeof window === 'undefined') {
-        state.name = 'nodejs';
-        state.supported = true;
-        return state;
-    }
+export type Browser = {
+    version: number,
+    download: string,
+    update: string,
+}
+
+export const getBrowserState = (supportedBrowsers: { [key: string]: Browser }): BrowserState => {
+    if (typeof window === 'undefined') return state;
     const { browser, os, platform } = Bowser.parse(window.navigator.userAgent);
-    const supported = DataManager.getConfig().supportedBrowsers;
-    state.name = `${browser.name}: ${browser.version}; ${os.name}: ${os.version};`;
-    state.mobile = platform.type !== 'desktop';
-    state.osname = os.name;
-    if (state.mobile && typeof navigator.usb === 'undefined') {
-        state.supported = false;
-    } else {
-        const supportedBrowser = supported[browser.name.toLowerCase()];
-        if (supportedBrowser) {
-            state.supported = true;
-            state.outdated = supportedBrowser.version > parseInt(browser.version, 10);
-            state.experimental = supportedBrowser.experimental;
-        }
+    const mobile = platform.type !== 'desktop';
+    let supported = !!supportedBrowsers[browser.name.toLowerCase()];
+    let outdated = false;
+
+    if (mobile && typeof navigator.usb === 'undefined') {
+        supported = false;
+    }
+    if (supported) {
+        const { version } = supportedBrowsers[browser.name.toLowerCase()];
+        outdated = version > parseInt(browser.version, 10);
+        supported = !outdated;
     }
 
-    return state;
+    return {
+        name: `${browser.name}: ${browser.version}; ${os.name}: ${os.version};`,
+        osname: os.name,
+        mobile,
+        supported,
+        outdated,
+    };
 };
 
 // Parse JSON loaded from config.assets.bridge

--- a/src/styles/popup/view/browser.less
+++ b/src/styles/popup/view/browser.less
@@ -1,4 +1,4 @@
-.browser {
+.browser-not-supported {
   display: flex;
   flex-direction: column;
   // justify-content: center; // breaks on IE
@@ -25,6 +25,12 @@
       p {
         font-size: 10px;
       }
+    }
+  }
+
+  .buttons {
+    label {
+      margin-top: 10px;
     }
   }
 }


### PR DESCRIPTION
- Enable access to unsupported browsers (like Safari or Opera), access is grated after user confirmation displayed in popup
- Move browser validation logic from Core (iframe) to popup

![Screenshot 2019-11-15 at 12 07 45](https://user-images.githubusercontent.com/3435913/68939322-9be72500-07a0-11ea-9900-f06cd397671d.png)
