### PR TITLE
Fix Flow error in usb-permissions JS

### DIFF
--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -31,6 +31,9 @@ function switchToPopupTab(event) {
 window.addEventListener('message', function (event) {
     if (event.data === 'usb-permissions-init') {
         const iframe = document.getElementById('trezor-usb-permissions');
+        if (!iframe || !(iframe instanceof HTMLIFrameElement)) {
+            throw new Error('trezor-usb-permissions missing or incorrect dom type');
+        }
         iframe.contentWindow.postMessage({
             type: 'usb-permissions-init',
             extension: chrome.runtime.id,


### PR DESCRIPTION
This solves the two Flow errors in this file:

```
Cannot get `iframe.contentWindow` because property `contentWindow` is missing in  `HTMLElement` [1].Flow(InferError)
dom.js(1250, 38): [1] `HTMLElement`

Cannot get `iframe.contentWindow` because property `contentWindow` is missing in  null [1].Flow(InferError)
dom.js(1250, 52): [1] null
```