### PR TITLE
fix messages overwrite

### DIFF
--- a/src/js/device/DeviceList.js
+++ b/src/js/device/DeviceList.js
@@ -76,7 +76,7 @@ export default class DeviceList extends EventEmitter {
             _log.debug('Initializing transports');
             await transport.init(_log.enabled);
             _log.debug('Configuring transports');
-            await transport.configure(this.defaultMessages);
+            await transport.configure(JSON.parse(JSON.stringify(this.defaultMessages)));
             _log.debug('Configuring transports done');
 
             const { activeName } = transport;
@@ -98,7 +98,7 @@ export default class DeviceList extends EventEmitter {
     async reconfigure(json: JSON, custom?: boolean) {
         if (this.currentMessages === json) return;
         try {
-            await this.transport.configure(json);
+            await this.transport.configure(JSON.parse(JSON.stringify(json)));
             this.currentMessages = json;
             this.hasCustomMessages = typeof custom === 'boolean' ? custom : false;
         } catch (error) {
@@ -109,7 +109,7 @@ export default class DeviceList extends EventEmitter {
     async restoreMessages() {
         if (!this.hasCustomMessages) return;
         try {
-            await this.transport.configure(this.defaultMessages);
+            await this.transport.configure(JSON.parse(JSON.stringify(this.defaultMessages)));
             this.hasCustomMessages = false;
         } catch (error) {
             throw ERROR.WRONG_TRANSPORT_CONFIG;

--- a/src/js/device/DeviceList.js
+++ b/src/js/device/DeviceList.js
@@ -76,7 +76,7 @@ export default class DeviceList extends EventEmitter {
             _log.debug('Initializing transports');
             await transport.init(_log.enabled);
             _log.debug('Configuring transports');
-            await transport.configure(JSON.parse(JSON.stringify(this.defaultMessages)));
+            await transport.configure(JSON.stringify(this.defaultMessages));
             _log.debug('Configuring transports done');
 
             const { activeName } = transport;
@@ -98,7 +98,7 @@ export default class DeviceList extends EventEmitter {
     async reconfigure(json: JSON, custom?: boolean) {
         if (this.currentMessages === json) return;
         try {
-            await this.transport.configure(JSON.parse(JSON.stringify(json)));
+            await this.transport.configure(JSON.stringify(json));
             this.currentMessages = json;
             this.hasCustomMessages = typeof custom === 'boolean' ? custom : false;
         } catch (error) {
@@ -109,7 +109,7 @@ export default class DeviceList extends EventEmitter {
     async restoreMessages() {
         if (!this.hasCustomMessages) return;
         try {
-            await this.transport.configure(JSON.parse(JSON.stringify(this.defaultMessages)));
+            await this.transport.configure(JSON.stringify(this.defaultMessages));
             this.hasCustomMessages = false;
         } catch (error) {
             throw ERROR.WRONG_TRANSPORT_CONFIG;


### PR DESCRIPTION
I found a tricky bug. 

### Steps to reproduce
1. T1 without firmware with bootloader 1.8.0
1. Go to Trezor Suite, checkout `firmware-fixes` branch.
1. Enter onboarding, install fw.
1. Go to next step, try to create new wallet.
1. Get `Wrong config response` from DeviceList.reconfigure (comming from trezor-link);

Why this happens?

Installing new firmware works fine, but it has a side effect! It mutates `DataManager.messages` property this way. 

![image](https://user-images.githubusercontent.com/30367552/72340193-08f73800-36c8-11ea-9f09-6beda09a2ca0.png)

Later on, we supply trezor-link with messages object that contains no data. 

I havent tracked it all the way down, but I expect that trezor-link overwrites the passed messages object somewhere. Possible way around this is to pass a fresh object instead. Not sure if it can break something though (most likely no)

