### PR TITLE
types(features): add features.backup_type field

### DIFF
--- a/src/js/types/trezor/device.js
+++ b/src/js/types/trezor/device.js
@@ -84,6 +84,7 @@ export type Features = {
     session_id?: string;
     passphrase_always_on_device?: boolean;
     capabilities?: string[];
+    backup_type?: 'Bip39' | 'Slip39_Basic' | 'Slip39_Advanced' | null;
 }
 
 export type KnownDevice = {|

--- a/src/ts/types/trezor/device.d.ts
+++ b/src/ts/types/trezor/device.d.ts
@@ -64,6 +64,7 @@ export interface Features {
     session_id?: string;
     passphrase_always_on_device?: boolean;
     capabilities?: string[];
+    backup_type?: 'Bip39' | 'Slip39_Basic' | 'Slip39_Advanced' | null;
 }
 
 export type KnownDevice = {


### PR DESCRIPTION
backup_type on features has been around for a while but has not been typed yet. 

If firmware sends this in features, then it has values. Tested with 2.3.1.
`'Bip39' | 'Slip39_Basic' | 'Slip39_Advanced'`

1.9.1 returns `null`


And the last part I am not sure about is making it optional. I'd say, that if older definitions get loaded, this field would be undefined but I haven't tested it yet.
