### PR TITLE
Make `getAddress` work with multisig BTC addresses.

### DIFF
--- a/docs/methods/getAddress.md
+++ b/docs/methods/getAddress.md
@@ -21,6 +21,8 @@ TrezorConnect.getAddress(params).then(function(result) {
 * `showOnTrezor` — *optional* `boolean` determines if address will be displayed on device. Default is set to `true`
 * `coin` - *optional* `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 * `crossChain` — *optional* `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
+* `multisig` - *optional* [MultisigRedeemScriptType](../../src/js/types/trezor.js#L107), redeem script information (multisig addresses only)
+* `scriptType` - *optional* [InputScriptType](../../src/js/types/trezor.js#L113), address script type
 
 #### Exporting bundle of addresses
 * `bundle` - `Array` of Objects with `path`, `showOnTrezor`, `coin` and `crossChain` fields

--- a/src/flowtype/tests/get-address.js
+++ b/src/flowtype/tests/get-address.js
@@ -1,4 +1,8 @@
 /* @flow */
+import type {
+  MultisigRedeemScriptType,
+  InputScriptType,
+} from '../../js/types/trezor.js';
 
 declare module 'flowtype/tests/get-address' {
     declare export type TestGetAddressPayload = {
@@ -6,6 +10,8 @@ declare module 'flowtype/tests/get-address' {
         path: string | Array<number>,
         coin: string,
         showOnTrezor: boolean,
+        multisig?: MultisigRedeemScriptType,
+        scriptType?: InputScriptType,
     };
     declare export type ExpectedGetAddressResponse = {
         payload: {

--- a/src/js/core/methods/GetAddress.js
+++ b/src/js/core/methods/GetAddress.js
@@ -9,7 +9,7 @@ import { NO_COIN_INFO } from '../../constants/errors';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { Address } from '../../types/trezor';
+import type { Address, MultisigRedeemScriptType, InputScriptType } from '../../types/trezor';
 import type { CoreMessage, UiPromiseResponse, BitcoinNetworkInfo } from '../../types';
 
 type Batch = {
@@ -17,6 +17,8 @@ type Batch = {
     address: ?string,
     coinInfo: BitcoinNetworkInfo,
     showOnTrezor: boolean,
+    multisig?: MultisigRedeemScriptType,
+    scriptType?: InputScriptType,
 }
 
 type Params = Array<Batch>;
@@ -50,6 +52,8 @@ export default class GetAddress extends AbstractMethod {
                 { name: 'coin', type: 'string' },
                 { name: 'address', type: 'string' },
                 { name: 'showOnTrezor', type: 'boolean' },
+                { name: 'multisig', type: 'object' },
+                { name: 'scriptType', type: 'string' },
             ]);
 
             const path: Array<number> = validatePath(batch.path, 3);
@@ -84,6 +88,8 @@ export default class GetAddress extends AbstractMethod {
                 address: batch.address,
                 coinInfo,
                 showOnTrezor,
+                multisig: batch.multisig,
+                scriptType: batch.scriptType,
             });
         });
 
@@ -167,7 +173,9 @@ export default class GetAddress extends AbstractMethod {
                 const silent = await this.device.getCommands().getAddress(
                     batch.path,
                     batch.coinInfo,
-                    false
+                    false,
+                    batch.multisig,
+                    batch.scriptType,
                 );
                 if (typeof batch.address === 'string') {
                     if (batch.address !== silent.address) {
@@ -181,7 +189,9 @@ export default class GetAddress extends AbstractMethod {
             const response = await this.device.getCommands().getAddress(
                 batch.path,
                 batch.coinInfo,
-                batch.showOnTrezor
+                batch.showOnTrezor,
+                batch.multisig,
+                batch.scriptType,
             );
             responses.push(response);
 

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -218,12 +218,13 @@ export default class DeviceCommands {
         return state;
     }
 
-    async getAddress(address_n: Array<number>, coinInfo: BitcoinNetworkInfo, showOnTrezor: boolean): Promise<trezor.Address> {
-        const scriptType: trezor.InputScriptType = getScriptType(address_n);
+  async getAddress(address_n: Array<number>, coinInfo: BitcoinNetworkInfo, showOnTrezor: boolean, multisig?: trezor.MultisigRedeemScriptType, scriptType?: trezor.InputScriptType): Promise<trezor.Address> {
+        if (!scriptType) { scriptType = getScriptType(address_n); }
         const response: Object = await this.typedCall('GetAddress', 'Address', {
             address_n,
             coin_name: coinInfo.name,
             show_display: !!showOnTrezor,
+            multisig,
             script_type: scriptType && scriptType !== 'SPENDMULTISIG' ? scriptType : 'SPENDADDRESS', // script_type 'SPENDMULTISIG' throws Failure_FirmwareError
         });
 

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -218,7 +218,7 @@ export default class DeviceCommands {
         return state;
     }
 
-  async getAddress(address_n: Array<number>, coinInfo: BitcoinNetworkInfo, showOnTrezor: boolean, multisig?: trezor.MultisigRedeemScriptType, scriptType?: trezor.InputScriptType): Promise<trezor.Address> {
+    async getAddress(address_n: Array<number>, coinInfo: BitcoinNetworkInfo, showOnTrezor: boolean, multisig?: trezor.MultisigRedeemScriptType, scriptType?: trezor.InputScriptType): Promise<trezor.Address> {
         if (!scriptType) { scriptType = getScriptType(address_n); }
         const response: Object = await this.typedCall('GetAddress', 'Address', {
             address_n,

--- a/src/js/types/params.js
+++ b/src/js/types/params.js
@@ -5,6 +5,8 @@ import type {
     TransactionOutput,
     RefTransaction,
     DebugLinkDecision,
+    MultisigRedeemScriptType,
+    InputScriptType,
 } from './trezor';
 import type { AccountAddresses, AccountUtxo } from './account';
 
@@ -144,6 +146,8 @@ export type $GetAddress = {|
     coin?: string,
     showOnTrezor?: boolean,
     crossChain?: boolean,
+    multisig?: MultisigRedeemScriptType,
+    scriptType?: InputScriptType,
 |};
 
 export type $GetDeviceState = $Common;


### PR DESCRIPTION
An attempt at solving https://github.com/trezor/connect/issues/509.

This PR attempts to correctly pass `multisig` and `scriptType` parameters in `TrezorConnect.getAddress` to lower-level code.  This is intended to enable displaying & confirming multisig BTC addresses from TrezorConnect. 

I have created this PR as a draft because it could benefit from a test case or few to test the new parameters are being passed correctly.  (I have been unable to run the test suite so far, still trying tho!)