### PR TITLE
fixed validation of custom backends

### DIFF
--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -277,6 +277,11 @@ export const setCustomBackend = (coinInfo: CoinInfo, blockchainLink: $ElementTyp
     }
 };
 
+export const isBackendSupported = (coinInfo: CoinInfo) => {
+    const info = customBackends[coinInfo.shortcut] || coinInfo;
+    if (!info.blockchainLink) { throw ERRORS.TypedError('Backend_NotSupported'); }
+};
+
 export const initBlockchain = async (coinInfo: CoinInfo, postMessage: $ElementType<Options, 'postMessage'>) => {
     let backend = find(coinInfo.name);
     if (!backend) {

--- a/src/js/core/methods/ComposeTransaction.js
+++ b/src/js/core/methods/ComposeTransaction.js
@@ -12,7 +12,7 @@ import { getBitcoinNetwork, fixCoinInfoNetwork } from '../../data/CoinInfo';
 
 import { formatAmount } from '../../utils/formatUtils';
 
-import { initBlockchain } from '../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 
 import TransactionComposer from './tx/TransactionComposer';
 import {
@@ -65,9 +65,8 @@ export default class ComposeTransaction extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         // set required firmware from coinInfo support
         this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);

--- a/src/js/core/methods/GetAccountInfo.js
+++ b/src/js/core/methods/GetAccountInfo.js
@@ -10,7 +10,7 @@ import { getCoinInfo } from '../../data/CoinInfo';
 import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
-import { initBlockchain } from '../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 
 import type { CoreMessage, CoinInfo } from '../../types';
 import type { GetAccountInfo as GetAccountInfoParams, AccountInfo, AccountUtxo } from '../../types/account';
@@ -68,9 +68,8 @@ export default class GetAccountInfo extends AbstractMethod {
             if (!coinInfo) {
                 throw ERRORS.TypedError('Method_UnknownCoin');
             }
-            if (!coinInfo.blockchainLink) {
-                throw ERRORS.TypedError('Backend_NotSupported');
-            }
+            // validate backend
+            isBackendSupported(coinInfo);
             // validate path if exists
             if (batch.path) {
                 batch.address_n = validatePath(batch.path, 3);

--- a/src/js/core/methods/PushTransaction.js
+++ b/src/js/core/methods/PushTransaction.js
@@ -4,7 +4,7 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams } from './helpers/paramsValidator';
 import { getCoinInfo } from '../../data/CoinInfo';
 import { ERRORS } from '../../constants';
-import { initBlockchain } from '../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 
 import type { CoreMessage, CoinInfo } from '../../types';
 
@@ -34,9 +34,8 @@ export default class PushTransaction extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         if (coinInfo.type === 'bitcoin' && !/^[0-9A-Fa-f]*$/.test(payload.tx)) {
             throw ERRORS.TypedError('Method_InvalidParameter', 'Transaction must be hexadecimal');

--- a/src/js/core/methods/SignTransaction.js
+++ b/src/js/core/methods/SignTransaction.js
@@ -7,7 +7,7 @@ import { getBitcoinNetwork } from '../../data/CoinInfo';
 import { getLabel } from '../../utils/pathUtils';
 import { ERRORS } from '../../constants';
 
-import { initBlockchain } from '../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 import signTx from './helpers/signtx';
 import verifyTx from './helpers/signtxVerify';
 
@@ -137,9 +137,8 @@ export default class SignTransaction extends AbstractMethod {
             const hdInputs: Array<BuildTxInput> = params.inputs.map(inputToHD);
             const refTxsIds = getReferencedTransactions(hdInputs);
             if (refTxsIds.length > 0) {
-                if (!params.coinInfo.blockchainLink) {
-                    throw ERRORS.TypedError('Backend_NotSupported');
-                }
+                // validate backend
+                isBackendSupported(params.coinInfo);
                 const blockchain = await initBlockchain(params.coinInfo, this.postMessage);
                 const bjsRefTxs = await blockchain.getReferencedTransactions(refTxsIds);
                 refTxs = transformReferencedTransactions(bjsRefTxs);
@@ -166,9 +165,8 @@ export default class SignTransaction extends AbstractMethod {
         );
 
         if (params.push) {
-            if (!params.coinInfo.blockchainLink) {
-                throw ERRORS.TypedError('Backend_NotSupported');
-            }
+            // validate backend
+            isBackendSupported(params.coinInfo);
             const blockchain = await initBlockchain(params.coinInfo, this.postMessage);
             const txid = await blockchain.pushTransaction(response.serializedTx);
             return {

--- a/src/js/core/methods/blockchain/BlockchainDisconnect.js
+++ b/src/js/core/methods/blockchain/BlockchainDisconnect.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { find as findBlockchainBackend } from '../../../backend/BlockchainLink';
+import { isBackendSupported, find as findBlockchainBackend } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -33,9 +33,8 @@ export default class BlockchainDisconnect extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             coinInfo,

--- a/src/js/core/methods/blockchain/BlockchainEstimateFee.js
+++ b/src/js/core/methods/blockchain/BlockchainEstimateFee.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 import Fees from '../tx/Fees';
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type {
     CoreMessage,
@@ -59,9 +59,8 @@ export default class BlockchainEstimateFee extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             coinInfo,

--- a/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
+++ b/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -41,9 +41,8 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             coinInfo: coinInfo,

--- a/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -33,9 +33,8 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             currencies: payload.currencies,

--- a/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
+++ b/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -33,9 +33,8 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod 
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             timestamps: payload.timestamps,

--- a/src/js/core/methods/blockchain/BlockchainGetTransactions.js
+++ b/src/js/core/methods/blockchain/BlockchainGetTransactions.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -33,9 +33,8 @@ export default class BlockchainGetTransactions extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             txs: payload.txs,

--- a/src/js/core/methods/blockchain/BlockchainSubscribe.js
+++ b/src/js/core/methods/blockchain/BlockchainSubscribe.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo, BlockchainSubscribeAccount } from '../../../types';
 
@@ -41,9 +41,8 @@ export default class BlockchainSubscribe extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             accounts: payload.accounts,

--- a/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -33,9 +33,8 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             currency: payload.currency,

--- a/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
+++ b/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo, BlockchainSubscribeAccount } from '../../../types';
 
@@ -41,9 +41,8 @@ export default class BlockchainUnsubscribe extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             accounts: payload.accounts,

--- a/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
@@ -4,7 +4,7 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 
-import { initBlockchain } from '../../../backend/BlockchainLink';
+import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type { CoreMessage, CoinInfo } from '../../../types';
 
@@ -31,9 +31,8 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod {
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        if (!coinInfo.blockchainLink) {
-            throw ERRORS.TypedError('Backend_NotSupported');
-        }
+        // validate backend
+        isBackendSupported(coinInfo);
 
         this.params = {
             coinInfo,


### PR DESCRIPTION
validate not only `coinInfo.blockchainLink` but custom backends as well