### PR TITLE
Fix/fee per unit xrp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 8.1.13 (not released)
 
 ### Fixed
-- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html).
+- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet or testnet, see: https://xrpl.org/parallel-networks.html).
 - Initial `GetFeatures` message called on bootloader below 1.4.0.
 - Cardano double passphrase prompt.
+- validation of `FeeLevel.feePerUnit` loaded from the backend (`blockchainEstimateFee` method).
 
 # 8.1.12
 

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -84,7 +84,10 @@ export default class Blockchain {
     async init() {
         this.link.on('connected', async () => {
             const info = await this.link.getInfo();
-            if (this.coinInfo.shortcut !== 'tXRP' && info.shortcut !== this.coinInfo.shortcut) {
+            // There is no `rippled` setting that defines which network it uses neither mainnet or testnet
+            // see: https://xrpl.org/parallel-networks.html
+            const shortcut = this.coinInfo.shortcut === 'tXRP' ? 'XRP' : this.coinInfo.shortcut;
+            if (info.shortcut.toLowerCase() !== shortcut.toLowerCase()) {
                 this.onError(ERRORS.TypedError('Backend_Invalid'));
                 return;
             }

--- a/src/js/data/CoinInfo.js
+++ b/src/js/data/CoinInfo.js
@@ -254,7 +254,7 @@ const parseEthereumNetworksJson = (json: JSON): void => {
         ethereumNetworks.push({
             type: 'ethereum',
             blockchainLink,
-            blocktime: Math.round(network.blocktime_seconds / 60),
+            blocktime: -1, // unknown
             chain: network.chain,
             chainId: network.chain_id,
             // key not used
@@ -284,19 +284,21 @@ const parseMiscNetworksJSON = (json: JSON, type?: 'misc' | 'nem') => {
     const networksObject: Object = json;
     Object.keys(networksObject).forEach(key => {
         const network = networksObject[key];
-        let minFee = 1;
-        let maxFee = 1;
+        let minFee = -1; // unknown
+        let maxFee = -1; // unknown
+        let defaultFees = {'Normal': -1}; // unknown
         const shortcut = network.shortcut.toLowerCase();
         if (shortcut === 'xrp' || shortcut === 'txrp') {
             minFee = 10;
             maxFee = 10000;
+            defaultFees = {'Normal': 12};
         }
         miscNetworks.push({
             type: type || 'misc',
             blockchainLink: network.blockchain_link,
-            blocktime: 0,
+            blocktime: -1,
             curve: network.curve,
-            defaultFees: {'Normal': 1},
+            defaultFees,
             minFee,
             maxFee,
             label: network.name,


### PR DESCRIPTION
- better backend validation: shortcut to lowecase + 'tXRP' as 'XRP'
- validate `feePerUnit` from the backend
- uknown blocktime value is -1