### PR TITLE
Feature/custom connectSrc

### DIFF
--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -89,7 +89,12 @@ export const parse = (input: $Shape<ConnectSettings> = {}) => {
     if (typeof input.connectSrc === 'string') {
         settings.connectSrc = input.connectSrc;
     }
-    // For debugging purposes `connectSrc` could be also defined in url query of hosting page. Usage:
+    // For debugging purposes `connectSrc` could be defined in `global.__TREZOR_CONNECT_SRC` variable
+    if (typeof global !== 'undefined' && typeof global.__TREZOR_CONNECT_SRC === 'string') {
+        settings.connectSrc = global.__TREZOR_CONNECT_SRC;
+    }
+
+    // For debugging purposes `connectSrc` could be defined in url query of hosting page. Usage:
     // https://3rdparty-page.com/?trezor-connect-src=https://localhost:8088/
     if (typeof window !== 'undefined' && window.location && typeof window.location.search === 'string') {
         const vars = window.location.search.split('&');

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -88,8 +88,16 @@ export const parse = (input: $Shape<ConnectSettings> = {}) => {
 
     if (typeof input.connectSrc === 'string') {
         settings.connectSrc = input.connectSrc;
-    } else if (typeof window !== 'undefined' && typeof window.__TREZOR_CONNECT_SRC === 'string') {
-        settings.connectSrc = window.__TREZOR_CONNECT_SRC;
+    }
+    // For debugging purposes `connectSrc` could be also defined in url query of hosting page. Usage:
+    // https://3rdparty-page.com/?trezor-connect-src=https://localhost:8088/
+    if (typeof window !== 'undefined' && window.location && typeof window.location.search === 'string') {
+        const vars = window.location.search.split('&');
+        const customUrl = vars.find(v => v.indexOf('trezor-connect-src') >= 0);
+        if (customUrl) {
+            const [, connectSrc] = customUrl.split('=');
+            settings.connectSrc = decodeURIComponent(connectSrc);
+        }
     }
     const src = settings.connectSrc || DEFAULT_DOMAIN;
     settings.iframeSrc = `${src}iframe.html`;


### PR DESCRIPTION
replace `window.__TREZOR_CONNECT_SRC` settings with parameter from url, which allow to set custom connect url for debugging purposes.
Usage:
`https://3rdparty-page.com/?trezor-connect-src=https://localhost:8088/`