### PR TITLE
fix: compose transaction with P2PKH accounts fee/tx size

### DIFF
--- a/src/js/core/methods/ComposeTransaction.js
+++ b/src/js/core/methods/ComposeTransaction.js
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import AbstractMethod from './AbstractMethod';
 import Discovery from './helpers/Discovery';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
-import { validatePath } from '../../utils/pathUtils';
+import * as pathUtils from '../../utils/pathUtils';
 import { resolveAfter } from '../../utils/promiseUtils';
 
 import { UI, ERRORS } from '../../constants';
@@ -117,12 +117,14 @@ export default class ComposeTransaction extends AbstractMethod {
 
     async precompose(account: $ElementType<PrecomposeParams, 'account'>, feeLevels: $ElementType<PrecomposeParams, 'feeLevels'>): Promise<PrecomposedTransaction[]> {
         const { coinInfo, outputs, baseFee } = this.params;
+        const address_n = pathUtils.validatePath(account.path);
+        const segwit = pathUtils.isSegwitPath(address_n) || pathUtils.isBech32Path(address_n);
         const composer = new TransactionComposer({
             account: {
-                type: 'normal',
-                label: 'normal',
-                descriptor: 'normal',
-                address_n: validatePath(account.path),
+                type: segwit ? 'normal' : 'legacy',
+                label: 'Account',
+                descriptor: account.path,
+                address_n,
                 addresses: account.addresses,
             },
             utxo: account.utxo,

--- a/src/js/core/methods/tx/TransactionComposer.js
+++ b/src/js/core/methods/tx/TransactionComposer.js
@@ -165,7 +165,7 @@ export default class TransactionComposer {
             outputs: this.outputs,
             height: this.blockHeight,
             feeRate,
-            segwit: coinInfo.segwit,
+            segwit: coinInfo.segwit && account.type !== 'legacy',
             inputAmounts: true, // since 2.3.4 every utxo needs to have "amount" field
             basePath: account.address_n,
             network: coinInfo.network,


### PR DESCRIPTION
turns out p2pkh (legacy) accounts in suite fees was incorrect (lower) because of this hardcoded account type