### PR TITLE
shell: patch flow binary

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,10 +3,12 @@ with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "trezor-connect-dev";
   buildInputs = [
+    autoPatchelfHook
     nodejs-12_x
     (yarn.override { nodejs = nodejs-12_x; })
   ];
   shellHook = ''
     export PATH="$PATH:$(pwd)/node_modules/.bin"
+    autoPatchelf $(pwd)/node_modules/flow-bin/
   '';
 }


### PR DESCRIPTION
Needed in order for the flow to run properly - `npm run flow`