### PR TITLE
version 8.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 8.1.12
 #### Fixed
 - `interactionTimeout` moved to a lower block in code
+- `composeTransaction` filter `max = -1` field from the result
 #### Changed
 - Don't try to validate multisig output scripts (not implemented yet)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.1.12 [unreleased]
+
+#### Changed
+- Don't try to validate multisig output scripts (not implemented yet)
+
 # 8.1.11
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.11
+#### Changed
+- Default value of `interactionTimeout` has been increased from 2 minutes to 5 minutes.
+
 # 8.1.10
 #### Changed
 - Cardano Shelley Update #638 #639

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Added
 - Public `getCoinInfo` method.
+- iframe errors (timeout/blocked) displayed in popup.
 #### Fixed
 - `interactionTimeout` moved to a lower block in code.
 - `composeTransaction` filter `max = -1` field from the result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 #### Fixed
 - `interactionTimeout` moved to a lower block in code.
 - `composeTransaction` filter `max = -1` field from the result.
+- skip device state verification on device management methods.
 #### Changed
 - Using `blockchainSetCustomBackend` method with an empty array of URLs will disable custom backends (reset to default).
 - Blockbook will verify that it is connecting to the right coin backend or it will throw an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,27 @@
 # 8.1.11
+
 #### Changed
 - Default value of `interactionTimeout` has been increased from 2 minutes to 5 minutes.
 
 #### Fixed
 - Allow unhardenended path (compatibility for Casa)
-- zcash: don't send version_group_id for tx version lower than 3
+- zcash: don't send `version_group_id` for tx version lower than 3
 
 # 8.1.10
+
 #### Changed
 - Cardano Shelley Update #638 #639
 - Updated dependencies
 
 # 8.1.9
+
 #### Fixed
 - `composeTransaction` - remove unnecessary condition when using `send-max` outputs
 #### Added
 - `interactionTimeout` property to the initial settings. This will timeout users who stay inactive for a specified amount of time (in seconds).
 
 # 8.1.8
+
 #### Added
 - `ButtonRequest_PinEntry`
 - `legacyXpub` field in response of `getAccountInfo` (BTC-like coins) used in `metadata` (labeling)
@@ -27,6 +31,7 @@
 - Improved tests (trezor-user-env)
 
 # 8.1.7
+
 #### Fixed
 - `composeTransaction` missing zcash specific fields (in popup mode)
 - `firmwareUpdate` default download url (data.trezor.io)
@@ -35,6 +40,7 @@
 - Typed errors
 
 # 8.1.6
+
 #### Fixed
 - `composeTransaction` sequence flag
 - Zcash `extra_data` field
@@ -44,6 +50,7 @@
 - Refactor Bitcoin-like signing
 
 # 8.1.5
+
 #### Fixed
 - `estimateFee` fee levels for `DGB`
 - `unavailableCapabilities` reload condition
@@ -51,25 +58,31 @@
 - `webextension` example
 
 # 8.1.4
+
 #### Fixed
 - `composeTransaction` returns zcash inputs with amount
-- update `trezor-common` (`LTC` minfee_kb, removed `CPC` and `ZEN`)
+- update `trezor-common` (`LTC` `minfee_kb`, removed `CPC` and `ZEN`)
 
 # 8.1.3
+
 #### Fixed
 - `@trezor/blockchain-link` recv transaction targets
 - add missing `type` field to `RequestPin`
 
 # 8.1.2
+
 #### Fixed
 - bech32 xpub format in fw < 1.7.2 & 2.0.10
 - workaround for pending unread message (trezor/trezord-go#154)
 - blockchainSubscribe optional params
 
 # 8.1.1 (npm only)
+
+#### Fixed
 - flowtype fix
 
 # 8.1.0
+
 #### Added
 - Support for FW 1.9.0 and 2.3.0 (passphrase redesign)
 - Typescript types
@@ -83,6 +96,7 @@
 - `TrezorConnect.blockchainSetCustomBackend` method
 - `TrezorConnect.cancel` is now trying to send (post) 'Cancel' message to acquired device (not working with TrezorBridge < 2.0.29)
 - Implement @trezor/rollout module https://github.com/trezor/connect/issues/295
+
 #### Fixed
 - General cleanup in flowtype declarations
 - disableWebUsb method
@@ -90,14 +104,17 @@
 - Fixed race condition in nodejs https://github.com/trezor/connect/issues/504
 
 # 8.0.15 (server side only)
+
 #### Fixed
 - `getAccountInfo` Bech32 accounts shouldn't be default #547
 
 # 8.0.14 (server side only)
+
 #### Fixed
 - `signtxVerify` P2WSH output #541
 
 # 8.0.13
+
 #### Fixed
 - `getAddress` for multisig addresses #509
 - `bundle` params spread #514
@@ -105,39 +122,50 @@
 - functions used as classes #512
 
 # 8.0.12
+
 #### Added
 - Peercoin support
+
 #### Updated
-- ZCash Blossom fork (updated branch_id)
+- ZCash Blossom fork (updated `branch_id`)
 
 # 8.0.11
+
 #### Added
 - React native transport
+
 #### Updated
-- TRANSPORT_EVENT "bridge" field send only in browser env. Whole logic moved from Core/DataManager to iframe
+- `TRANSPORT_EVENT` "bridge" field send only in browser env. Whole logic moved from Core/DataManager to iframe
 
 # 8.0.10
+
 #### Added
 - Jest unit tests
+
 #### Fixed
 - Browser validation logic moved from Core to popup, not restricted anymore
 - popupMessagePort assignment for browsers without BroadcastChannel support
 - multiple eslint/flow fixes
+
 #### Updated
-- Update outdated and remove unused node_modules dependencies
+- Update outdated and remove unused `node_modules` dependencies
 
 # 8.0.9
+
 #### Fixed
 - `getAccountInfo` bump @trezor/blockchain-link version with fixed ripple auto reconnection and ripple-lib issue https://github.com/ripple/ripple-lib/issues/1066
 
 # 8.0.8
+
 #### Fixed
 - `tezosSignTransaction` Babylon fork update, exclude firmware lower than 2.1.8
 
 # 8.0.7
+
 #### Added
 - `stellarSignTransaction` plugin - a tool for transforming StellarSDK.Transaction object into TrezorConnect.StellarTransaction
 - `stellarSignTransaction` missing tests
+
 #### Fixed
 - `stellarSignTransaction` parameters types (number > string, add required and optional params)
 - `blockchainEstimateFee` method (smart fees)
@@ -146,56 +174,72 @@
 - `rippleSingTransaction` amount type to string
 
 # 8.0.6
+
 #### Added
 - `firmwareUpdate` method now emits `ButtonRequest_FirmwareUpdate` event and `ui-firmware-progress` event
 - `blockchainGetTransactions` and `blockchainEstimateFee` methods
 - `composeTransaction` returns precomposed transaction for account
+
 #### Fixed
 - Removed unnecessary error wrapper (core.js)
+
 #### Removed
 - removed standalone `firmwareErase` and `firmwareUpload` methods.
 
 # 8.0.5 (server side only)
+
 #### Fixed
 - fix `disconnect`-`method response` race condition
 - `getAccountInfo` runtime error when using descriptor without path
 - Firmware releases channel (beta-wallet)
 
 # 8.0.4 (server side only)
+
 #### Added
 - Added `Unobtanium` support
+
 #### Fixed
 - `pendingTransport` race condition using lazyLoading and multiple devices connected
 - simplified `Core` error rejection
 - `BNB` firmware range
-#### Updated 
+
+#### Updated
 - coins.json
 
 # 8.0.3
+
 #### Added
 - Added `Binance Chain (BNB)` support
+
 #### Fixed
 - `TrezorConnect.cancel` race condition between device release and returned response
-#### Updated 
+
+#### Updated
 - protobuf messages
 - firmware releases
 
 # 8.0.2
+
 #### Added
 - Added `Device.Features.features` field
+
 #### Changed
 - `CoinInfo.blockchainLink` field generated from `coins.json:blockbook` for BTC-like and ETH-like
-#### Updated 
+
+#### Updated
 - supported coins
 - protobuf messages
 
 # 8.0.1
+
 #### Added
 - Added `TrezorConnect.disableWebUSB` method
+
 #### Fixed
 - renamed EOS actions parameters 'buyram': quantity > quant, 'voteproducer': data.account > data.voter
 
 # 8.0.0
+
 #### Breaking changes
 - Changed communication process between host, iframe and popup. BroadcastChannel is used as default, postMessage as fallback
 - Completely rewritten backend layer. Old way using hd-wallet and bitcore/blockbook-api-v1 is dropped in favour of `@trezor/blockchain-link`
@@ -213,44 +257,51 @@
 - Added shamir recovery
 
 # 7.0.5
-__added__
+
+#### Added
 - Added cloudfront cache invalidation
-__fixed__
+
+#### Fixed
 - Url encoding in `TrezorConnect.manifest`
 
 # 7.0.4
-__added__
+
+#### Added
 - Added EOS methods `TrezorConnect.eosGetPublicKey` and `TrezorConnect.eosSignTransaction`
 - Added `TrezorConnect.firmwareUpdate` (management method)
 - Added new firmware releases
 - Added new bridge releases
-__fixed__
+
+#### Fixed
 - Dependencies security vulnerabilities
 - Minor fixes in flowtype and tests
 
 # 7.0.3
-__added__
+
+#### Added
 - Added management methods `applyFlags`, `applySettings`, `backupDevice`, `changePin`, `firmwareErase`, `firmwareUpload`, `recoveryDevice`
 
 # 7.0.2
-__added__
+
+#### Added
 - Added missing params to `TrezorConnect.signTransaction` method [`version`, `expiry`, `overwintered`, `versionGroupId`, `branchId`, `refTxs`]
 - Possibility to use `TrezorConnect.signTransaction` without build-in backend (using `refTxs` field)
 - Added `TrezorConnect.getSettings` method
 
-__fixed__
+#### Fixed
 - Fixed `Dash` and `Zcash` special transactions
 - `EthereumGetAddress` address validation
 - Flowtype for `CardanoInput`
 
 # 7.0.1
-__added__
+
+#### Added
 - Added `TrezorConnect.manifest` method
 - Added DebugLink (emulator) support: `TrezorConnect.debugLinkDecision` and `TrezorConnect.debugLinkGetState` methods
 - Added `TrezorConnect.ethereumGetPublicKey` method (with fallback for older firmware)
 - Added `TrezorConnect.loadDevice` method
 - Added `Capricoin` support (with required changes in `hd-wallet` and `bitcoinjs-lib-zcash` libs)
-- Added `firmwareRange` to every method (validation if device FW is in range: min_required_firmware - max_compatible_firmware declared in config.json)
+- Added `firmwareRange` to every method (validation if device FW is in range: `min_required_firmware` - `max_compatible_firmware` declared in config.json)
 - Added conditional protobuf messages (fallback for older FW)
 - Added "device not backed up" confirmation
 - Added `blockchain-link` dependency
@@ -259,36 +310,39 @@ __added__
 - Added `TrezorConnect.blockchainUnsubscribe` method
 - Added `BlockchainEvent` (connect/error/block/notification)
 
-__changed__
+#### Changed
 - Upgrade npm modules (babel@7)
 - Changed `network` for `protocol_magic` in `TrezorConnect.cardanoSignTransaction` method
 
-__fixed__
+#### Fixed
 - ComposeTransaction: fees/legacy detection
 - test with DebugLink device
 - removed "window" references
 
 # 6.0.5
-__changed__
+
+#### Changed
 - Delay for popup window
 - Temporary disable webusb (chrome72 issue)
 
 # 6.0.4
-__added__
+
+#### Added
 - Added `UI.ADDRESS_VALIDATION` event
 
-__changed__
+#### Changed
 - `getAddress`, `cardanoGetAddress`, `ethereumGetAddress`, `liskGetAddress`, `nemGetAddress`, `rippleGetAddress`, `stellarGetAddress`, `tezosGetAddress` methods (allow to handle `UI.ADDRESS_VALIDATION` event)
 - refactor `ButtonRequest_Address` view in popup: display address and copy to clipboard button
 - extend `getAccountInfo` response (utxo, used addresses, unused addresses)
 - Moved flowtype declarations from ./src/flowtype to ./src/js/types
 - Refactor CoinInfo to 3 types: BitcoinNetworkInfo, EthereumNetworkInfo and MiscNetworkInfo
 
-__fixed__
+#### Fixed
 - `stellarSignTransaction` with multiple operations
 
 # 6.0.3
-__added__
+
+#### Added
 - Added `TrezorConnect.tezosGetAddress` method
 - Added `TrezorConnect.tezosGetPublicKey` method
 - Added `TrezorConnect.tezosSignTransaction` method
@@ -297,36 +351,39 @@ __added__
 - Added new firmware releases
 - Added new bridge releases
 
-__changed__
+#### Changed
 - Whitelist `trusted` mode for instances hosted locally
 - Send correct `script_type` in `GetPublicKey` message
 
-__fixed__
+#### Fixed
 - Stellar signTransaction amount validation
 - Stellar signer field validation ("StellarSetOptionsOp" operation in "stellarSignTransaction" method)
 - Firmware (model) not supported popup screen
 
 # 6.0.2
-__added__
+
+#### Added
 - Added `TrezorConnect.wipeDevice` method
 - Added `TrezorConnect.resetDevice` method
 - Calling method on device with seedless setup is disabled by default
 
-__changed__
+#### Changed
 - Post message to window.parent instead of window.top
 - Authenticating device using BTC testnet path instead of dummy m/1/0/0
 
 # 6.0.1
-__fixed__
-- WRONG_PREVIOUS_SESSION race condition when switching between tabs and acquiring device
+
+#### Fixed
+- `WRONG_PREVIOUS_SESSION` race condition when switching between tabs and acquiring device
 - removed unnecessary console.logs and build scripts
 - Docker build for npm
 
-__changed__
+#### Changed
 - Renamed directory "dist" to "build"
 
 # 6.0.0
-__added__
+
+#### Added
 - Added `TrezorConnect.pushTransaction` method with ethereum blockbook support
 - Added `TrezorConnect.ethereumGetAccountInfo` method
 - Added `TrezorConnect.blockchainSubscribe` method
@@ -335,40 +392,44 @@ __added__
 - Added `./data/bridge/releases.json`
 - Added bridge release info in TRANSPORT.START and TRANSPORT.ERROR event
 
-__fixed__
+#### Fixed
 - TRANSPORT.ERROR event when computer goes to sleep
 - unexpectedDeviceMode immediately rejects call in trusted mode
 
-__changed__
+#### Changed
 - coins.json merged as one file (removed data/ethereumNetworks.json)
 - License to T-RSL
 
 # 5.0.34
-__fixed__
+
+#### Fixed
 - Unicode character in regexp, (https://github.com/trezor/connect/pull/229)
 
 # 5.0.33
-__fixed__
+
+#### Fixed
 - `TrezorConnect.ethereumSignMessage` and `TrezorConnect.ethereumVerifyMessage` methods with "hex" parameter
 - flowtype for `TrezorConnect.cardanoGetPublicKey` in `TrezorConnect.cardanoSignTransaction` methods
 
 # 5.0.32
-__added__
+
+#### Added
 - Added `TrezorConnect.cardanoGetPublicKey` method
 - Ability to sign hexed ethereum message
 - `network` parameter to `TrezorConnect.cardanoSignTransaction` method
 
-__fixed__
+#### Fixed
 - TRANSPORT.ERROR event when computer goes to sleep
 - finding backend by name instead of urls
 - proper FW version for Lisk and Stellar
 
-__removed__
+#### Removed
 - Removed `TrezorConnect.cardanoSignMessage` method
 - Removed `TrezorConnect.cardanoVerifyMessage` method
 
 # 5.0.31
-__added__
+
+#### Added
 - Support for Cardano
 - Support for Ripple
 - Support for Lisk
@@ -376,28 +437,31 @@ __added__
 - Disable customMessage method for devices with official firmware
 - Added new field in `TrezorConnect.signEthereumTransaction` for `Wanchain`
 
-__changed__
+#### Changed
 - Separate "getPublicKey" and "getAddress" methods for all coins
 
-__fixed__
+
+#### Fixed
 - Device state verification while using multiple instances with the same passphrase
 - ConnectSettings sensitive settings verification in DataManager
 - removed package-lock.json from repository
 
 # 5.0.30
-__added__
+
+#### Added
 - Added 'send-max' and 'opreturn' output types to `TrezorConnect.composeTransaction`
 
-__fixed__
+#### Fixed
 - Handle popup close event while waiting for iframe handshake
-- Removed ledgerVersion (protocol_version) from StellarSignTransaction method
+- Removed ledgerVersion (`protocol_version`) from StellarSignTransaction method
 - One time permissions stored in session in application variable
 - `TrezorConnect.ethereumSignTransaction` recompute "v" value if Trezor returns value in range [0,1]
 - Webextensions: Handling if popup is called from "normal" window or extension popup
 - ConnectSetting default domain
 
 # 5.0.29
-__fixed__
+
+#### Fixed
 - Fixed flowtype for TrezorConnect methods (bundled methods return bundled results)
 - Fixed renderWebUSBButton method
 - Removed "babel-polyfill" from npm and export unminified script https://connect.trezor.io/5/trezor-connect.js
@@ -405,60 +469,67 @@ __fixed__
 - Web extensions: open popup tab next to currently used tab
 
 # 5.0.28
-__added__
+
+#### Added
 - Added support for WebExtensions (Chrome/Firefox)
 - Added host icon for whitelisted domains
 
-__fixed__
+#### Fixed
 - Fixed passphrase input type (revert to password type)
 - Fixed popup and iframe timeout handling
 
 # 5.0.27
-__fixed__
+
+#### Fixed
 - Fixed handling not initialized iframe
 - Fixed iframe ad-blocker handling
 - Fixed popup views
 
-__changed__
+#### Changed
 - Popup as new tab
 
 # 5.0.26
-__added__
+
+#### Added
 - Added support for Dogecoin and Vertcoin
 
-__fixed__
+#### Fixed
 - Fixed handling not initialized device
 - SignTransaction: amount as string
 - Handle origin of file://
 
-__changed__
+#### Changed
 - Default url in connect
 
 # 5.0.25
-__added__
+
+#### Added
 - Added documentation
 
-__fixed__
+#### Fixed
 - filter UI events for popup and trusted apps
 - Fixed `TrezorConnect.signMessage` and `TrezorConnect.verifyMessage` signature to base64 format
 
-__changed__
-- Changed constants prefix from "__" to "-"
+#### Changed
+- Changed constants prefix from `__` to `-`
 
 # 5.0.24
-__fixed__
+
+#### Fixed
 - removed popup delay if lazy loading
 - validation of device state if method is using emptyPassphrase
 - retyped Device, distinguished by "type" field
 - eslint fixes
 
 # 5.0.23
-__fixed__
+
+#### Fixed
 - npm package dependencies
 - Unsupported browser (IE)
 
 # 5.0.21
-__added__
+
+#### Added
 - Added `TrezorConnect.pushTransaction` method
 - Added bundle parameters in `TrezorConnect.cipherKeyValue` method
 - Added bundle parameters in `TrezorConnect.getPublicKey` method
@@ -471,7 +542,7 @@ __added__
 - Tests with emulator
 - Added '@babel/runtime' to package dependency
 
-__fixed__
+#### Fixed
 - Fixed device authentication and popup open delay
 - Minor fixes in popup view
 - Ethereum methods accepts values with '0x' prefix
@@ -479,28 +550,31 @@ __fixed__
 - Ethereum methods returns values prefixed with '0x'
 
 # 5.0.20
-__added__
+
+#### Added
 - Added firmware check against CoinInfo.support values
 - Added outdate firmware warning in popup
 
-__fixed__
+#### Fixed
 - Fixed `TrezorConnect.requestLogin` parameters
-- Fixed race condition in UI.REQUEST_CONFIRMATION
+- Fixed race condition in `UI.REQUEST_CONFIRMATION`
 - Fixed popup.html buttons click
 
-
 # 5.0.18
-__added__
+
+#### Added
 - Added iframe lazy loading
 
-__fixed__
+
+#### Fixed
 - Build script for npm module
 - Ultimate flow type
 - Reorganized files and imports
 - Minor fixes in code
 
 # 5.0.17
-__added__
+
+#### Added
 - Added `TrezorConnect.getAccountInfo` method
 - Added `TrezorConnect.signTransaction` method
 - Added `TrezorConnect.composeTransaction` method
@@ -511,49 +585,52 @@ __added__
 - Added cashaddr support for BCH
 - Added documentation
 
-__fixed__
+#### Fixed
 - Fixed `TrezorConnect.customMessage` logic and security
 - Fixed `TrezorConnect.stellarSignTransaction` parameters compatible with "js-stellar-base"
 - Fixed flowtype declarations for all methods. Params and responses
 
-__removed__
+#### Removed
 - Removed unnecessary settings from ConnectSettings
 - Removed unused methods from TrezorConnect
 
 # 5.0.16
-__added__
+
+#### Added
 - Added `TrezorConnect.stellarSignTransaction` method
 
-__changed__
+#### Changed
 - Changed `TrezorConnect.ethereumSignTransaction` parameters
 
-__removed__
+#### Removed
 - Removed type and event fields from RESPONSE
 
 # 5.0.15
-__fixed__
+
+#### Fixed
 - Library exports
 
 # 5.0.14
-__added__
+
+#### Added
 - Added `TrezorConnect.nemGetAddress` method
 - Added `TrezorConnect.nemSignTransaction` method
 - Added `TrezorConnect.stellarGetAddress` method
 - Added `TrezorConnect.customMessage` method
 
-__fixed__
+#### Fixed
 - Fixed flowtype
 
-
 # 5.0.13
-__added__
-- Added messages from json instead of config_signed.bin
+
+#### Added
+- Added messages from json instead of `config_signed.bin`
 - Added popup.html UI/css
 - Karma + Jasmine tests
 
-__removed__
+#### Removed
 - Removed support for Bridge v1 and chrome extension
 
-
 # 5.0.10
+
 From this version trezor-connect is used by Trezor Password Manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 8.1.12 [unreleased]
-
+# 8.1.12
+#### Fixed
+- `interactionTimeout` moved to a lower block in code
 #### Changed
 - Don't try to validate multisig output scripts (not implemented yet)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 #### Changed
 - Default value of `interactionTimeout` has been increased from 2 minutes to 5 minutes.
 
+#### Fixed
+- Allow unhardenended path (compatibility for Casa)
+- zcash: don't send version_group_id for tx version lower than 3
+
 # 8.1.10
 #### Changed
 - Cardano Shelley Update #638 #639

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # 8.1.12
+
+#### Added
+- Public `getCoinInfo` method.
 #### Fixed
-- `interactionTimeout` moved to a lower block in code
+- `interactionTimeout` moved to a lower block in code.
 #### Changed
-- Don't try to validate multisig output scripts (not implemented yet)
+- Using `setCustomBackend` method with an empty array of URLs will disable custom backends (reset to default).
+- Blockbook will verify that it is connecting to the right coin backend or it will throw an error.
+- Don't try to validate multisig output scripts (not implemented yet).
 
 # 8.1.11
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trezor Connect API version 8.1.10
+# Trezor Connect API version 8.1.11
 [![Build Status](https://travis-ci.org/trezor/connect.png?branch=develop)](https://travis-ci.org/trezor/connect)
 [![NPM](https://img.shields.io/npm/v/trezor-connect.svg)](https://www.npmjs.org/package/trezor-connect)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/connect?targetFile=package.json)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trezor Connect API version 8.1.11
+# Trezor Connect API version 8.1.12
 [![Build Status](https://travis-ci.org/trezor/connect.png?branch=develop)](https://travis-ci.org/trezor/connect)
 [![NPM](https://img.shields.io/npm/v/trezor-connect.svg)](https://www.npmjs.org/package/trezor-connect)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/connect?targetFile=package.json)

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -13,6 +13,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 * [TrezorConnect.cipherKeyValue](methods/cipherKeyValue.md)
 * [TrezorConnect.wipeDevice](methods/wipeDevice.md)
 * [TrezorConnect.resetDevice](methods/resetDevice.md)
+* [TrezorConnect.getCoinInfo](methods/getCoinInfo.md)
 
 ### Bitcoin, Bitcoin Cash, Bitcoin Gold, Litecoin, Dash, ZCash, Testnet
 

--- a/docs/methods/getCoinInfo.md
+++ b/docs/methods/getCoinInfo.md
@@ -1,0 +1,67 @@
+## Get Coin Info
+Returns information about a specified coin from the [coins.json](../../src/data/coins.json) file.
+
+ES6
+```javascript
+const result = await TrezorConnect.getCoinInfo(params);
+```
+
+CommonJS
+```javascript
+TrezorConnect.getCoinInfo(params).then(function(result) {
+
+});
+```
+
+### Params
+[****Optional common params****](commonParams.md)
+#### Exporting single address
+* `coin` — *obligatory* `string` coin symbol (btc, eth, bch, ...).
+
+### Example
+Get coin info for Bitcoin.
+```javascript
+TrezorConnect.getCoinInfo({
+    coin: 'btc',
+});
+```
+
+### Result
+Result for Bitcoin
+```javascript
+{
+    success: true,
+    payload: {
+        blockchainLink: Object { type: "blockbook", url: (5) […] },
+        blocks: 10,
+        blocktime: 10,
+        cashAddrPrefix: null,
+        curveName: "secp256k1",
+        decimals: 8,
+        defaultFees: Object { Economy: 70, High: 200, Low: 10, … },
+        dustLimit: 546,
+        forceBip143: false,
+        forkid: null,
+        hasTimestamp: false,
+        hashGenesisBlock: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        isBitcoin: true,
+        label: "Bitcoin",
+        maxAddressLength: 34,
+        maxFee: 2000,
+        maxFeeSatoshiKb: 2000000,
+        minAddressLength: 27,
+        minFee: 1,
+        minFeeSatoshiKb: 1000,
+        name: "Bitcoin",
+        network: Object { messagePrefix: "Bitcoin Signed Message:\n", bech32: "bc", pubKeyHash: 0, … },
+        segwit: true,
+        shortcut: "BTC",
+        slip44: 0,
+        support: Object { connect: true, trezor1: "1.5.2", trezor2: "2.0.5", … },
+        type: "bitcoin",
+        xPubMagic: 76067358,
+        xPubMagicSegwit: 77429938,
+        xPubMagicSegwitNative: 78792518,
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-connect",
-    "version": "8.1.11",
+    "version": "8.1.12",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-connect",
-    "version": "8.1.10",
+    "version": "8.1.11",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/src/data/bridge/releases.json
+++ b/src/data/bridge/releases.json
@@ -25,7 +25,7 @@
 			},
 			{
 				"platform": ["mac"],
-				"name": "Mac OS X",
+				"name": "macOS",
 				"url": "trezor-bridge-{version}.pkg",
 				"signature": "trezor-bridge-{version}.pkg.asc"
 			},

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -1710,13 +1710,10 @@
 
         <!-- Iframe not loading failure -->
         <div class="iframe-failure">
-            <div>
-                <h3>Could not communicate with the source website</h3>
-                <p>
-                    The source website was not able to communicate with Trezor Connect. This can be caused by pop-up or ad blockers. Please ensure all <a href="https://trezor.io/" target="_blank" rel="noreferrer noopener">trezor.io</a> domains are allowed.
-                </p>
-            </div>
-
+            <h3>Could not communicate with the source website</h3>
+            <p>
+                The source website was not able to communicate with Trezor Connect. This can be caused by pop-up or ad blockers. Please ensure all <a href="https://trezor.io/" target="_blank" rel="noreferrer noopener">trezor.io</a> domains are allowed.
+            </p>
             <button class="cancel" onclick="window.closeWindow();">Close</button>
         </div>
 

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -1708,6 +1708,18 @@
             <a class="button notification-button" href="https://wallet.trezor.io/?backup=1" target="_blank" rel="noreferrer noopener" onclick="window.closeWindow();">Create a backup in 3 minutes.</a>
         </div>
 
+        <!-- Iframe not loading failure -->
+        <div class="iframe-failure">
+            <div>
+                <h3>Could not communicate with the source website</h3>
+                <p>
+                    The source website was not able to communicate with Trezor Connect. This can be caused by pop-up or ad blockers. Please ensure all <a href="https://trezor.io/" target="_blank" rel="noreferrer noopener">trezor.io</a> domains are allowed.
+                </p>
+            </div>
+
+            <button class="cancel" onclick="window.closeWindow();">Close</button>
+        </div>
+
     </div>
 
     <script type="text/javascript" async="false">

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -273,7 +273,7 @@ export const find = (name: string) => {
 };
 
 export const setCustomBackend = (coinInfo: CoinInfo, blockchainLink: $ElementType<CoinInfo, 'blockchainLink'>) => {
-    if (!blockchainLink) {
+    if (!blockchainLink || blockchainLink.url.length === 0) {
         delete customBackends[coinInfo.shortcut];
     } else {
         customBackends[coinInfo.shortcut] = coinInfo;

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -84,11 +84,15 @@ export default class Blockchain {
     async init() {
         this.link.on('connected', async () => {
             const info = await this.link.getInfo();
+            if (info.name !== this.coinInfo.name) {
+                this.onError(ERRORS.TypedError('Backend_Invalid'));
+                return;
+            }
+
             this.postMessage(BlockchainMessage(BLOCKCHAIN.CONNECT, {
                 coin: this.coinInfo,
                 ...info,
             }));
-            // TODO: check for 1st block hash (different for btc forks)
         });
 
         this.link.on('disconnected', () => {

--- a/src/js/constants/errors.js
+++ b/src/js/constants/errors.js
@@ -29,6 +29,7 @@ export const ERROR_CODES = {
     'Backend_NotSupported': 'BlockchainLink settings not found in coins.json', // thrown by methods which using backends, blockchainLink not defined for this coin
     'Backend_WorkerMissing': '', // thrown by BlockchainLink class, worker not specified
     'Backend_Disconnected': 'Backend disconnected', // thrown by BlockchainLink class
+    'Backend_Invalid': 'Invalid backend', // thrown by BlockchainLink class, invalid backend (ie: backend for wrong coin set)
     'Backend_Error': '', // thrown by BlockchainLink class, generic message from 'blockchain-link'
 
     'Runtime': '', // thrown from several places, this shouldn't ever happen tho

--- a/src/js/constants/ui.js
+++ b/src/js/constants/ui.js
@@ -56,3 +56,5 @@ export const LOGIN_CHALLENGE_RESPONSE: 'ui-login_challenge_response' = 'ui-login
 
 export const BUNDLE_PROGRESS: 'ui-bundle_progress' = 'ui-bundle_progress';
 export const ADDRESS_VALIDATION: 'ui-address_validation' = 'ui-address_validation';
+
+export const IFRAME_FAILURE: 'ui-iframe-failure' = 'ui-iframe-failure';

--- a/src/js/constants/ui.js
+++ b/src/js/constants/ui.js
@@ -57,4 +57,4 @@ export const LOGIN_CHALLENGE_RESPONSE: 'ui-login_challenge_response' = 'ui-login
 export const BUNDLE_PROGRESS: 'ui-bundle_progress' = 'ui-bundle_progress';
 export const ADDRESS_VALIDATION: 'ui-address_validation' = 'ui-address_validation';
 
-export const IFRAME_FAILURE: 'ui-iframe-failure' = 'ui-iframe-failure';
+export const IFRAME_FAILURE: 'ui-iframe_failure' = 'ui-iframe_failure';

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -64,14 +64,10 @@ const getPopupPromise = (requestWindow: boolean = true): Deferred<void> => {
 /**
  * Start interaction timeout timer
  */
-const interactionTimeout = () => {
-    if ()
-
-    _interactionTimeout.start(() => {
-        // eslint-disable-next-line no-use-before-define
-        onPopupClosed('Interaction timeout');
-    });
-};
+const interactionTimeout = () => _interactionTimeout.start(() => {
+    // eslint-disable-next-line no-use-before-define
+    onPopupClosed('Interaction timeout');
+});
 
 /**
  * Creates an instance of uiPromise.

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -14,7 +14,6 @@ import { find as findMethod } from './methods';
 
 import { create as createDeferred } from '../utils/deferred';
 import { resolveAfter } from '../utils/promiseUtils';
-import { versionCompare } from '../utils/versionUtils';
 import Log, { init as initLog } from '../utils/debug';
 import InteractionTimeout from '../utils/interactionTimeout';
 
@@ -66,19 +65,6 @@ const getPopupPromise = (requestWindow: boolean = true): Deferred<void> => {
  * Start interaction timeout timer
  */
 const interactionTimeout = () => _interactionTimeout.start(() => {
-    /**
-     * Bridge version =< 2.0.28 has a bug that doesn't permit it to cancel
-     * user interactions in progress, so we have to do it manually.
-     */
-    const { type, version } = _core.getTransportInfo();
-    if (type === 'bridge' && versionCompare(version, '2.0.28') < 1) {
-        if (_deviceList && _deviceList.asArray().length > 0) {
-            _deviceList.allDevices().forEach(d => {
-                d.legacyForceRelease();
-            });
-        }
-    }
-
     // eslint-disable-next-line no-use-before-define
     onPopupClosed('Interaction timeout');
 });

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -64,10 +64,14 @@ const getPopupPromise = (requestWindow: boolean = true): Deferred<void> => {
 /**
  * Start interaction timeout timer
  */
-const interactionTimeout = () => _interactionTimeout.start(() => {
-    // eslint-disable-next-line no-use-before-define
-    onPopupClosed('Interaction timeout');
-});
+const interactionTimeout = () => {
+    if ()
+
+    _interactionTimeout.start(() => {
+        // eslint-disable-next-line no-use-before-define
+        onPopupClosed('Interaction timeout');
+    });
+};
 
 /**
  * Creates an instance of uiPromise.
@@ -961,7 +965,8 @@ export const init = async (settings: ConnectSettings) => {
         await DataManager.load(settings);
         await initCore();
 
-        _interactionTimeout = new InteractionTimeout(settings.interactionTimeout || 0);
+        // If we're not in popup mode, set the interaction timeout to 0 (= disabled)
+        _interactionTimeout = new InteractionTimeout(settings.popup ? settings.interactionTimeout : 0);
 
         return _core;
     } catch (error) {

--- a/src/js/core/methods/ApplyFlags.js
+++ b/src/js/core/methods/ApplyFlags.js
@@ -18,7 +18,7 @@ export default class ApplyFlags extends AbstractMethod {
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
-        this.useEmptyPassphrase = true;
+        this.useDeviceState = false;
 
         const payload: Object = message.payload;
 

--- a/src/js/core/methods/ApplySettings.js
+++ b/src/js/core/methods/ApplySettings.js
@@ -12,7 +12,7 @@ type Params = {
     label?: string;
     use_passphrase?: boolean;
     homescreen?: string;
-    passhprase_source?: number;
+    passphrase_source?: number;
     auto_lock_delay_ms?: number;
 }
 
@@ -22,7 +22,7 @@ export default class ApplySettings extends AbstractMethod {
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
-        this.useEmptyPassphrase = true;
+        this.useDeviceState = false;
         const payload: Object = message.payload;
 
         validateParams(payload, [
@@ -40,7 +40,7 @@ export default class ApplySettings extends AbstractMethod {
             label: payload.label,
             use_passphrase: payload.use_passphrase,
             homescreen: payload.homescreen,
-            passhprase_source: payload.passhprase_source,
+            passphrase_source: payload.passphrase_source,
             auto_lock_delay_ms: payload.auto_lock_delay_ms,
             display_rotation: payload.display_rotation,
         };

--- a/src/js/core/methods/BackupDevice.js
+++ b/src/js/core/methods/BackupDevice.js
@@ -10,7 +10,7 @@ export default class BackupDevice extends AbstractMethod {
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
-        this.useEmptyPassphrase = true;
+        this.useDeviceState = false;
     }
 
     async confirmation(): Promise<boolean> {

--- a/src/js/core/methods/ChangePin.js
+++ b/src/js/core/methods/ChangePin.js
@@ -14,8 +14,9 @@ export default class ChangePin extends AbstractMethod {
 
     constructor(message: CoreMessage) {
         super(message);
-        this.useEmptyPassphrase = true;
         this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+
         const payload: Object = message.payload;
         validateParams(payload, [
             { name: 'remove', type: 'boolean' },

--- a/src/js/core/methods/ComposeTransaction.js
+++ b/src/js/core/methods/ComposeTransaction.js
@@ -133,7 +133,7 @@ export default class ComposeTransaction extends AbstractMethod {
         await composer.init(blockchain);
         return feeLevels.map(level => {
             composer.composeCustomFee(level.feePerUnit);
-            const tx = composer.composed.custom;
+            const tx = { ...composer.composed.custom }; // needs to spread otherwise flow has a problem with BuildTxResult vs PrecomposedTransaction (max could be undefined)
             if (tx.type === 'final') {
                 const inputs = tx.transaction.inputs.map(inp => inputToTrezor(inp, 0xffffffff));
                 const outputs = tx.transaction.outputs.sorted.map(out => outputToTrezor(out, coinInfo));
@@ -358,7 +358,7 @@ export default class ComposeTransaction extends AbstractMethod {
 
         if (this.params.push) {
             const blockchain = await initBlockchain(coinInfo, this.postMessage);
-            const txid: string = await blockchain.pushTransaction(response.serializedTx);
+            const txid = await blockchain.pushTransaction(response.serializedTx);
             return {
                 ...response,
                 txid,

--- a/src/js/core/methods/GetCoinInfo.js
+++ b/src/js/core/methods/GetCoinInfo.js
@@ -1,0 +1,42 @@
+/* @flow */
+
+import AbstractMethod from './AbstractMethod';
+import { validateParams } from './helpers/paramsValidator';
+import { ERRORS } from '../../constants';
+
+import { getCoinInfo } from '../../data/CoinInfo';
+import type { CoreMessage, CoinInfo } from '../../types';
+
+type Params = {
+    coinInfo: CoinInfo;
+};
+
+export default class GetCoinInfo extends AbstractMethod {
+    params: Params;
+
+    constructor(message: CoreMessage) {
+        super(message);
+        this.requiredPermissions = [];
+        this.useDevice = false;
+        this.useUi = false;
+
+        const payload: Object = message.payload;
+
+        validateParams(payload, [
+            { name: 'coin', type: 'string', obligatory: true },
+        ]);
+
+        const coinInfo = getCoinInfo(payload.coin);
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+
+        this.params = {
+            coinInfo,
+        };
+    }
+
+    async run() {
+        return this.params.coinInfo;
+    }
+}

--- a/src/js/core/methods/index.js
+++ b/src/js/core/methods/index.js
@@ -68,6 +68,7 @@ import BackupDevice from './BackupDevice';
 import ChangePin from './ChangePin';
 import FirmwareUpdate from './FirmwareUpdate';
 import RecoveryDevice from './RecoveryDevice';
+import GetCoinInfo from './GetCoinInfo';
 
 const classes: { [k: string]: any } = {
     'blockchainDisconnect': BlockchainDisconnect,
@@ -133,6 +134,7 @@ const classes: { [k: string]: any } = {
     'changePin': ChangePin,
     'firmwareUpdate': FirmwareUpdate,
     'recoveryDevice': RecoveryDevice,
+    'getCoinInfo': GetCoinInfo,
 };
 
 export const find = (message: CoreMessage): AbstractMethod => {

--- a/src/js/core/methods/tx/TransactionComposer.js
+++ b/src/js/core/methods/tx/TransactionComposer.js
@@ -144,7 +144,7 @@ export default class TransactionComposer {
         const changeAddress = addresses.change[changeId].address;
         const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;
 
-        return buildTx({
+        const result = buildTx({
             utxos: this.utxos,
             outputs: this.outputs,
             height: this.blockHeight,
@@ -157,6 +157,11 @@ export default class TransactionComposer {
             changeAddress,
             dustThreshold: coinInfo.dustLimit,
         });
+        // hd-wallet returns `max = -1` when sendMax is not requested
+        // https://github.com/trezor/hd-wallet/blob/master/src/build-tx/coinselect.js#L101
+        // delete this value from the result, it should be either string or undefined
+        if (result.type !== 'error' && result.max === -1) delete result.max;
+        return result;
     }
 
     dispose() {

--- a/src/js/core/methods/tx/TransactionComposer.js
+++ b/src/js/core/methods/tx/TransactionComposer.js
@@ -65,19 +65,19 @@ export default class TransactionComposer {
     }
 
     // Composing fee levels for SelectFee view in popup
-    composeAllFeeLevels(): boolean {
+    composeAllFeeLevels() {
         const { levels } = this.feeLevels;
         if (this.utxos.length < 1) return false;
 
         this.composed = {};
-        let atLeastOneValid: boolean = false;
+        let atLeastOneValid = false;
         for (const level of levels) {
             if (level.feePerUnit !== '0') {
-                const tx: BuildTxResult = this.compose(level.feePerUnit);
+                const tx = this.compose(level.feePerUnit);
                 if (tx.type === 'final') {
                     atLeastOneValid = true;
                 }
-                this.composed[ level.label ] = tx;
+                this.composed[level.label] = tx;
             }
         }
 
@@ -102,7 +102,7 @@ export default class TransactionComposer {
     }
 
     composeCustomFee(fee: string) {
-        const tx: BuildTxResult = this.compose(fee);
+        const tx = this.compose(fee);
         this.composed['custom'] = tx;
         if (tx.type === 'final') {
             this.feeLevels.updateCustomFee(tx.feePerByte);
@@ -111,8 +111,8 @@ export default class TransactionComposer {
         }
     }
 
-    getFeeLevelList(): Array<SelectFeeLevel> {
-        const list: Array<SelectFeeLevel> = [];
+    getFeeLevelList() {
+        const list: SelectFeeLevel[] = [];
         const { levels } = this.feeLevels;
         levels.forEach(level => {
             const tx = this.composed[level.label];
@@ -135,7 +135,7 @@ export default class TransactionComposer {
         return list;
     }
 
-    compose(feeRate: string): BuildTxResult {
+    compose(feeRate: string) {
         const { account, coinInfo } = this;
         const { addresses } = account;
         if (!addresses) return { type: 'error', error: 'ADDRESSES-NOT-SET' };

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -10,7 +10,7 @@ import type {
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION = '8.1.11';
+const VERSION = '8.1.12';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -36,7 +36,7 @@ const initialSettings: ConnectSettings = {
     env: 'web',
     lazyLoad: false,
     timestamp: new Date().getTime(),
-    interactionTimeout: 120, // 2 minutes
+    interactionTimeout: 600, // 5 minutes
 };
 
 let currentSettings: ConnectSettings = initialSettings;

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -10,7 +10,7 @@ import type {
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION = '8.1.10';
+const VERSION = '8.1.11';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -7,6 +7,7 @@ import * as iframe from '../../iframe/builder';
 import webUSBButton from '../../webusb/button';
 
 import { parseMessage, errorMessage } from '../../message';
+import { UiMessage } from '../../message/builder';
 import { parse as parseSettings } from '../../data/ConnectSettings';
 import Log, { init as initLog } from '../../utils/debug';
 
@@ -172,7 +173,10 @@ export const call = async (params: any): Promise<any> => {
         try {
             await init(_settings);
         } catch (error) {
-            if (_popupManager) {
+            // Catch fatal iframe errors (not loading)
+            if (['Init_IframeBlocked', 'Init_IframeTimeout'].indexOf(error.code) === 1) {
+                _popupManager.postMessage(UiMessage(UI.IFRAME_FAILURE));
+            } else if (_popupManager) {
                 _popupManager.close();
             }
             return errorMessage(error);

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -173,11 +173,13 @@ export const call = async (params: any): Promise<any> => {
         try {
             await init(_settings);
         } catch (error) {
-            // Catch fatal iframe errors (not loading)
-            if (['Init_IframeBlocked', 'Init_IframeTimeout'].indexOf(error.code) === 1) {
-                _popupManager.postMessage(UiMessage(UI.IFRAME_FAILURE));
-            } else if (_popupManager) {
-                _popupManager.close();
+            if (_popupManager) {
+                // Catch fatal iframe errors (not loading)
+                if (['Init_IframeBlocked', 'Init_IframeTimeout'].indexOf(error.code) === 1) {
+                    _popupManager.postMessage(UiMessage(UI.IFRAME_FAILURE));
+                } else {
+                    _popupManager.close();
+                }
             }
             return errorMessage(error);
         }

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -175,7 +175,7 @@ export const call = async (params: any): Promise<any> => {
         } catch (error) {
             if (_popupManager) {
                 // Catch fatal iframe errors (not loading)
-                if (['Init_IframeBlocked', 'Init_IframeTimeout'].indexOf(error.code) === 1) {
+                if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
                     _popupManager.postMessage(UiMessage(UI.IFRAME_FAILURE));
                 } else {
                     _popupManager.close();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -290,6 +290,10 @@ const TrezorConnect: API = {
         return call({ method: 'recoveryDevice', ...params });
     },
 
+    getCoinInfo: params => {
+        return call({ method: 'getCoinInfo', ...params });
+    },
+
     dispose: () => {
         dispose();
     },

--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '8.1.11';
+const VERSION = '8.1.12';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '8.1.10';
+const VERSION = '8.1.11';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -33,6 +33,12 @@ const handleMessage = (event: PostMessageEvent) => {
         return;
     }
 
+    // This is message from the window.opener
+    if (data.type === UI.IFRAME_FAILURE) {
+        showView('iframe-failure');
+        return;
+    }
+
     // ignore messages from origin other then MessagePort (iframe)
     const isMessagePort = event.target instanceof MessagePort || (typeof BroadcastChannel !== 'undefined' && event.target instanceof BroadcastChannel);
     if (!isMessagePort) return;
@@ -127,9 +133,6 @@ const handleMessage = (event: PostMessageEvent) => {
             break;
         case UI.INVALID_PASSPHRASE :
             view.initInvalidPassphraseView(message.payload);
-            break;
-        case UI.IFRAME_FAILURE:
-            showView('iframe-failure');
             break;
     }
 };

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -128,6 +128,9 @@ const handleMessage = (event: PostMessageEvent) => {
         case UI.INVALID_PASSPHRASE :
             view.initInvalidPassphraseView(message.payload);
             break;
+        case UI.IFRAME_FAILURE:
+            showView('iframe-failure');
+            break;
     }
 };
 

--- a/src/js/types/account.js
+++ b/src/js/types/account.js
@@ -205,7 +205,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'nonfinal';
-          max?: string;
+          max: string | typeof undefined;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;
@@ -213,7 +213,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'final';
-          max?: string;
+          max: string | typeof undefined;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;

--- a/src/js/types/account.js
+++ b/src/js/types/account.js
@@ -146,12 +146,14 @@ export type AccountInfo = {
 // Compose transaction
 
 export type RegularOutput = {
+    type?: 'external';
     address: string;
     amount: string;
     script_type?: 'PAYTOADDRESS';
 }
 
 export type InternalOutput = {
+    type?: 'internal';
     address_n: number[];
     amount: string;
     script_type?: string;
@@ -203,7 +205,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'nonfinal';
-          max: string;
+          max?: string;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;
@@ -211,7 +213,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'final';
-          max: string;
+          max?: string;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -9,6 +9,7 @@ import * as Account from './account';
 import * as Bitcoin from './networks/bitcoin';
 import * as Binance from './networks/binance';
 import * as Cardano from './networks/cardano';
+import * as CoinInfo from './networks/coinInfo';
 import * as EOS from './networks/eos';
 import * as Ethereum from './networks/ethereum';
 import * as Lisk from './networks/lisk';
@@ -274,6 +275,11 @@ export type API = {
      * Ask device to initiate recovery procedure
      */
     recoveryDevice: Method<Mgmnt.RecoveryDevice, P.DefaultMessage>;
+
+    /**
+     * Get static coin info
+     */
+    getCoinInfo: Method<CoinInfo.GetCoinInfo, CoinInfo.CoinInfo>;
 
     // // Developer mode
     customMessage: Method<Misc.CustomMessage, any>;

--- a/src/js/types/events.js
+++ b/src/js/types/events.js
@@ -91,6 +91,10 @@ export type AddressValidationMessage = {
     payload: ?ButtonRequestData;
 }
 
+export type IFrameFailure = {
+    type: typeof UI.IFRAME_FAILURE;
+}
+
 export type IFrameError = {
     type: typeof IFRAME.ERROR;
     payload: {
@@ -337,6 +341,7 @@ export interface UiMessageBuilder {
     (type: FT<BundleProgress<any>>, payload: FP<BundleProgress<any>>): CoreMessage;
     (type: FT<FirmwareProgress>, payload: FP<FirmwareProgress>): CoreMessage;
     (type: FT<CustomMessageRequest>, payload: FP<CustomMessageRequest>): CoreMessage;
+    (type: FT<IFrameFailure>): CoreMessage;
     // ui response
     (type: FT<ReceivePermission>, payload: FP<ReceivePermission>): CoreMessage;
     (type: FT<ReceiveConfirmation>, payload: FP<ReceiveConfirmation>): CoreMessage;

--- a/src/js/types/networks/coinInfo.js
+++ b/src/js/types/networks/coinInfo.js
@@ -88,3 +88,7 @@ export type MiscNetworkInfo = Common & {
 };
 
 export type CoinInfo = BitcoinNetworkInfo | EthereumNetworkInfo | MiscNetworkInfo;
+
+export type GetCoinInfo = {
+    coin: string;
+};

--- a/src/js/utils/installers.js
+++ b/src/js/utils/installers.js
@@ -55,7 +55,7 @@ const BRIDGE_INSTALLERS: Array<ProtoInstallerShort> = [{
     platform: ['win32', 'win64'],
 }, {
     shortUrl: '/bridge/%version%/trezor-bridge-%version%.pkg',
-    label: 'Mac OS X',
+    label: 'macOS',
     platform: 'mac',
 }, {
     shortUrl: '/bridge/%version%/trezor-bridge_%version%_amd64.deb',

--- a/src/js/utils/interactionTimeout.js
+++ b/src/js/utils/interactionTimeout.js
@@ -8,8 +8,10 @@ export default class InteractionTimeout {
     timeout: ?TimeoutID = null;
     seconds: number = 0;
 
-    constructor(seconds: number) {
-        this.seconds = seconds;
+    constructor(seconds: ?number) {
+        if (seconds) {
+            this.seconds = seconds;
+        }
     }
 
     get seconds() {

--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -49,6 +49,7 @@ export const isBech32Path = (path: ?Array<number>): boolean => {
 
 export const getScriptType = (path: ?Array<number>): InputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'SPENDADDRESS';
+
     const p1 = fromHardened(path[0]);
     switch (p1) {
         case 48:
@@ -65,7 +66,7 @@ export const getScriptType = (path: ?Array<number>): InputScriptType => {
 export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
 
-    // compatibility for Casa - allow an unhardened 49 path to use paytop2shwitness
+    // compatibility for Casa - allow an unhardened 49 path to use PAYTOP2SHWITNESS
     if (path[0] === 49) {
         return 'PAYTOP2SHWITNESS';
     }

--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -67,7 +67,7 @@ export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
 
     // compatibility for Casa - allow an unhardened 49 path to use paytop2shwitness
     if (path[0] === 49) {
-        return 'PAYTOP2SHWITNESS'
+        return 'PAYTOP2SHWITNESS';
     }
 
     const p = fromHardened(path[0]);

--- a/src/js/utils/windowsUtils.js
+++ b/src/js/utils/windowsUtils.js
@@ -14,3 +14,15 @@ export const sendMessageToOpener = (message: any, origin: string) => {
         window.postMessage(message, window.location.origin);
     }
 };
+
+// browser built-in functionality to quickly and safely escape the string
+export const escapeHtml = (payload: Object) => {
+    if (!payload) return;
+    try {
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(JSON.stringify(payload)));
+        return JSON.parse(div.innerHTML);
+    } catch (error) {
+        // do nothing
+    }
+};

--- a/src/styles/popup.less
+++ b/src/styles/popup.less
@@ -44,3 +44,4 @@
 @import './popup/view/transport.less';
 @import './popup/view/invalidPassphrase.less';
 @import './popup/view/noBackup.less';
+@import './popup/view/iframeFailure.less';

--- a/src/styles/popup/view/iframeFailure.less
+++ b/src/styles/popup/view/iframeFailure.less
@@ -6,6 +6,10 @@
     margin-bottom: 3px;
   }
 
+  p {
+    flex: 1;
+  }
+
   .cancel {
     margin-top: 16px;
   }

--- a/src/styles/popup/view/iframeFailure.less
+++ b/src/styles/popup/view/iframeFailure.less
@@ -1,0 +1,13 @@
+.iframe-failure {
+  display: flex;
+  flex-direction: column;
+
+  h3 {
+    margin-bottom: 3px;
+  }
+
+  .cancel {
+    margin-top: 16px;
+  }
+}
+  

--- a/src/ts/types/account.d.ts
+++ b/src/ts/types/account.d.ts
@@ -144,12 +144,14 @@ export interface AccountInfo {
 // Compose transaction
 
 export interface RegularOutput {
+    type?: 'external';
     address: string;
     amount: string;
     script_type?: 'PAYTOADDRESS';
 }
 
 export interface InternalOutput {
+    type?: 'internal';
     address_n: number[];
     amount: string;
     script_type?: string;
@@ -201,7 +203,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'nonfinal';
-          max: string;
+          max?: string;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;
@@ -209,7 +211,7 @@ export type PrecomposedTransaction =
       }
     | {
           type: 'final';
-          max: string;
+          max?: string;
           totalSpent: string; // all the outputs, no fee, no change
           fee: string;
           feePerByte: string;

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -8,6 +8,7 @@ import * as Account from './account';
 import * as Bitcoin from './networks/bitcoin';
 import * as Binance from './networks/binance';
 import * as Cardano from './networks/cardano';
+import * as CoinInfo from './networks/coinInfo';
 import * as EOS from './networks/eos';
 import * as Ethereum from './networks/ethereum';
 import * as Lisk from './networks/lisk';
@@ -356,6 +357,11 @@ export namespace TrezorConnect {
      * Ask device to initiate recovery procedure
      */
     function recoveryDevice(params: P.CommonParams & Mgmnt.RecoveryDevice): P.Response<P.DefaultMessage>;
+
+    /**
+     * Get static coin info
+     */
+    function getCoinInfo(params: CoinInfo.GetCoinInfo): P.Response<CoinInfo.CoinInfo>;
 
     // // Developer mode
     function customMessage(params: P.CommonParams & Misc.CustomMessage): P.Response<any>;

--- a/src/ts/types/networks/coinInfo.d.ts
+++ b/src/ts/types/networks/coinInfo.d.ts
@@ -89,3 +89,7 @@ export interface MiscNetworkInfo extends Common {
 }
 
 export type CoinInfo = BitcoinNetworkInfo | EthereumNetworkInfo | MiscNetworkInfo;
+
+export type GetCoinInfo = {
+    coin: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7082,12 +7082,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,9 +2872,9 @@ bluebird@^3.5.5:
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 bn.js@^5.1.1:
   version "5.1.1"
@@ -4288,23 +4288,10 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.207.tgz#b19ce94d61187d72411ebb83dfe287366a785102"
   integrity sha512-RIgAnfqbjZNECBLjslfy4cIYvcPl3GAXmnENrcoo0TZ8fGkyEEAealAbO7MoevW4xYUPe+e68cWAj6eP0DmMHw==
 
-elliptic@^6.0.0, elliptic@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.0.tgz#2b8ed4c891b7de3200e14412a5b8248c7af505ca"
-  integrity sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
-
-elliptic@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+elliptic@^6.0.0, elliptic@^6.4.1, elliptic@^6.5.2:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"


### PR DESCRIPTION
#### Added
- Public `getCoinInfo` method.
- iframe errors (timeout/blocked) displayed in popup.
#### Fixed
- `interactionTimeout` moved to a lower block in code.
- `composeTransaction` filter `max = -1` field from the result.
- skip device state verification on device management methods.
#### Changed
- Using `blockchainSetCustomBackend` method with an empty array of URLs will disable custom backends (reset to default).
- Blockbook will verify that it is connecting to the right coin backend or it will throw an error.
- Don't try to validate multisig output scripts (not implemented yet).