### PR TITLE
Fix/disable 2.3.1 in popup mode

### DIFF
--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -129,8 +129,8 @@ export default class DataManager {
 
         // parse firmware definitions
         if (this.settings.popup) {
-            // $FlowIssue: temporary remove 2.3.1 FW update from "popup mode" (issue with invalid derivation path control https://github.com/trezor/trezor-firmware/issues/1044)
-            delete this.assets['firmware-t2'][0];
+            // $FlowIssue: temporary remove 2.3.1 (latest) FW update from "popup mode" (issue with invalid derivation path control https://github.com/trezor/trezor-firmware/issues/1044)
+            this.assets['firmware-t2'] = this.assets['firmware-t2'].slice(1);
         }
         parseFirmware(this.assets['firmware-t1'], 1);
         parseFirmware(this.assets['firmware-t2'], 2);

--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -128,6 +128,10 @@ export default class DataManager {
         parseCoinsJson(this.assets['coins']);
 
         // parse firmware definitions
+        if (this.settings.popup) {
+            // $FlowIssue: temporary remove 2.3.1 FW update from "popup mode" (issue with invalid derivation path control https://github.com/trezor/trezor-firmware/issues/1044)
+            delete this.assets['firmware-t2'][0];
+        }
         parseFirmware(this.assets['firmware-t1'], 1);
         parseFirmware(this.assets['firmware-t2'], 2);
     }


### PR DESCRIPTION
Temporary disable 2.3.1 FW update in "popup mode"
Remove this after 2.3.2 release

Issue: https://github.com/trezor/trezor-firmware/issues/1044