### PR TITLE
Add missing protocol magic validation to cardanoGetAddress

### DIFF
--- a/src/js/core/methods/CardanoGetAddress.js
+++ b/src/js/core/methods/CardanoGetAddress.js
@@ -55,6 +55,7 @@ export default class CardanoGetAddress extends AbstractMethod {
             validateParams(batch, [
                 { name: 'addressParameters', type: 'object', obligatory: true },
                 { name: 'networkId', type: 'number', obligatory: true },
+                { name: 'protocolMagic', type: 'number', obligatory: true },
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 


### PR DESCRIPTION
Problem: `cardanoGetAddress` call was not actually validating the presence of the `protocolMagic` paramater even though the documentation stated that it's an obligatory parameter: https://github.com/trezor/connect/blob/develop/docs/methods/cardanoGetAddress.md#exporting-single-address

As the protocol magic is used internally to evaluate which network is the call meant for and this PR: https://github.com/trezor/trezor-firmware/pull/1274 is introducing a check for its consistency with network id, integrations with trezor-connect that forgot to pass the protocol magic will stop working as Trezor will fail on the networkId <-> protocolMagic consistency check

Changes:
* Add check for presence of protocol magic in the cardanoGetAddress parameters validation logic

Testing:
* tested end-to-end with Adalite and works as expected (throws an error if protocolMagic is missing)