### PR TITLE
Hotfix 8.1

### DIFF
--- a/src/js/env/browser/workers.js
+++ b/src/js/env/browser/workers.js
@@ -6,7 +6,7 @@ import RippleWorker from 'worker-loader?name=workers/ripple-worker.[hash].js!@tr
 import TrezorLink from 'trezor-link';
 
 const WebUsbPlugin = () => {
-    return new TrezorLink.Lowlevel(new TrezorLink.WebUsb(), () => new SharedConnectionWorker());
+    return new TrezorLink.Lowlevel(new TrezorLink.WebUsb(), typeof SharedWorker !== 'undefined' ? () => new SharedConnectionWorker() : null);
 };
 
 const ReactNativeUsbPlugin = undefined;

--- a/src/ts/types/trezor/device.d.ts
+++ b/src/ts/types/trezor/device.d.ts
@@ -84,13 +84,13 @@ export type UnknownDevice = {
     id?: null;
     path: string;
     label: string;
-    features?: typeof undefined | null;
-    firmware?: typeof undefined | null;
-    firmwareRelease?: typeof undefined | null;
-    status?: typeof undefined | null;
-    mode?: typeof undefined | null;
-    state?: typeof undefined | null;
-    unavailableCapabilities?: typeof undefined | null;
+    features?: typeof undefined;
+    firmware?: typeof undefined;
+    firmwareRelease?: typeof undefined;
+    status?: typeof undefined;
+    mode?: typeof undefined;
+    state?: typeof undefined;
+    unavailableCapabilities?: typeof undefined;
 };
 
 export type Device = KnownDevice | UnknownDevice;


### PR DESCRIPTION
Webusb + android: do not use sharedworker-loader if `SharedWorker` is not available