### PR TITLE
fix T1 + bootloader < 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.1.13 (not released)
+
+### Fixed
+- initial `GetFeatures` message called on bootloader below 1.4.0
+
 # 8.1.12
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 8.1.13 (not released)
 
 ### Fixed
+- exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html)
 - initial `GetFeatures` message called on bootloader below 1.4.0
 
 # 8.1.12

--- a/src/js/core/methods/GetFeatures.js
+++ b/src/js/core/methods/GetFeatures.js
@@ -10,7 +10,7 @@ export default class GetFeatures extends AbstractMethod {
         super(message);
         this.requiredPermissions = [];
         this.useUi = false;
-        this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE];
+        this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.skipFirmwareCheck = true;
     }


### PR DESCRIPTION
T1 + bootloader < 1.4.0 doesn't know the "GetFeatures" message yet and it will send no response to it
transport response is pending endlessly, calling any other message will end up with "device call in progress"

set the timeout for this call so whenever it happens "unacquired device" will be created instead
next time device should be called together with "Initialize" message (by calling "acquireDevice" from the UI)