### PR TITLE
version 8.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 - Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet or testnet, see: https://xrpl.org/parallel-networks.html).
 - Initial `GetFeatures` message called on bootloader below 1.4.0.
 - Cardano double passphrase prompt.
-- validation of `FeeLevel.feePerUnit` loaded from the backend (`blockchainEstimateFee` method).
+- Validation of `FeeLevel.feePerUnit` loaded from the backend (`blockchainEstimateFee` method).
+- `showOnTrezor` parameter for `ethereumGetPublicKey`. 
+
+### Added
+- `showOnTrezor` parameter for `getPublicKey` method.
 
 # 8.1.12
 
@@ -15,7 +19,8 @@
 #### Fixed
 - `interactionTimeout` moved to a lower block in code.
 - `composeTransaction` filter `max = -1` field from the result.
-- skip device state verification on device management methods.
+- Skip device state verification on device management methods.
+
 #### Changed
 - Using `blockchainSetCustomBackend` method with an empty array of URLs will disable custom backends (reset to default).
 - Blockbook will verify that it is connecting to the right coin backend or it will throw an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 8.1.13 (not released)
 
 ### Fixed
-- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html).
+- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet or testnet, see: https://xrpl.org/parallel-networks.html).
 - Initial `GetFeatures` message called on bootloader below 1.4.0.
 - Cardano double passphrase prompt.
+- validation of `FeeLevel.feePerUnit` loaded from the backend (`blockchainEstimateFee` method).
 
 # 8.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # 8.1.13 (not released)
 
 ### Fixed
-- exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html)
-- initial `GetFeatures` message called on bootloader below 1.4.0
+- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html).
+- Initial `GetFeatures` message called on bootloader below 1.4.0.
+- Cardano double passphrase prompt.
 
 # 8.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.1.13 (not released)
+
+### Fixed
+- initial `GetFeatures` message called on bootloader below 1.4.0
+
 # 8.1.12
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Added
 - Public `getCoinInfo` method.
 - iframe errors (timeout/blocked) displayed in popup.
+
 #### Fixed
 - `interactionTimeout` moved to a lower block in code.
 - `composeTransaction` filter `max = -1` field from the result.
@@ -31,6 +32,7 @@
 
 #### Fixed
 - `composeTransaction` - remove unnecessary condition when using `send-max` outputs
+
 #### Added
 - `interactionTimeout` property to the initial settings. This will timeout users who stay inactive for a specified amount of time (in seconds).
 
@@ -41,6 +43,7 @@
 - `legacyXpub` field in response of `getAccountInfo` (BTC-like coins) used in `metadata` (labeling)
 - `n` field of `AccountTransaction:TransactionTarget` (output index) used in `metadata`
 - `branch_id` in signTx `TXMETA` (ZCash)
+
 #### Changed
 - Improved tests (trezor-user-env)
 
@@ -49,6 +52,7 @@
 #### Fixed
 - `composeTransaction` missing zcash specific fields (in popup mode)
 - `firmwareUpdate` default download url (data.trezor.io)
+
 #### Changed
 - Updated dependencies
 - Typed errors
@@ -58,8 +62,10 @@
 #### Fixed
 - `composeTransaction` sequence flag
 - Zcash `extra_data` field
+
 #### Added
 - Disconnect device during action timeout penalty (to allow u2f login)
+
 #### Changed
 - Refactor Bitcoin-like signing
 
@@ -68,6 +74,7 @@
 #### Fixed
 - `estimateFee` fee levels for `DGB`
 - `unavailableCapabilities` reload condition
+
 #### Added
 - `webextension` example
 
@@ -194,23 +201,21 @@
 - `blockchainGetTransactions` and `blockchainEstimateFee` methods
 - `composeTransaction` returns precomposed transaction for account
 
-#### Fixed
-- Removed unnecessary error wrapper (core.js)
-
 #### Removed
-- removed standalone `firmwareErase` and `firmwareUpload` methods.
+- Unnecessary error wrapper (core.js)
+- Standalone `firmwareErase` and `firmwareUpload` methods.
 
 # 8.0.5 (server side only)
 
 #### Fixed
-- fix `disconnect`-`method response` race condition
+- `disconnect`-`method response` race condition
 - `getAccountInfo` runtime error when using descriptor without path
 - Firmware releases channel (beta-wallet)
 
 # 8.0.4 (server side only)
 
 #### Added
-- Added `Unobtanium` support
+- Unobtanium support
 
 #### Fixed
 - `pendingTransport` race condition using lazyLoading and multiple devices connected
@@ -223,7 +228,7 @@
 # 8.0.3
 
 #### Added
-- Added `Binance Chain (BNB)` support
+- Binance Chain (BNB) support
 
 #### Fixed
 - `TrezorConnect.cancel` race condition between device release and returned response
@@ -235,7 +240,7 @@
 # 8.0.2
 
 #### Added
-- Added `Device.Features.features` field
+- `Device.Features.features` field
 
 #### Changed
 - `CoinInfo.blockchainLink` field generated from `coins.json:blockbook` for BTC-like and ETH-like
@@ -247,9 +252,9 @@
 # 8.0.1
 
 #### Added
-- Added `TrezorConnect.disableWebUSB` method
+- `TrezorConnect.disableWebUSB` method
 
-#### Fixed
+#### Changed
 - renamed EOS actions parameters 'buyram': quantity > quant, 'voteproducer': data.account > data.voter
 
 # 8.0.0
@@ -262,18 +267,18 @@
 - `TrezorConnect.getAccountInfo` parameters
 
 #### Added
-- Added nodejs support
-- Added `lazyLoad` parameter to `TrezorConnect.init`
-- Added bech32 accounts support
+- nodejs support
+- `lazyLoad` parameter to `TrezorConnect.init`
+- bech32 accounts support
 - Webextension usb permissions iframe dynamically included into html
-- Added correct `script_type` to `TransactionInput` and `TransactionOutput` of Bitcoin-like TxRequest protobuf message
-- Added signed transaction validation for Bitcoin `signTransaction` and `composeTransaction` methods
-- Added shamir recovery
+- correct `script_type` to `TransactionInput` and `TransactionOutput` of Bitcoin-like TxRequest protobuf message
+- signed transaction validation for Bitcoin `signTransaction` and `composeTransaction` methods
+- shamir recovery
 
 # 7.0.5
 
 #### Added
-- Added cloudfront cache invalidation
+- Cloudfront cache invalidation
 
 #### Fixed
 - Url encoding in `TrezorConnect.manifest`
@@ -281,10 +286,10 @@
 # 7.0.4
 
 #### Added
-- Added EOS methods `TrezorConnect.eosGetPublicKey` and `TrezorConnect.eosSignTransaction`
-- Added `TrezorConnect.firmwareUpdate` (management method)
-- Added new firmware releases
-- Added new bridge releases
+- EOS methods `TrezorConnect.eosGetPublicKey` and `TrezorConnect.eosSignTransaction`
+- `TrezorConnect.firmwareUpdate` (management method)
+- New firmware releases
+- New bridge releases
 
 #### Fixed
 - Dependencies security vulnerabilities
@@ -293,40 +298,40 @@
 # 7.0.3
 
 #### Added
-- Added management methods `applyFlags`, `applySettings`, `backupDevice`, `changePin`, `firmwareErase`, `firmwareUpload`, `recoveryDevice`
+- Management methods `applyFlags`, `applySettings`, `backupDevice`, `changePin`, `firmwareErase`, `firmwareUpload`, `recoveryDevice`
 
 # 7.0.2
 
 #### Added
-- Added missing params to `TrezorConnect.signTransaction` method [`version`, `expiry`, `overwintered`, `versionGroupId`, `branchId`, `refTxs`]
+- Missing params to `TrezorConnect.signTransaction` method [`version`, `expiry`, `overwintered`, `versionGroupId`, `branchId`, `refTxs`]
 - Possibility to use `TrezorConnect.signTransaction` without build-in backend (using `refTxs` field)
-- Added `TrezorConnect.getSettings` method
+- `TrezorConnect.getSettings` method
 
 #### Fixed
-- Fixed `Dash` and `Zcash` special transactions
+- Dash and Zcash special transactions
 - `EthereumGetAddress` address validation
 - Flowtype for `CardanoInput`
 
 # 7.0.1
 
 #### Added
-- Added `TrezorConnect.manifest` method
-- Added DebugLink (emulator) support: `TrezorConnect.debugLinkDecision` and `TrezorConnect.debugLinkGetState` methods
-- Added `TrezorConnect.ethereumGetPublicKey` method (with fallback for older firmware)
-- Added `TrezorConnect.loadDevice` method
-- Added `Capricoin` support (with required changes in `hd-wallet` and `bitcoinjs-lib-zcash` libs)
-- Added `firmwareRange` to every method (validation if device FW is in range: `min_required_firmware` - `max_compatible_firmware` declared in config.json)
-- Added conditional protobuf messages (fallback for older FW)
-- Added "device not backed up" confirmation
-- Added `blockchain-link` dependency
-- Added `TrezorConnect.rippleGetAccountInfo` method
-- Added `TrezorConnect.blockchainGetFee` method
-- Added `TrezorConnect.blockchainUnsubscribe` method
-- Added `BlockchainEvent` (connect/error/block/notification)
+- `TrezorConnect.manifest` method
+- DebugLink (emulator) support: `TrezorConnect.debugLinkDecision` and `TrezorConnect.debugLinkGetState` methods
+- `TrezorConnect.ethereumGetPublicKey` method (with fallback for older firmware)
+- `TrezorConnect.loadDevice` method
+- `Capricoin` support (with required changes in `hd-wallet` and `bitcoinjs-lib-zcash` libs)
+- `firmwareRange` to every method (validation if device FW is in range: `min_required_firmware` - `max_compatible_firmware` declared in config.json)
+- Conditional protobuf messages (fallback for older FW)
+- "device not backed up" confirmation
+- `blockchain-link` dependency
+- `TrezorConnect.rippleGetAccountInfo` method
+- `TrezorConnect.blockchainGetFee` method
+- `TrezorConnect.blockchainUnsubscribe` method
+- `BlockchainEvent` (connect/error/block/notification)
 
 #### Changed
 - Upgrade npm modules (babel@7)
-- Changed `network` for `protocol_magic` in `TrezorConnect.cardanoSignTransaction` method
+- `network` for `protocol_magic` in `TrezorConnect.cardanoSignTransaction` method
 
 #### Fixed
 - ComposeTransaction: fees/legacy detection
@@ -357,13 +362,13 @@
 # 6.0.3
 
 #### Added
-- Added `TrezorConnect.tezosGetAddress` method
-- Added `TrezorConnect.tezosGetPublicKey` method
-- Added `TrezorConnect.tezosSignTransaction` method
-- Added `TrezorConnect.dispose` method
-- Added `TrezorConnect.cancel` method
-- Added new firmware releases
-- Added new bridge releases
+- `TrezorConnect.tezosGetAddress` method
+- `TrezorConnect.tezosGetPublicKey` method
+- `TrezorConnect.tezosSignTransaction` method
+- `TrezorConnect.dispose` method
+- `TrezorConnect.cancel` method
+- new firmware releases
+- new bridge releases
 
 #### Changed
 - Whitelist `trusted` mode for instances hosted locally
@@ -377,11 +382,11 @@
 # 6.0.2
 
 #### Added
-- Added `TrezorConnect.wipeDevice` method
-- Added `TrezorConnect.resetDevice` method
-- Calling method on device with seedless setup is disabled by default
+- `TrezorConnect.wipeDevice` method
+- `TrezorConnect.resetDevice` method
 
 #### Changed
+- Calling method on device with seedless setup is disabled by default
 - Post message to window.parent instead of window.top
 - Authenticating device using BTC testnet path instead of dummy m/1/0/0
 
@@ -398,13 +403,13 @@
 # 6.0.0
 
 #### Added
-- Added `TrezorConnect.pushTransaction` method with ethereum blockbook support
-- Added `TrezorConnect.ethereumGetAccountInfo` method
-- Added `TrezorConnect.blockchainSubscribe` method
-- Added `TrezorConnect.blockchainDisconnect` method
-- Added `BLOCKCHAIN` events
-- Added `./data/bridge/releases.json`
-- Added bridge release info in TRANSPORT.START and TRANSPORT.ERROR event
+- `TrezorConnect.pushTransaction` method with ethereum blockbook support
+- `TrezorConnect.ethereumGetAccountInfo` method
+- `TrezorConnect.blockchainSubscribe` method
+- `TrezorConnect.blockchainDisconnect` method
+- `BLOCKCHAIN` events
+- `./data/bridge/releases.json`
+- Bridge release info in TRANSPORT.START and TRANSPORT.ERROR event
 
 #### Fixed
 - TRANSPORT.ERROR event when computer goes to sleep
@@ -428,7 +433,7 @@
 # 5.0.32
 
 #### Added
-- Added `TrezorConnect.cardanoGetPublicKey` method
+- `TrezorConnect.cardanoGetPublicKey` method
 - Ability to sign hexed ethereum message
 - `network` parameter to `TrezorConnect.cardanoSignTransaction` method
 
@@ -438,8 +443,8 @@
 - proper FW version for Lisk and Stellar
 
 #### Removed
-- Removed `TrezorConnect.cardanoSignMessage` method
-- Removed `TrezorConnect.cardanoVerifyMessage` method
+- `TrezorConnect.cardanoSignMessage` method
+- `TrezorConnect.cardanoVerifyMessage` method
 
 # 5.0.31
 
@@ -449,11 +454,10 @@
 - Support for Lisk
 - Exception for not supported firmware when value for "trezor1" or "trezor2" inside coins.json is not set
 - Disable customMessage method for devices with official firmware
-- Added new field in `TrezorConnect.signEthereumTransaction` for `Wanchain`
+- New field in `TrezorConnect.signEthereumTransaction` for `Wanchain`
 
 #### Changed
 - Separate "getPublicKey" and "getAddress" methods for all coins
-
 
 #### Fixed
 - Device state verification while using multiple instances with the same passphrase
@@ -463,7 +467,7 @@
 # 5.0.30
 
 #### Added
-- Added 'send-max' and 'opreturn' output types to `TrezorConnect.composeTransaction`
+- 'send-max' and 'opreturn' output types to `TrezorConnect.composeTransaction`
 
 #### Fixed
 - Handle popup close event while waiting for iframe handshake
@@ -476,28 +480,32 @@
 # 5.0.29
 
 #### Fixed
-- Fixed flowtype for TrezorConnect methods (bundled methods return bundled results)
-- Fixed renderWebUSBButton method
-- Removed "babel-polyfill" from npm and export unminified script https://connect.trezor.io/5/trezor-connect.js
-- Added https://connect.trezor.io/5/trezor-connect.min.js to export with bundled "babel-polyfill"
+- flowtype for TrezorConnect methods (bundled methods return bundled results)
+- renderWebUSBButton method
+
+#### Removed
+- "babel-polyfill" from npm and export unminified script https://connect.trezor.io/5/trezor-connect.js
+
+#### Changed
+- https://connect.trezor.io/5/trezor-connect.min.js to export with bundled "babel-polyfill"
 - Web extensions: open popup tab next to currently used tab
 
 # 5.0.28
 
 #### Added
-- Added support for WebExtensions (Chrome/Firefox)
-- Added host icon for whitelisted domains
+- Support for WebExtensions (Chrome/Firefox)
+- Host icon for whitelisted domains
 
 #### Fixed
-- Fixed passphrase input type (revert to password type)
-- Fixed popup and iframe timeout handling
+- Passphrase input type (revert to password type)
+- Popup and iframe timeout handling
 
 # 5.0.27
 
 #### Fixed
-- Fixed handling not initialized iframe
-- Fixed iframe ad-blocker handling
-- Fixed popup views
+- Handling not initialized iframe
+- Iframe ad-blocker handling
+- Popup views
 
 #### Changed
 - Popup as new tab
@@ -505,10 +513,10 @@
 # 5.0.26
 
 #### Added
-- Added support for Dogecoin and Vertcoin
+- Support for Dogecoin and Vertcoin
 
 #### Fixed
-- Fixed handling not initialized device
+- Handling not initialized device
 - SignTransaction: amount as string
 - Handle origin of file://
 
@@ -518,14 +526,14 @@
 # 5.0.25
 
 #### Added
-- Added documentation
+- Documentation
 
 #### Fixed
 - filter UI events for popup and trusted apps
-- Fixed `TrezorConnect.signMessage` and `TrezorConnect.verifyMessage` signature to base64 format
+- `TrezorConnect.signMessage` and `TrezorConnect.verifyMessage` signature to base64 format
 
 #### Changed
-- Changed constants prefix from `__` to `-`
+- constants prefix from `__` to `-`
 
 # 5.0.24
 
@@ -544,20 +552,20 @@
 # 5.0.21
 
 #### Added
-- Added `TrezorConnect.pushTransaction` method
-- Added bundle parameters in `TrezorConnect.cipherKeyValue` method
-- Added bundle parameters in `TrezorConnect.getPublicKey` method
-- Added bundle parameters in `TrezorConnect.getAddress` method
-- Added bundle parameters in `TrezorConnect.ethereumGetAddress` method
-- Added bundle parameters in `TrezorConnect.nemGetAddress` method
-- Added bundle parameters in `TrezorConnect.stellarGetAddress` method
-- Added type conversion from stellar-sdk to protobuf in `TrezorConnect.stellarSignTransaction` method
+- `TrezorConnect.pushTransaction` method
+- bundle parameters in `TrezorConnect.cipherKeyValue` method
+- bundle parameters in `TrezorConnect.getPublicKey` method
+- bundle parameters in `TrezorConnect.getAddress` method
+- bundle parameters in `TrezorConnect.ethereumGetAddress` method
+- bundle parameters in `TrezorConnect.nemGetAddress` method
+- bundle parameters in `TrezorConnect.stellarGetAddress` method
+- type conversion from stellar-sdk to protobuf in `TrezorConnect.stellarSignTransaction` method
 - Popup warning with outdated firmware and outdated bridge
 - Tests with emulator
-- Added '@babel/runtime' to package dependency
+- '@babel/runtime' to package dependency
 
 #### Fixed
-- Fixed device authentication and popup open delay
+- Device authentication and popup open delay
 - Minor fixes in popup view
 - Ethereum methods accepts values with '0x' prefix
 - Ethereum methods returns checksummed addresses (with different checksum typ for RSK network)
@@ -566,19 +574,18 @@
 # 5.0.20
 
 #### Added
-- Added firmware check against CoinInfo.support values
-- Added outdate firmware warning in popup
+- Firmware check against CoinInfo.support values
+- Outdate firmware warning in popup
 
 #### Fixed
-- Fixed `TrezorConnect.requestLogin` parameters
-- Fixed race condition in `UI.REQUEST_CONFIRMATION`
-- Fixed popup.html buttons click
+- `TrezorConnect.requestLogin` parameters
+- Race condition in `UI.REQUEST_CONFIRMATION`
+- `popup.html` buttons click
 
 # 5.0.18
 
 #### Added
-- Added iframe lazy loading
-
+- iframe lazy loading
 
 #### Fixed
 - Build script for npm module
@@ -589,35 +596,35 @@
 # 5.0.17
 
 #### Added
-- Added `TrezorConnect.getAccountInfo` method
-- Added `TrezorConnect.signTransaction` method
-- Added `TrezorConnect.composeTransaction` method
-- Added `TrezorConnect.signMessage` method
-- Added `TrezorConnect.verifyMessage` method
-- Added `TrezorConnect.getAddress` method
-- Added `TrezorConnect.requestLogin` method
-- Added cashaddr support for BCH
-- Added documentation
+- `TrezorConnect.getAccountInfo` method
+- `TrezorConnect.signTransaction` method
+- `TrezorConnect.composeTransaction` method
+- `TrezorConnect.signMessage` method
+- `TrezorConnect.verifyMessage` method
+- `TrezorConnect.getAddress` method
+- `TrezorConnect.requestLogin` method
+- cashaddr support for BCH
+- documentation
 
 #### Fixed
-- Fixed `TrezorConnect.customMessage` logic and security
-- Fixed `TrezorConnect.stellarSignTransaction` parameters compatible with "js-stellar-base"
-- Fixed flowtype declarations for all methods. Params and responses
+- `TrezorConnect.customMessage` logic and security
+- `TrezorConnect.stellarSignTransaction` parameters compatible with "js-stellar-base"
+- flowtype declarations for all methods. Params and responses
 
 #### Removed
-- Removed unnecessary settings from ConnectSettings
-- Removed unused methods from TrezorConnect
+- unnecessary settings from ConnectSettings
+- unused methods from TrezorConnect
 
 # 5.0.16
 
 #### Added
-- Added `TrezorConnect.stellarSignTransaction` method
+- `TrezorConnect.stellarSignTransaction` method
 
 #### Changed
-- Changed `TrezorConnect.ethereumSignTransaction` parameters
+- `TrezorConnect.ethereumSignTransaction` parameters
 
 #### Removed
-- Removed type and event fields from RESPONSE
+- type and event fields from RESPONSE
 
 # 5.0.15
 
@@ -627,23 +634,23 @@
 # 5.0.14
 
 #### Added
-- Added `TrezorConnect.nemGetAddress` method
-- Added `TrezorConnect.nemSignTransaction` method
-- Added `TrezorConnect.stellarGetAddress` method
-- Added `TrezorConnect.customMessage` method
+- `TrezorConnect.nemGetAddress` method
+- `TrezorConnect.nemSignTransaction` method
+- `TrezorConnect.stellarGetAddress` method
+- `TrezorConnect.customMessage` method
 
 #### Fixed
-- Fixed flowtype
+- flowtype
 
 # 5.0.13
 
 #### Added
-- Added messages from json instead of `config_signed.bin`
-- Added popup.html UI/css
+- messages from json instead of `config_signed.bin`
+- popup.html UI/css
 - Karma + Jasmine tests
 
 #### Removed
-- Removed support for Bridge v1 and chrome extension
+- support for Bridge v1 and chrome extension
 
 # 5.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 8.1.13 (not released)
 
 ### Fixed
+- exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet/testnet, see: https://xrpl.org/parallel-networks.html)
 - initial `GetFeatures` message called on bootloader below 1.4.0
 
 # 8.1.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 8.1.13 (not released)
+# 8.1.13
 
 ### Fixed
 - Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet or testnet, see: https://xrpl.org/parallel-networks.html).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trezor Connect API version 8.1.12
+# Trezor Connect API version 8.1.13
 [![Build Status](https://travis-ci.org/trezor/connect.png?branch=develop)](https://travis-ci.org/trezor/connect)
 [![NPM](https://img.shields.io/npm/v/trezor-connect.svg)](https://www.npmjs.org/package/trezor-connect)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/connect?targetFile=package.json)

--- a/docs/methods/signTransaction.md
+++ b/docs/methods/signTransaction.md
@@ -21,9 +21,9 @@ TrezorConnect.signTransaction(params).then(function(result) {
 [****Optional common params****](commonParams.md)
 ###### [flowtype](../../src/js/types/params.js#L169-L164)
 * `coin` - *obligatory* `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
-* `inputs` - *obligatory* `Array` of [TransactionInput](../../src/js/types/protobuf.js#L100-L108),
-* `outputs` - *obligatory* `Array` of [TransactionOutput](../../src/js/types/protobuf.js#113-L131),
-* `refTxs` - *optional* `Array` of [RefTransaction](../../src/js/types/protobuf.js#L139-L144). If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format. Since Firmware 2.3.0/1.9.0 referenced transactions are required. Zcash and Komodo refTxs should also contains `expiry`, `version_group_id` and `extra_data` fields.
+* `inputs` - *obligatory* `Array` of [TransactionInput](../../src/js/types/trezor/protobuf.js#L100-L108),
+* `outputs` - *obligatory* `Array` of [TransactionOutput](../../src/js/types/trezor/protobuf.js#L113-L131),
+* `refTxs` - *optional* `Array` of [RefTransaction](../../src/js/types/trezor/protobuf.js#L139-L144). If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format. Since Firmware 2.3.0/1.9.0 referenced transactions are required. Zcash and Komodo refTxs should also contains `expiry`, `version_group_id` and `extra_data` fields.
 * `locktime` - *optional* `number`,
 * `version` - *optional* `number` transaction version,
 * `expiry` - *optional* `number`, only for Decred and Zcash,

--- a/docs/methods/signTransaction.md
+++ b/docs/methods/signTransaction.md
@@ -21,9 +21,9 @@ TrezorConnect.signTransaction(params).then(function(result) {
 [****Optional common params****](commonParams.md)
 ###### [flowtype](../../src/js/types/params.js#L169-L164)
 * `coin` - *obligatory* `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
-* `inputs` - *obligatory* `Array` of [TransactionInput](../../src/js/types/params.js#L137-L148),
-* `outputs` - *obligatory* `Array` of [TransactionOutput](../../src/js/types/params.js#L150-L162),
-* `refTxs` - *optional* `Array` of [RefTransaction](../../src/js/types/trezor.js#L148-L157). If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format. Since Firmware 2.3.0/1.9.0 referenced transactions are required. Zcash and Komodo refTxs should also contains `expiry`, `version_group_id` and `extra_data` fields.
+* `inputs` - *obligatory* `Array` of [TransactionInput](../../src/js/types/protobuf.js#L100-L108),
+* `outputs` - *obligatory* `Array` of [TransactionOutput](../../src/js/types/protobuf.js#113-L131),
+* `refTxs` - *optional* `Array` of [RefTransaction](../../src/js/types/protobuf.js#L139-L144). If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format. Since Firmware 2.3.0/1.9.0 referenced transactions are required. Zcash and Komodo refTxs should also contains `expiry`, `version_group_id` and `extra_data` fields.
 * `locktime` - *optional* `number`,
 * `version` - *optional* `number` transaction version,
 * `expiry` - *optional* `number`, only for Decred and Zcash,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-connect",
-    "version": "8.1.12",
+    "version": "8.1.13",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -84,7 +84,10 @@ export default class Blockchain {
     async init() {
         this.link.on('connected', async () => {
             const info = await this.link.getInfo();
-            if (this.coinInfo.shortcut !== 'tXRP' && info.shortcut !== this.coinInfo.shortcut) {
+            // There is no `rippled` setting that defines which network it uses neither mainnet or testnet
+            // see: https://xrpl.org/parallel-networks.html
+            const shortcut = this.coinInfo.shortcut === 'tXRP' ? 'XRP' : this.coinInfo.shortcut;
+            if (info.shortcut.toLowerCase() !== shortcut.toLowerCase()) {
                 this.onError(ERRORS.TypedError('Backend_Invalid'));
                 return;
             }

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -84,7 +84,7 @@ export default class Blockchain {
     async init() {
         this.link.on('connected', async () => {
             const info = await this.link.getInfo();
-            if (info.name !== this.coinInfo.name) {
+            if (this.coinInfo.shortcut !== 'tXRP' && info.shortcut !== this.coinInfo.shortcut) {
                 this.onError(ERRORS.TypedError('Backend_Invalid'));
                 return;
             }

--- a/src/js/constants/index.js
+++ b/src/js/constants/index.js
@@ -3,6 +3,7 @@ import * as BLOCKCHAIN from './blockchain';
 import * as DEVICE from './device';
 import * as ERRORS from './errors';
 import * as IFRAME from './iframe';
+import * as NETWORK from './network';
 import * as POPUP from './popup';
 import * as TRANSPORT from './transport';
 import * as UI from './ui';
@@ -20,6 +21,7 @@ export {
     DEVICE,
     ERRORS,
     IFRAME,
+    NETWORK,
     POPUP,
     TRANSPORT,
     UI,

--- a/src/js/constants/network.js
+++ b/src/js/constants/network.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+export const TYPES = Object.freeze({
+    'bitcoin': 'Bitcoin',
+    'ethereum': 'Ethereum',
+    'eos': 'Eos',
+    'nem': 'NEM',
+    'stellar': 'Stellar',
+    'lisk': 'Lisk',
+    'cardano': 'Cardano',
+    'ripple': 'Ripple',
+    'tezos': 'Tezors',
+    'binance': 'Binance',
+});

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -496,7 +496,7 @@ export const onCall = async (message: CoreMessage) => {
 
             // Make sure that device will display pin/passphrase
             try {
-                const invalidDeviceState = method.useDeviceState ? await device.validateState() : undefined;
+                const invalidDeviceState = method.useDeviceState ? await device.validateState(method.network) : undefined;
                 if (invalidDeviceState) {
                     if (isUsingPopup) {
                         // initialize user response promise

--- a/src/js/core/methods/AbstractMethod.js
+++ b/src/js/core/methods/AbstractMethod.js
@@ -2,7 +2,7 @@
 
 import Device from '../../device/Device';
 import DataManager from '../../data/DataManager';
-import { UI, DEVICE, ERRORS } from '../../constants';
+import { UI, DEVICE, ERRORS, NETWORK } from '../../constants';
 import { load as loadStorage, save as saveStorage, PERMISSIONS_KEY } from '../../storage';
 import { versionCompare } from '../../utils/versionUtils';
 
@@ -39,6 +39,7 @@ export default class AbstractMethod implements MethodInterface {
     allowDeviceMode: Array<string>; // used in device management (like ResetDevice allow !UI.INITIALIZED)
     requireDeviceMode: Array<string>;
     debugLink: boolean;
+    network: string;
 
     +confirmation: () => Promise<boolean>;
     +noBackupConfirmation: () => Promise<boolean>;
@@ -74,6 +75,14 @@ export default class AbstractMethod implements MethodInterface {
             this.allowDeviceMode = [ UI.SEEDLESS ];
         }
         this.debugLink = false;
+        // Determine the type based on the method name
+        this.network = 'Bitcoin';
+        Object.keys(NETWORK.TYPES).forEach(t => {
+            if (this.name.startsWith(t)) {
+                this.network = NETWORK.TYPES[t];
+                return;
+            }
+        });
         // default values for all methods
         this.firmwareRange = {
             '1': { min: '1.0.0', max: '0' },

--- a/src/js/core/methods/GetFeatures.js
+++ b/src/js/core/methods/GetFeatures.js
@@ -10,7 +10,7 @@ export default class GetFeatures extends AbstractMethod {
         super(message);
         this.requiredPermissions = [];
         this.useUi = false;
-        this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE];
+        this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.skipFirmwareCheck = true;
     }

--- a/src/js/core/methods/GetPublicKey.js
+++ b/src/js/core/methods/GetPublicKey.js
@@ -15,6 +15,7 @@ import type { CoreMessage, UiPromiseResponse, BitcoinNetworkInfo } from '../../t
 type Batch = {
     path: Array<number>;
     coinInfo: ?BitcoinNetworkInfo;
+    showOnTrezor: boolean;
 }
 type Params = Array<Batch>;
 
@@ -45,6 +46,7 @@ export default class GetPublicKey extends AbstractMethod {
                 { name: 'path', obligatory: true },
                 { name: 'coin', type: 'string' },
                 { name: 'crossChain', type: 'boolean' },
+                { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
             let coinInfo: ?BitcoinNetworkInfo;
@@ -59,9 +61,16 @@ export default class GetPublicKey extends AbstractMethod {
             } else if (!coinInfo) {
                 coinInfo = getBitcoinNetwork(path);
             }
+
+            let showOnTrezor: boolean = false;
+            if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
+                showOnTrezor = batch.showOnTrezor;
+            }
+
             bundle.push({
                 path,
                 coinInfo,
+                showOnTrezor,
             });
 
             // set required firmware from coinInfo support
@@ -105,7 +114,9 @@ export default class GetPublicKey extends AbstractMethod {
             const batch: Batch = this.params[i];
             const response: HDNodeResponse = await this.device.getCommands().getHDNode(
                 batch.path,
-                batch.coinInfo
+                batch.coinInfo,
+                true,
+                batch.showOnTrezor
             );
             responses.push(response);
 

--- a/src/js/data/CoinInfo.js
+++ b/src/js/data/CoinInfo.js
@@ -254,7 +254,7 @@ const parseEthereumNetworksJson = (json: JSON): void => {
         ethereumNetworks.push({
             type: 'ethereum',
             blockchainLink,
-            blocktime: Math.round(network.blocktime_seconds / 60),
+            blocktime: -1, // unknown
             chain: network.chain,
             chainId: network.chain_id,
             // key not used
@@ -284,19 +284,21 @@ const parseMiscNetworksJSON = (json: JSON, type?: 'misc' | 'nem') => {
     const networksObject: Object = json;
     Object.keys(networksObject).forEach(key => {
         const network = networksObject[key];
-        let minFee = 1;
-        let maxFee = 1;
+        let minFee = -1; // unknown
+        let maxFee = -1; // unknown
+        let defaultFees = {'Normal': -1}; // unknown
         const shortcut = network.shortcut.toLowerCase();
         if (shortcut === 'xrp' || shortcut === 'txrp') {
             minFee = 10;
             maxFee = 10000;
+            defaultFees = {'Normal': 12};
         }
         miscNetworks.push({
             type: type || 'misc',
             blockchainLink: network.blockchain_link,
-            blocktime: 0,
+            blocktime: -1,
             curve: network.curve,
-            defaultFees: {'Normal': 1},
+            defaultFees,
             minFee,
             maxFee,
             label: network.name,

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -10,7 +10,7 @@ import type {
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION = '8.1.12';
+const VERSION = '8.1.13';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -106,11 +106,13 @@ export default class DeviceCommands {
         address_n: Array<number>,
         coin_name: string,
         script_type?: ?string,
+        show_display?: ?boolean,
     ): Promise<trezor.PublicKey> {
         const response: MessageResponse<trezor.PublicKey> = await this.typedCall('GetPublicKey', 'PublicKey', {
             address_n,
             coin_name,
             script_type,
+            show_display,
         });
         return response.message;
     }
@@ -120,6 +122,7 @@ export default class DeviceCommands {
         path: Array<number>,
         coinInfo: ?BitcoinNetworkInfo,
         validation?: boolean = true,
+        showOnTrezor?: boolean = false,
     ): Promise<trezor.HDNodeResponse> {
         if (!this.device.atLeast(['1.7.2', '2.0.10']) || !coinInfo) {
             return await this.getBitcoinHDNode(path, coinInfo);
@@ -143,8 +146,8 @@ export default class DeviceCommands {
         }
 
         let publicKey: trezor.PublicKey;
-        if (!validation) {
-            publicKey = await this.getPublicKey(path, coinInfo.name, scriptType);
+        if (showOnTrezor || !validation) {
+            publicKey = await this.getPublicKey(path, coinInfo.name, scriptType, showOnTrezor);
         } else {
             const suffix: number = 0;
             const childPath: Array<number> = path.concat([suffix]);
@@ -179,7 +182,7 @@ export default class DeviceCommands {
     async getBitcoinHDNode(
         path: Array<number>,
         coinInfo?: ?BitcoinNetworkInfo,
-        validation?: boolean = true,
+        validation?: boolean = true
     ): Promise<trezor.HDNodeResponse> {
         let publicKey: trezor.PublicKey;
         if (!validation) {
@@ -302,7 +305,7 @@ export default class DeviceCommands {
         const childPath: Array<number> = address_n.concat([suffix]);
         const resKey: MessageResponse<trezor.PublicKey> = await this.typedCall('EthereumGetPublicKey', 'EthereumPublicKey', {
             address_n: address_n,
-            show_display: false,
+            show_display: showOnTrezor,
         });
         const childKey: MessageResponse<trezor.PublicKey> = await this.typedCall('EthereumGetPublicKey', 'EthereumPublicKey', {
             address_n: childPath,

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import { DEVICE, ERRORS } from '../constants';
+import { DEVICE, ERRORS, NETWORK } from '../constants';
 import randombytes from 'randombytes';
 
 import * as bitcoin from '@trezor/utxo-lib';
 import * as hdnodeUtils from '../utils/hdnode';
-import { isMultisigPath, isSegwitPath, isBech32Path, getSerializedPath, getScriptType } from '../utils/pathUtils';
+import { isMultisigPath, isSegwitPath, isBech32Path, getSerializedPath, getScriptType, toHardened } from '../utils/pathUtils';
 import { getAccountAddressN } from '../utils/accountUtils';
 import { toChecksumAddress } from '../utils/ethereumUtils';
 import { resolveAfter } from '../utils/promiseUtils';
@@ -562,12 +562,8 @@ export default class DeviceCommands {
         return await this.typedCall('ClearSession', 'Success', settings);
     }
 
-    async getDeviceState() {
-        const response = await this.typedCall('GetAddress', 'Address', {
-            address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 0, 0],
-            coin_name: 'Testnet',
-            script_type: 'SPENDADDRESS',
-        });
+    async getDeviceState(networkType: ?string) {
+        const response = await this._getAddressForNetworkType(networkType);
         // bitcoin.crypto.hash256(Buffer.from(secret, 'binary')).toString('hex');
         const state: string = response.message.address;
         return state;
@@ -771,6 +767,26 @@ export default class DeviceCommands {
         }
 
         return Promise.resolve(res);
+    }
+
+    async _getAddressForNetworkType(networkType: ?string) {
+        switch (networkType) {
+            case NETWORK.TYPES.cardano:
+                return await this.typedCall('CardanoGetAddress', 'CardanoAddress', {
+                    address_parameters: {
+                        address_type: 8, // Byron
+                        address_n: [toHardened(44), toHardened(1815), toHardened(0), 0, 0],
+                    },
+                    protocol_magic: 42,
+                    network_id: 0,
+                });
+            default:
+                return await this.typedCall('GetAddress', 'Address', {
+                    address_n: [toHardened(44), toHardened(1), toHardened(0), 0, 0],
+                    coin_name: 'Testnet',
+                    script_type: 'SPENDADDRESS',
+                });
+        }
     }
 
     _promptPin(type: string): Promise<string> {

--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '8.1.12';
+const VERSION = '8.1.13';
 const versionN = VERSION.split('.').map(s => parseInt(s));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;


### PR DESCRIPTION
### Fixed
- Exclude `tXRP` from backend verification (There is no rippled setting that defines which network it uses neither mainnet or testnet, see: https://xrpl.org/parallel-networks.html).
- Initial `GetFeatures` message called on bootloader below 1.4.0.
- Cardano double passphrase prompt.
- Validation of `FeeLevel.feePerUnit` loaded from the backend (`blockchainEstimateFee` method).
- `showOnTrezor` parameter for `ethereumGetPublicKey`. 

### Added
- `showOnTrezor` parameter for `getPublicKey` method.