### PR TITLE
fix: reload unavailableCapabilities

### DIFF
--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -383,10 +383,11 @@ export default class Device extends EventEmitter {
     }
 
     _updateFeatures(feat: Features) {
-        feat.capabilities = parseCapabilities(feat);
+        const capabilities = parseCapabilities(feat);
+        feat.capabilities = capabilities;
         const version = [feat.major_version, feat.minor_version, feat.patch_version];
         // capabilities could change in case where features was fetched with older version of messages.json which doesn't know this field
-        const capabilitiesDidChanged = this.features && this.features.capabilities && feat.capabilities && this.features.capabilities.join('') !== feat.capabilities.join('');
+        const capabilitiesDidChanged = this.features && this.features.capabilities && this.features.capabilities.join('') !== capabilities.join('');
         // check if FW version or capabilities did change
         if (versionCompare(version, this.getVersion()) !== 0 || capabilitiesDidChanged) {
             this.unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks(), DataManager.getConfig().supportedFirmware);

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -387,9 +387,9 @@ export default class Device extends EventEmitter {
         feat.capabilities = capabilities;
         const version = [feat.major_version, feat.minor_version, feat.patch_version];
         // capabilities could change in case where features was fetched with older version of messages.json which doesn't know this field
-        const capabilitiesDidChanged = this.features && this.features.capabilities && this.features.capabilities.join('') !== capabilities.join('');
+        const capabilitiesDidChange = this.features && this.features.capabilities && this.features.capabilities.join('') !== capabilities.join('');
         // check if FW version or capabilities did change
-        if (versionCompare(version, this.getVersion()) !== 0 || capabilitiesDidChanged) {
+        if (versionCompare(version, this.getVersion()) !== 0 || capabilitiesDidChange) {
             this.unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks(), DataManager.getConfig().supportedFirmware);
             this.firmwareStatus = getFirmwareStatus(feat);
             this.firmwareRelease = getRelease(feat);

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -386,7 +386,7 @@ export default class Device extends EventEmitter {
         feat.capabilities = parseCapabilities(feat);
         const version = [feat.major_version, feat.minor_version, feat.patch_version];
         // capabilities could change in case where features was fetched with older version of messages.json which doesn't know this field
-        const capabilitiesDidChanged = this.features && this.features.capabilities && this.features.capabilities.join('') !== feat.capabilities.join('');
+        const capabilitiesDidChanged = this.features && this.features.capabilities && feat.capabilities && this.features.capabilities.join('') !== feat.capabilities.join('');
         // check if FW version or capabilities did change
         if (versionCompare(version, this.getVersion()) !== 0 || capabilitiesDidChanged) {
             this.unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks(), DataManager.getConfig().supportedFirmware);

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -385,8 +385,10 @@ export default class Device extends EventEmitter {
     _updateFeatures(feat: Features) {
         feat.capabilities = parseCapabilities(feat);
         const version = [feat.major_version, feat.minor_version, feat.patch_version];
-        // check if FW version did change
-        if (versionCompare(version, this.getVersion()) !== 0) {
+        // capabilities could change in case where features was fetched with older version of messages.json which doesn't know this field
+        const capabilitiesDidChanged = this.features && this.features.capabilities && this.features.capabilities.join('') !== feat.capabilities.join('');
+        // check if FW version or capabilities did change
+        if (versionCompare(version, this.getVersion()) !== 0 || capabilitiesDidChanged) {
             this.unavailableCapabilities = getUnavailableCapabilities(feat, getAllNetworks(), DataManager.getConfig().supportedFirmware);
             this.firmwareStatus = getFirmwareStatus(feat);
             this.firmwareRelease = getRelease(feat);


### PR DESCRIPTION
capabilities could change in case where features was fetched with older version of messages.json which doesn't know this field