### PR TITLE
Fix/cardano double passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # 8.1.13 (not released)
 
 ### Fixed
-- exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html)
-- initial `GetFeatures` message called on bootloader below 1.4.0
+- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html).
+- Initial `GetFeatures` message called on bootloader below 1.4.0.
+- Cardano double passphrase prompt.
 
 # 8.1.12
 

--- a/src/js/constants/index.js
+++ b/src/js/constants/index.js
@@ -3,6 +3,7 @@ import * as BLOCKCHAIN from './blockchain';
 import * as DEVICE from './device';
 import * as ERRORS from './errors';
 import * as IFRAME from './iframe';
+import * as NETWORK from './network';
 import * as POPUP from './popup';
 import * as TRANSPORT from './transport';
 import * as UI from './ui';
@@ -20,6 +21,7 @@ export {
     DEVICE,
     ERRORS,
     IFRAME,
+    NETWORK,
     POPUP,
     TRANSPORT,
     UI,

--- a/src/js/constants/network.js
+++ b/src/js/constants/network.js
@@ -2,7 +2,7 @@
 
 export const TYPES = Object.freeze({
     'bitcoin': 'Bitcoin',
-    'etherum': 'Etherum',
+    'ethereum': 'Ethereum',
     'eos': 'Eos',
     'nem': 'NEM',
     'stellar': 'Stellar',

--- a/src/js/constants/network.js
+++ b/src/js/constants/network.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+export const TYPES = Object.freeze({
+    'bitcoin': 'Bitcoin',
+    'etherum': 'Etherum',
+    'eos': 'Eos',
+    'nem': 'NEM',
+    'stellar': 'Stellar',
+    'lisk': 'Lisk',
+    'cardano': 'Cardano',
+    'ripple': 'Ripple',
+    'tezos': 'Tezors',
+    'binance': 'Binance',
+});

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -5,7 +5,7 @@ import DataManager from '../data/DataManager';
 import DeviceList from '../device/DeviceList';
 import Device from '../device/Device';
 
-import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS, NETWORK } from '../constants';
+import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS } from '../constants';
 
 import { UiMessage, DeviceMessage, TransportMessage, ResponseMessage } from '../message/builder';
 

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -5,7 +5,7 @@ import DataManager from '../data/DataManager';
 import DeviceList from '../device/DeviceList';
 import Device from '../device/Device';
 
-import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS } from '../constants';
+import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS, NETWORK } from '../constants';
 
 import { UiMessage, DeviceMessage, TransportMessage, ResponseMessage } from '../message/builder';
 
@@ -496,7 +496,7 @@ export const onCall = async (message: CoreMessage) => {
 
             // Make sure that device will display pin/passphrase
             try {
-                const invalidDeviceState = method.useDeviceState ? await device.validateState() : undefined;
+                const invalidDeviceState = method.useDeviceState ? await device.validateState(method.network) : undefined;
                 if (invalidDeviceState) {
                     if (isUsingPopup) {
                         // initialize user response promise

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -5,7 +5,7 @@ import DataManager from '../data/DataManager';
 import DeviceList from '../device/DeviceList';
 import Device from '../device/Device';
 
-import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS } from '../constants';
+import { CORE_EVENT, RESPONSE_EVENT, TRANSPORT, DEVICE, POPUP, UI, IFRAME, ERRORS, NETWORK } from '../constants';
 
 import { UiMessage, DeviceMessage, TransportMessage, ResponseMessage } from '../message/builder';
 

--- a/src/js/core/methods/AbstractMethod.js
+++ b/src/js/core/methods/AbstractMethod.js
@@ -2,7 +2,7 @@
 
 import Device from '../../device/Device';
 import DataManager from '../../data/DataManager';
-import { UI, DEVICE, ERRORS } from '../../constants';
+import { UI, DEVICE, ERRORS, NETWORK } from '../../constants';
 import { load as loadStorage, save as saveStorage, PERMISSIONS_KEY } from '../../storage';
 import { versionCompare } from '../../utils/versionUtils';
 
@@ -39,6 +39,7 @@ export default class AbstractMethod implements MethodInterface {
     allowDeviceMode: Array<string>; // used in device management (like ResetDevice allow !UI.INITIALIZED)
     requireDeviceMode: Array<string>;
     debugLink: boolean;
+    network: string;
 
     +confirmation: () => Promise<boolean>;
     +noBackupConfirmation: () => Promise<boolean>;
@@ -74,6 +75,14 @@ export default class AbstractMethod implements MethodInterface {
             this.allowDeviceMode = [ UI.SEEDLESS ];
         }
         this.debugLink = false;
+        // Determine the type based on the method name
+        this.network = 'Bitcoin';
+        Object.keys(NETWORK.TYPES).forEach(t => {
+            if (this.name.startsWith(t)) {
+                this.network = NETWORK.TYPES[t];
+                return;
+            }
+        });
         // default values for all methods
         this.firmwareRange = {
             '1': { min: '1.0.0', max: '0' },

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -77,8 +77,7 @@ export default class Device extends EventEmitter {
     internalState: string[] = [];
     externalState: string[] = [];
     unavailableCapabilities: { [key: string]: UnavailableCapability } = {};
-
-    currentNetworkType: ?string;
+    currentNetworkType: string[] = [];
 
     constructor(transport: Transport, descriptor: DeviceDescriptor) {
         super();
@@ -632,12 +631,24 @@ export default class Device extends EventEmitter {
         }
     }
 
+    _getCurrentNetworkType() {
+        return this.currentNetworkType[this.instance];
+    }
+
+    _setCurrentNetworkType(networkType: ?string) {
+        if (typeof networkType !== 'string') {
+            delete this.currentNetworkType[this.instance];
+        } else {
+            this.currentNetworkType[this.instance] = networkType;
+        }
+    }
+
     _altModeChange(networkType: ?string) {
-        const prevAltMode = this._isAltModeNetworkType(this.currentNetworkType);
+        const prevAltMode = this._isAltModeNetworkType(this._getCurrentNetworkType());
         const nextAltMode = this._isAltModeNetworkType(networkType);
 
         // Update network type
-        this.currentNetworkType = networkType;
+        this._setCurrentNetworkType(networkType);
 
         return prevAltMode !== nextAltMode;
     }

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -340,10 +340,10 @@ export default class Device extends EventEmitter {
         return this.externalState[this.instance];
     }
 
-    async validateState() {
+    async validateState(networkType: ?string) {
         if (!this.features) return;
         const expectedState = this.getExternalState();
-        const state = await this.commands.getDeviceState();
+        const state = await this.commands.getDeviceState(networkType);
         const uniqueState = `${state}@${this.features.device_id || 'device_id'}:${this.instance}`;
         if (!this.useLegacyPassphrase() && this.features.session_id) {
             this.setInternalState(this.features.session_id);

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -77,7 +77,7 @@ export default class Device extends EventEmitter {
     internalState: string[] = [];
     externalState: string[] = [];
     unavailableCapabilities: { [key: string]: UnavailableCapability } = {};
-    currentNetworkType: string[] = [];
+    networkTypeState: string[] = [];
 
     constructor(transport: Transport, descriptor: DeviceDescriptor) {
         super();
@@ -631,24 +631,24 @@ export default class Device extends EventEmitter {
         }
     }
 
-    _getCurrentNetworkType() {
-        return this.currentNetworkType[this.instance];
+    _getNetworkTypeState() {
+        return this.networkTypeState[this.instance];
     }
 
-    _setCurrentNetworkType(networkType: ?string) {
+    _setNetworkTypeState(networkType: ?string) {
         if (typeof networkType !== 'string') {
-            delete this.currentNetworkType[this.instance];
+            delete this.networkTypeState[this.instance];
         } else {
-            this.currentNetworkType[this.instance] = networkType;
+            this.networkTypeState[this.instance] = networkType;
         }
     }
 
     _altModeChange(networkType: ?string) {
-        const prevAltMode = this._isAltModeNetworkType(this._getCurrentNetworkType());
+        const prevAltMode = this._isAltModeNetworkType(this._getNetworkTypeState());
         const nextAltMode = this._isAltModeNetworkType(networkType);
 
         // Update network type
-        this._setCurrentNetworkType(networkType);
+        this._setNetworkTypeState(networkType);
 
         return prevAltMode !== nextAltMode;
     }

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -78,7 +78,6 @@ export default class Device extends EventEmitter {
     externalState: string[] = [];
     unavailableCapabilities: { [key: string]: UnavailableCapability } = {};
 
-    // Alternative state for Cardano support
     currentNetworkType: ?string;
 
     constructor(transport: Transport, descriptor: DeviceDescriptor) {
@@ -346,7 +345,6 @@ export default class Device extends EventEmitter {
     async validateState(networkType: ?string) {
         if (!this.features) return;
         const altMode = this._altModeChange(networkType);
-        console.log('altMode', altMode);
         const expectedState = altMode ? undefined : this.getExternalState();
         const state = await this.commands.getDeviceState(networkType);
         const uniqueState = `${state}@${this.features.device_id || 'device_id'}:${this.instance}`;

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -5,7 +5,7 @@ import randombytes from 'randombytes';
 
 import * as bitcoin from '@trezor/utxo-lib';
 import * as hdnodeUtils from '../utils/hdnode';
-import { isMultisigPath, isSegwitPath, isBech32Path, getSerializedPath, getScriptType } from '../utils/pathUtils';
+import { isMultisigPath, isSegwitPath, isBech32Path, getSerializedPath, getScriptType, toHardened } from '../utils/pathUtils';
 import { getAccountAddressN } from '../utils/accountUtils';
 import { toChecksumAddress } from '../utils/ethereumUtils';
 import { resolveAfter } from '../utils/promiseUtils';
@@ -771,19 +771,18 @@ export default class DeviceCommands {
 
     async _getAddressForNetworkType(networkType: ?string) {
         switch (networkType) {
-            case NETWORK.TYPES['cardano']:
+            case NETWORK.TYPES.cardano:
                 return await this.typedCall('CardanoGetAddress', 'CardanoAddress', {
                     address_parameters: {
-                        address_type: 0,
-                        address_n: [(1852 | 0x80000000) >>> 0, (1815 | 0x80000000) >>> 0, (4 | 0x80000000) >>> 0, 0, 0],
-                        address_n_staking: [(1852 | 0x80000000) >>> 0, (1815 | 0x80000000) >>> 0, (4 | 0x80000000) >>> 0, 2, 0],
+                        address_type: 8, // Byron
+                        address_n: [toHardened(44), toHardened(1815), toHardened(0), 0, 0],
                     },
                     protocol_magic: 42,
                     network_id: 0,
                 });
             default:
                 return await this.typedCall('GetAddress', 'Address', {
-                    address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 0, 0],
+                    address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
                     coin_name: 'Testnet',
                     script_type: 'SPENDADDRESS',
                 });

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -170,7 +170,7 @@ export namespace CARDANO {
     }
 }
 
-export namespace NETWORK {
+declare namespace NETWORK {
     enum TYPES {
         'bitcoin' = 'Bitcoin',
         'etherum' = 'Etherum',

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -169,3 +169,18 @@ export namespace CARDANO {
         StakeDelegation = 2,
     }
 }
+
+export namespace NETWORK {
+    enum TYPES {
+        'bitcoin' = 'Bitcoin',
+        'etherum' = 'Etherum',
+        'eos' = 'Eos',
+        'nem' = 'NEM',
+        'stellar' = 'Stellar',
+        'lisk' = 'Lisk',
+        'cardano' = 'Cardano',
+        'ripple' = 'Ripple',
+        'tezos' = 'Tezors',
+        'binance' = 'Binance',
+    }
+}

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -169,18 +169,3 @@ export namespace CARDANO {
         StakeDelegation = 2,
     }
 }
-
-declare namespace NETWORK {
-    enum TYPES {
-        'bitcoin' = 'Bitcoin',
-        'etherum' = 'Etherum',
-        'eos' = 'Eos',
-        'nem' = 'NEM',
-        'stellar' = 'Stellar',
-        'lisk' = 'Lisk',
-        'cardano' = 'Cardano',
-        'ripple' = 'Ripple',
-        'tezos' = 'Tezors',
-        'binance' = 'Binance',
-    }
-}


### PR DESCRIPTION
Added `network` property to `AbstractMethod` base class. Added network parameter to `getDeviceState` method in `DeviceCommands` class so it can send the right call to the device and prepare the correct seed derivation mechanism (thus preventing the second passphrase request).