### PR TITLE
fix: remove timestamp from iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.1.15 (unreleased)
+
+### Changed
+- Removed timestamp from iframe URL.
+
 # 8.1.14
 
 ### Changed

--- a/src/js/iframe/builder.js
+++ b/src/js/iframe/builder.js
@@ -39,8 +39,8 @@ export const init = async (settings: ConnectSettings): Promise<void> => {
         const manifestString = settings.manifest
             ? JSON.stringify(settings.manifest)
             : 'undefined'; // note: btoa(undefined) === btoa('undefined') === "dW5kZWZpbmVk"
-        const manifest = `&version=${settings.version}&manifest=${encodeURIComponent(btoa(JSON.stringify(manifestString)))}`;
-        src = `${settings.iframeSrc}?${ Date.now() }${ manifest }`;
+        const manifest = `version=${settings.version}&manifest=${encodeURIComponent(btoa(JSON.stringify(manifestString)))}`;
+        src = `${settings.iframeSrc}?${ manifest }`;
     } else {
         src = settings.iframeSrc;
     }


### PR DESCRIPTION
Removes the timestamp from the iframe loading because it causes issue with keeping the iframe in cache (used for offline support) . The version number should be enough for cache busting.