### PR TITLE
allow path 49 unhardened in pathUtils

### DIFF
--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -64,6 +64,12 @@ export const getScriptType = (path: ?Array<number>): InputScriptType => {
 
 export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
+
+     // allow an unhardened 49 path to use paytop2shwitness
+     if (path[0] === 49) {
+        return 'PAYTOP2SHWITNESS'
+    }
+
     const p = fromHardened(path[0]);
     switch (p) {
         case 48:

--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -65,7 +65,7 @@ export const getScriptType = (path: ?Array<number>): InputScriptType => {
 export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
 
-     // allow an unhardened 49 path to use paytop2shwitness
+     // compatibility for Casa - allow an unhardened 49 path to use paytop2shwitness
      if (path[0] === 49) {
         return 'PAYTOP2SHWITNESS'
     }


### PR DESCRIPTION
At Casa, we use unhardened paths for our multisig addresses, specifically 49/{0,1}/X/X/X
We use unhardened paths so that we can derive paths for multiple coin types and accounts on our server, without requiring the private key or user export of their device.
In Trezor-Connect v6, we have not had any problems with our multisig implementation, but in v8 we are having issues with our change addresses.
Specifically, the change output fails validation when we provide the device the node and script information required for the trezor device to authorize the the change output without user interaction.

Upon a deep dive into the trezor code, I see that this fails because the output validation does the following:

determine the script type for validation based on the Hardened path provided to the output
if the path found is not a hardened path of the types allowed, then the output script type is assumed to be 'PAYTOADDRESS'
the script for that output is then recomputed based on the information supplied and the type computed and compared against the provided script for validation.
The issue we are having is that we are using the script type 'PAYTOP2SHWITNESS', with unhardened paths. When the validation function determines the script type based on the hardened path, the unhardened path we provide does not fall into a case provided by the getScriptType function, and the default script type of 'PAYTOADDRESS' is used instead. When the validation function then computes the script based on PAYTOADDRESS, validation fails because the PAYTOADDRESS script computed does not match our provided PAYTOP2SHWITNESS script.

The solution I propose is quite simple. Rather than only checking for a hardened 49 path to get PAYTOP2SHWITNESS, if the raw (unhardened) path is 49 also return PAYTOP2SHWITNESS.

This will result in the getScriptType for our specific input returning PAYTOP2SHWITNESS which will then allow validation to validate with our expected script type and succeed.