### PR TITLE
bitcoin: add hex support to sign message.

### DIFF
--- a/src/js/core/methods/EthereumGetAddress.js
+++ b/src/js/core/methods/EthereumGetAddress.js
@@ -3,8 +3,9 @@
 import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath, getSerializedPath } from '../../utils/pathUtils';
-import { getNetworkLabel, stripHexPrefix } from '../../utils/ethereumUtils';
+import { getNetworkLabel } from '../../utils/ethereumUtils';
 import { getEthereumNetwork, getUniqueNetworks } from '../../data/CoinInfo';
+import { stripHexPrefix } from '../../utils/formatUtils';
 
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -4,7 +4,8 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
-import { toChecksumAddress, getNetworkLabel, messageToHex } from '../../utils/ethereumUtils';
+import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
+import { messageToHex } from '../../utils/formatUtils';
 
 import type { MessageSignature } from '../../types/trezor';
 import type { CoreMessage, EthereumNetworkInfo } from '../../types';

--- a/src/js/core/methods/EthereumSignTransaction.js
+++ b/src/js/core/methods/EthereumSignTransaction.js
@@ -4,7 +4,8 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
-import { stripHexPrefix, getNetworkLabel } from '../../utils/ethereumUtils';
+import { getNetworkLabel } from '../../utils/ethereumUtils';
+import { stripHexPrefix } from '../../utils/formatUtils';
 import * as helper from './helpers/ethereumSignTx';
 
 import type { CoreMessage } from '../../types';

--- a/src/js/core/methods/EthereumVerifyMessage.js
+++ b/src/js/core/methods/EthereumVerifyMessage.js
@@ -5,7 +5,7 @@ import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import type { Success } from '../../types/trezor';
 import type { CoreMessage } from '../../types';
 
-import { stripHexPrefix, messageToHex } from '../../utils/ethereumUtils';
+import { stripHexPrefix, messageToHex } from '../../utils/formatUtils';
 
 type Params = {
     address: string,

--- a/src/js/core/methods/SignMessage.js
+++ b/src/js/core/methods/SignMessage.js
@@ -6,6 +6,7 @@ import { validatePath, getLabel } from '../../utils/pathUtils';
 import { getBitcoinNetwork } from '../../data/CoinInfo';
 import type { MessageSignature } from '../../types/trezor';
 import type { CoreMessage, BitcoinNetworkInfo } from '../../types';
+import { messageToHex } from '../../utils/formatUtils';
 
 type Params = {
     path: Array<number>,
@@ -28,6 +29,7 @@ export default class SignMessage extends AbstractMethod {
             { name: 'path', obligatory: true },
             { name: 'coin', type: 'string' },
             { name: 'message', type: 'string', obligatory: true },
+            { name: 'hex', type: 'boolean' },
         ]);
 
         const path: Array<number> = validatePath(payload.path);
@@ -46,7 +48,7 @@ export default class SignMessage extends AbstractMethod {
             this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
         }
 
-        const messageHex: string = Buffer.from(payload.message, 'utf8').toString('hex');
+        const messageHex: string = payload.hex ? messageToHex(payload.message) : Buffer.from(payload.message, 'utf8').toString('hex');
         this.params = {
             path,
             message: messageHex,

--- a/src/js/core/methods/VerifyMessage.js
+++ b/src/js/core/methods/VerifyMessage.js
@@ -8,6 +8,7 @@ import { NO_COIN_INFO } from '../../constants/errors';
 
 import type { Success } from '../../types/trezor';
 import type { CoreMessage, BitcoinNetworkInfo } from '../../types';
+import { messageToHex } from '../../utils/formatUtils';
 
 type Params = {
     address: string,
@@ -33,6 +34,7 @@ export default class VerifyMessage extends AbstractMethod {
             { name: 'signature', type: 'string', obligatory: true },
             { name: 'message', type: 'string', obligatory: true },
             { name: 'coin', type: 'string', obligatory: true },
+            { name: 'hex', type: 'boolean' },
         ]);
 
         const coinInfo: ?BitcoinNetworkInfo = getBitcoinNetwork(payload.coin);
@@ -43,8 +45,7 @@ export default class VerifyMessage extends AbstractMethod {
             this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
             this.info = getLabel('Verify #NETWORK message', coinInfo);
         }
-        // TODO: check if message is already a hex
-        const messageHex: string = Buffer.from(payload.message, 'utf8').toString('hex');
+        const messageHex: string = payload.hex ? messageToHex(payload.message) : Buffer.from(payload.message, 'utf8').toString('hex');
         const signatureHex: string = Buffer.from(payload.signature, 'base64').toString('hex');
 
         this.params = {

--- a/src/js/utils/ethereumUtils.js
+++ b/src/js/utils/ethereumUtils.js
@@ -1,14 +1,7 @@
 /* @flow */
 import createKeccakHash from 'keccak';
 import type { EthereumNetworkInfo, CoinInfo } from '../types';
-
-const hasHexPrefix = (str: string): boolean => {
-    return str.slice(0, 2).toLowerCase() === '0x';
-};
-
-export const stripHexPrefix = (str: string): string => {
-    return hasHexPrefix(str) ? str.slice(2) : str;
-};
+import { hasHexPrefix, stripHexPrefix } from './formatUtils';
 
 export const toChecksumAddress = (address: string, network: ?EthereumNetworkInfo): string => {
     if (hasHexPrefix(address)) return address;
@@ -33,27 +26,4 @@ export const getNetworkLabel = (label: string, network: ?CoinInfo): string => {
         return label.replace('#NETWORK', name);
     }
     return label.replace('#NETWORK', '');
-};
-
-// from (isHexString) https://github.com/ethjs/ethjs-util/blob/master/src/index.js
-const isHexString = (value: string, length?: number) => {
-    if (typeof value !== 'string' || !value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {
-        return false;
-    }
-    if (length && value.length !== 2 + 2 * length) { return false; }
-    return true;
-};
-
-// from (toBuffer) https://github.com/ethereumjs/ethereumjs-util/blob/master/index.js
-export const messageToHex = (message: string): string => {
-    let buffer: Buffer;
-    if (isHexString(message)) {
-        let clean = stripHexPrefix(message);
-        // pad left even
-        if (clean.length % 2 !== 0) { clean = '0' + clean; }
-        buffer = Buffer.from(clean, 'hex');
-    } else {
-        buffer = Buffer.from(message);
-    }
-    return buffer.toString('hex');
 };

--- a/src/js/utils/formatUtils.js
+++ b/src/js/utils/formatUtils.js
@@ -42,3 +42,34 @@ export const formatTime = (n: number): string => {
 export const btckb2satoshib = (n: string): string => {
     return new BigNumber(n).times(1e5).toFixed(0, BigNumber.ROUND_HALF_UP);
 };
+
+export const hasHexPrefix = (str: string): boolean => {
+    return str.slice(0, 2).toLowerCase() === '0x';
+};
+
+export const stripHexPrefix = (str: string): string => {
+    return hasHexPrefix(str) ? str.slice(2) : str;
+};
+
+// from (isHexString) https://github.com/ethjs/ethjs-util/blob/master/src/index.js
+const isHexString = (value: string, length?: number) => {
+    if (typeof value !== 'string' || !value.match(/^(0x|0X)?[0-9A-Fa-f]*$/)) {
+        return false;
+    }
+    if (length && value.length !== 2 + 2 * length) { return false; }
+    return true;
+};
+
+// from (toBuffer) https://github.com/ethereumjs/ethereumjs-util/blob/master/index.js
+export const messageToHex = (message: string): string => {
+    let buffer: Buffer;
+    if (isHexString(message)) {
+        let clean = stripHexPrefix(message);
+        // pad left even
+        if (clean.length % 2 !== 0) { clean = '0' + clean; }
+        buffer = Buffer.from(clean, 'hex');
+    } else {
+        buffer = Buffer.from(message);
+    }
+    return buffer.toString('hex');
+};


### PR DESCRIPTION
Add ability to optionally pass hex string to sign message.
Also moved hex utilities to format utilities (I noticed they are generic, not ethereum related)

This introduces a way to pass hex string instead of normal string for signing binary messages. The API is same as for ethereumSignMessage, where you have to pass optional `hex` parameter when you pass hex string in `message`. If `hex` is `false`, it will behave the same way as before.

---
Unrelated to this, but I noticed two tests are failing on Ripple (These are failing on `develop` branch as well): https://github.com/trezor/connect/issues/523