### PR TITLE
fix: add support for BCHN

### DIFF
--- a/src/js/data/CoinInfo.js
+++ b/src/js/data/CoinInfo.js
@@ -107,6 +107,9 @@ const detectBtcVersion = (data) => {
     if (data.subversion.startsWith('/Bitcoin ABC')) {
         return 'bch';
     }
+    if (data.subversion.startsWith('/Bitcoin Cash')) {
+        return 'bch';
+    }
     if (data.subversion.startsWith('/Bitcoin Gold')) {
         return 'btg';
     }


### PR DESCRIPTION
BCHN uses `Bitcoin Cash Node` as their subversion