### PR TITLE
fix: send pin request type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - yarn lint
   - yarn test:unit
   - make build-connect
-  - ./tests/run.sh 1 ci
+  - ./tests/run.sh 3 ci
 
 notifications:
   webhooks:

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -646,7 +646,7 @@ const onDevicePinHandler = async (device: Device, type: string, callback: (error
     // wait for popup handshake
     await getPopupPromise().promise;
     // request pin view
-    postMessage(UiMessage(UI.REQUEST_PIN, { device: device.toMessageObject() }));
+    postMessage(UiMessage(UI.REQUEST_PIN, { device: device.toMessageObject(), type }));
     // wait for pin
     const uiResp: UiPromiseResponse = await createUiPromise(UI.RECEIVE_PIN, device).promise;
     const pin: string = uiResp.payload;


### PR DESCRIPTION
connect did not send pin request type. pin request type is very important. with it, connect consumer does not need to gues "why is device asking for pin now" when trying to figure out appropriate UI. 

now connect sends pin request type :]