### PR TITLE
revert script type change for casa to avoid validation with multisig + p2shw

### DIFF
--- a/src/js/core/methods/helpers/signtxVerify.js
+++ b/src/js/core/methods/helpers/signtxVerify.js
@@ -77,7 +77,7 @@ const deriveOutputScript = async (getHDNode: GetHDNode, output: TransactionOutpu
     }
 
     // compatibility for Casa - If passing in multisig params with p2shw, skip validation
-    if (output.address_n && output.script_type === 'PAYTOP2SHWITNESS') {
+    if (output.multisig && output.script_type === 'PAYTOP2SHWITNESS') {
         return;
     }
 

--- a/src/js/core/methods/helpers/signtxVerify.js
+++ b/src/js/core/methods/helpers/signtxVerify.js
@@ -76,6 +76,11 @@ const deriveOutputScript = async (getHDNode: GetHDNode, output: TransactionOutpu
         throw ERRORS.TypedError('Runtime', 'deriveOutputScript: Neither address or address_n is set');
     }
 
+    // compatibility for Casa - If passing in multisig params with p2shw, skip validation
+    if (output.address_n && output.script_type === 'PAYTOP2SHWITNESS') {
+        return;
+    }
+
     const scriptType = output.address_n
         ? getOutputScriptType(output.address_n)
         : getAddressScriptType(output.address, coinInfo);

--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -50,11 +50,6 @@ export const isBech32Path = (path: ?Array<number>): boolean => {
 export const getScriptType = (path: ?Array<number>): InputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'SPENDADDRESS';
 
-    // compatibility for Casa - allow an unhardened 49 path to use SPENDMULTISIG
-    if (path[0] === 49) {
-        return 'SPENDMULTISIG';
-    }
-
     const p1 = fromHardened(path[0]);
     switch (p1) {
         case 48:
@@ -70,11 +65,6 @@ export const getScriptType = (path: ?Array<number>): InputScriptType => {
 
 export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
-
-    // compatibility for Casa - allow an unhardened 49 path to use PAYTOMULTISIG
-    if (path[0] === 49) {
-        return 'PAYTOMULTISIG';
-    }
 
     const p = fromHardened(path[0]);
     switch (p) {


### PR DESCRIPTION
@prusnak 
Hey Pavol. Thank you for recommending me to run trezor locally so I could step through and test this. I hadn't been able to figure out how to do that previously.
I was able to test your proposed changes and they actually did not work for us. It was able to skip the output validation, however the signature did not apply on our end because the signature scripts did not match our script / address types since this required us to move to paytomultisig instead of using our current script types.

Since the issue you had mentioned was that p2shw ignored the multisig components during validation, the solution I am proposing instead is that we skip the script validation when this combination is passed in.
I have tested locally and confirmed this code now works. Would greatly appreciate you helping to move this through or letting me know if you have any other suggestions.

Thanks!