### PR TITLE
Feat/protobuf types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ sync-%:
 protobuf:
 	make -C ./submodules/trezor-common/protob combine
 	./node_modules/.bin/proto2js ./submodules/trezor-common/protob/combined.proto > ./src/data/messages/messagesN.json
+	node ./scripts/protobuf-types.js
+	node ./scripts/protobuf-types.js typescript
 
 # Build coin definitions
 coins:

--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -1,0 +1,333 @@
+
+// type rule fixes, ideally it should not be here
+const RULE_PATCH = {
+    'BinanceAddress.address': 'required',
+    'BinancePublicKey.public_key': 'required',
+    'BinanceSignedTx.signature': 'required',
+    'BinanceSignedTx.public_key': 'required',
+    'MultisigRedeemScriptType.nodes': 'optional', // its valid to be undefined according to implementation/tests
+    'MultisigRedeemScriptType.address_n': 'optional', // its valid to be undefined according to implementation/tests
+    'PublicKey.node': 'required',
+    'PublicKey.xpub': 'required',
+    'MessageSignature.address': 'required',
+    'MessageSignature.signature': 'required',
+    'TxRequestDetailsType.request_index': 'required',
+    'TxRequest.request_type': 'required',
+    'TxRequest.details': 'required',
+    'CardanoBlockchainPointerType.block_index': 'required',
+    'CardanoBlockchainPointerType.tx_index': 'required',
+    'CardanoBlockchainPointerType.certificate_index': 'required',
+    'CardanoAddressParametersType.address_type': 'required',
+    'CardanoGetAddress.protocol_magic': 'required',
+    'CardanoGetAddress.network_id': 'required',
+    'CardanoGetAddress.address_parameters': 'required',
+    'CardanoAddress.address': 'required',
+    'CardanoPublicKey.xpub': 'required',
+    'CardanoPublicKey.node': 'required',
+    'CardanoSignedTx.tx_hash': 'required',
+    'CardanoSignedTx.serialized_tx': 'required',
+    'Success.message': 'required',
+    'HDNodeType.public_key': 'required',
+    'SignedIdentity.address': 'required',
+    'SignedIdentity.public_key': 'required',
+    'SignedIdentity.signature': 'required',
+    'EosPublicKey.wif_public_key': 'required',
+    'EosPublicKey.raw_public_key': 'required',
+    'EosAuthorizationKey.key': 'required',
+    'EosAuthorizationKey.address_n': 'optional', // its valid to be undefined according to implementation/tests
+    'EosAuthorizationKey.weight': 'required',
+    'EosActionUnknown.data_size': 'required',
+    'EosSignedTx.signature': 'required',
+    'EthereumPublicKey.node': 'required',
+    'EthereumPublicKey.xpub': 'required',
+    'EthereumAddress.address': 'required',
+    'EthereumMessageSignature.signature': 'required',
+    'EthereumMessageSignature.address': 'required',
+    'LiskAddress.address': 'required',
+    'LiskPublicKey.public_key': 'required',
+    'LiskSignTx.transaction': 'required',
+    'LiskSignedTx.signature': 'required',
+    'LiskSignMessage.message': 'required',
+    'LiskMessageSignature.public_key': 'required',
+    'LiskMessageSignature.signature': 'required',
+    'Features.major_version': 'required',
+    'Features.minor_version': 'required',
+    'Features.patch_version': 'required',
+    'Features.model': 'required',
+    'NEMSignedTx.data': 'required',
+    'NEMSignedTx.signature': 'required',
+    'NEMTransactionCommon.address_n': 'optional', // no address_n in multisig
+    'NEMTransfer.mosaics': 'optional', // its valid to be undefined according to implementation/tests
+    'NEMMosaicDefinition.networks': 'optional', // never used according to implementation/tests
+    'NEMAggregateModification.modifications': 'optional', // its valid to be undefined according to implementation/tests
+    'RippleAddress.address': 'required',
+    'RipplePayment.amount': 'required',
+    'RippleSignedTx.signature': 'required',
+    'RippleSignedTx.serialized_tx': 'required',
+    'StellarAssetType.type': 'required',
+    'StellarAssetType.code': 'required',
+    'StellarAddress.address': 'required',
+    'StellarPathPaymentOp.paths': 'optional', // its valid to be undefined according to implementation/tests
+    'StellarSignedTx.public_key': 'required',
+    'StellarSignedTx.signature': 'required',
+    'TezosAddress.address': 'required',
+    'TezosPublicKey.public_key': 'required',
+    'TezosContractID.tag': 'required',
+    'TezosContractID.hash': 'required',
+    'TezosRevealOp.source': 'required',
+    'TezosRevealOp.fee': 'required',
+    'TezosRevealOp.counter': 'required',
+    'TezosRevealOp.gas_limit': 'required',
+    'TezosRevealOp.storage_limit': 'required',
+    'TezosRevealOp.public_key': 'required',
+    'TezosTransactionOp.source': 'required',
+    'TezosTransactionOp.fee': 'required',
+    'TezosTransactionOp.counter': 'required',
+    'TezosTransactionOp.gas_limit': 'required',
+    'TezosTransactionOp.storage_limit': 'required',
+    'TezosTransactionOp.amount': 'required',
+    'TezosTransactionOp.destination': 'required',
+    'TezosOriginationOp.source': 'required',
+    'TezosOriginationOp.fee': 'required',
+    'TezosOriginationOp.counter': 'required',
+    'TezosOriginationOp.gas_limit': 'required',
+    'TezosOriginationOp.storage_limit': 'required',
+    'TezosOriginationOp.balance': 'required',
+    'TezosOriginationOp.script': 'required',
+    'TezosDelegationOp.source': 'required',
+    'TezosDelegationOp.fee': 'required',
+    'TezosDelegationOp.counter': 'required',
+    'TezosDelegationOp.gas_limit': 'required',
+    'TezosDelegationOp.storage_limit': 'required',
+    'TezosDelegationOp.delegate': 'required',
+    'TezosSignTx.branch': 'required',
+    'TezosSignedTx.signature': 'required',
+    'TezosSignedTx.sig_op_contents': 'required',
+    'TezosSignedTx.operation_hash': 'required',
+};
+
+// custom types IN to trezor
+// protobuf lib will handle the translation to required type
+// connect or other 3rd party libs are using compatible types (string as number etc...)
+const TYPE_PATCH = {
+    'Features.bootloader_mode': 'boolean | null',
+    'Features.device_id': 'string | null',
+    'Features.label': 'string | null',
+    'Features.bootloader_hash': 'string | null',
+    'Features.firmware_present': 'boolean | null',
+    'Features.fw_major': 'number | null',
+    'Features.fw_minor': 'number | null',
+    'Features.fw_patch': 'number | null',
+    'Features.fw_vendor': 'string | null',
+    'HDNodePathType.node': 'HDNodeType | string',
+    'TxInputType.amount': 'number | string',
+    'TxOutputBinType.amount': 'number | string',
+    'FirmwareUpload.payload': 'Buffer',
+    'CardanoSignTx.fee': 'string | number',
+    'CardanoSignTx.ttl': 'string | number',
+    'EosAsset.amount': 'string',
+    'EosAsset.symbol': 'string',
+    'EosPermissionLevel.actor': 'string',
+    'EosPermissionLevel.permission': 'string',
+    'EosAuthorizationKey.key': 'string',
+    'EosActionCommon.account': 'string',
+    'EosActionCommon.name': 'string',
+    'EosActionTransfer.sender': 'string',
+    'EosActionTransfer.receiver': 'string',
+    'EosActionDelegate.sender': 'string',
+    'EosActionDelegate.receiver': 'string',
+    'EosActionUndelegate.sender': 'string',
+    'EosActionUndelegate.receiver': 'string',
+    'EosActionRefund.owner': 'string',
+    'EosActionBuyRam.payer': 'string',
+    'EosActionBuyRam.receiver': 'string',
+    'EosActionBuyRamBytes.payer': 'string',
+    'EosActionBuyRamBytes.receiver': 'string',
+    'EosActionSellRam.account': 'string',
+    'EosActionVoteProducer.voter': 'string',
+    'EosActionVoteProducer.proxy': 'string',
+    'EosActionVoteProducer.producers': 'string',
+    'EosActionUpdateAuth.account': 'string',
+    'EosActionUpdateAuth.permission': 'string',
+    'EosActionUpdateAuth.parent': 'string',
+    'EosActionDeleteAuth.account': 'string',
+    'EosActionDeleteAuth.permission': 'string',
+    'EosActionLinkAuth.account': 'string',
+    'EosActionLinkAuth.code': 'string',
+    'EosActionLinkAuth.type': 'string',
+    'EosActionLinkAuth.requirement': 'string',
+    'EosActionUnlinkAuth.account': 'string',
+    'EosActionUnlinkAuth.code': 'string',
+    'EosActionUnlinkAuth.type': 'string',
+    'EosActionNewAccount.creator': 'string',
+    'EosActionNewAccount.name': 'string',
+    'NEMTransfer.amount': 'string | number',
+    'RipplePayment.amount': 'string | number',
+    'RippleSignTx.fee': 'string | number',
+    'StellarAssetType.type': '0 | 1 | 2',
+    'StellarSignTx.sequence_number': 'string | number',
+    'StellarSignTx.memo_id': 'string',
+    'StellarSignTx.memo_hash': 'Buffer | string',
+    'StellarPaymentOp.amount': 'string | number',
+    'StellarCreateAccountOp.starting_balance': 'string | number',
+    'StellarPathPaymentOp.send_max': 'string | number',
+    'StellarPathPaymentOp.destination_amount': 'string | number',
+    'StellarManageOfferOp.amount': 'string | number',
+    'StellarManageOfferOp.offer_id': 'string | number',
+    'StellarCreatePassiveOfferOp.amount': 'string | number',
+    'StellarSetOptionsOp.master_weight': 'string | number',
+    'StellarSetOptionsOp.low_threshold': 'string | number',
+    'StellarSetOptionsOp.medium_threshold': 'string | number',
+    'StellarSetOptionsOp.high_threshold': 'string | number',
+    'StellarSetOptionsOp.signer_key': 'Buffer | string',
+    'StellarChangeTrustOp.limit': 'string | number',
+    'StellarManageDataOp.value': 'Buffer | string',
+    'StellarBumpSequenceOp.bump_to': 'string | number',
+    'TezosContractID.tag': 'number',
+    'TezosContractID.hash': 'Uint8Array',
+    'TezosRevealOp.source': 'Uint8Array',
+    'TezosRevealOp.public_key': 'Uint8Array',
+    'TezosParametersManager.set_delegate': 'Uint8Array',
+    'TezosTransactionOp.source': 'Uint8Array',
+    'TezosTransactionOp.parameters': 'number[]',
+    'TezosOriginationOp.source': 'Uint8Array',
+    'TezosOriginationOp.delegate': 'Uint8Array',
+    'TezosOriginationOp.script': 'string | number[]',
+    'TezosDelegationOp.source': 'Uint8Array',
+    'TezosDelegationOp.delegate': 'Uint8Array',
+    'TezosSignTx.branch': 'Uint8Array',
+};
+
+const DEFINITION_PATCH = {
+    TxOutputType:
+`// - replacement
+export type TxOutputType = {|
+    address: string;
+    address_n?: typeof undefined;
+    script_type: 'PAYTOADDRESS';
+    amount: string;
+    multisig?: MultisigRedeemScriptType;
+|} | {|
+    address?: typeof undefined;
+    address_n: number[];
+    script_type: OutputScriptType;
+    amount: string;
+    multisig?: MultisigRedeemScriptType;
+|} | {|
+    address?: typeof undefined;
+    address_n?: typeof undefined;
+    amount: '0';
+    op_return_data: string;
+    script_type: 'PAYTOOPRETURN';
+|};
+// - replacement end
+`,
+    TxAck:
+`// - replacement
+export type RefTxInputType = {|
+    prev_hash: string;
+    prev_index: number;
+    script_sig: string;
+    sequence: number;
+|};
+
+export type TxAckResponse = {|
+    inputs: Array<TxInputType | RefTxInputType>;
+|} | {|
+    bin_outputs: TxOutputBinType[];
+|} | {|
+    outputs: TxOutputType[];
+|} | {|
+    extra_data: string;
+|} | {|
+    version?: number;
+    lock_time?: number;
+    inputs_cnt: number;
+    outputs_cnt: number;
+    extra_data?: string;
+    extra_data_len?: number;
+    timestamp?: number;
+    version_group_id?: number;
+    expiry?: number;
+    branch_id?: number;
+|};
+
+export type TxAck = {
+    tx: TxAckResponse;
+};
+// - replacement end
+`,
+};
+
+// skip unnecessary types
+const SKIP = [
+    'MessageType', // connect uses custom definition
+    'TransactionType', // connect uses custom definition
+    // not implemented
+    'CosiCommit',
+    'CosiCommitment',
+    'CosiSign',
+    'CosiSignature',
+    'MoneroRctKeyPublic',
+    'MoneroOutputEntry',
+    'MoneroMultisigKLRki',
+    'MoneroTransactionSourceEntry',
+    'MoneroAccountPublicAddress',
+    'MoneroTransactionDestinationEntry',
+    'MoneroTransactionRsigData',
+    'MoneroGetAddress',
+    'MoneroAddress',
+    'MoneroGetWatchKey',
+    'MoneroWatchKey',
+    'MoneroTransactionData',
+    'MoneroTransactionInitRequest',
+    'MoneroTransactionInitAck',
+    'MoneroTransactionSetInputRequest',
+    'MoneroTransactionSetInputAck',
+    'MoneroTransactionInputsPermutationRequest',
+    'MoneroTransactionInputsPermutationAck',
+    'MoneroTransactionInputViniRequest',
+    'MoneroTransactionInputViniAck',
+    'MoneroTransactionAllInputsSetRequest',
+    'MoneroTransactionAllInputsSetAck',
+    'MoneroTransactionSetOutputRequest',
+    'MoneroTransactionSetOutputAck',
+    'MoneroTransactionAllOutSetRequest',
+    'MoneroRingCtSig',
+    'MoneroTransactionAllOutSetAck',
+    'MoneroTransactionSignInputRequest',
+    'MoneroTransactionSignInputAck',
+    'MoneroTransactionFinalRequest',
+    'MoneroTransactionFinalAck',
+    'MoneroSubAddressIndicesList',
+    'MoneroKeyImageExportInitRequest',
+    'MoneroKeyImageExportInitAck',
+    'MoneroTransferDetails',
+    'MoneroKeyImageSyncStepRequest',
+    'MoneroExportedKeyImage',
+    'MoneroKeyImageSyncStepAck',
+    'MoneroKeyImageSyncFinalRequest',
+    'MoneroKeyImageSyncFinalAck',
+    'MoneroGetTxKeyRequest',
+    'MoneroGetTxKeyAck',
+    'MoneroLiveRefreshStartRequest',
+    'MoneroLiveRefreshStartAck',
+    'MoneroLiveRefreshStepRequest',
+    'MoneroLiveRefreshStepAck',
+    'MoneroLiveRefreshFinalRequest',
+    'MoneroLiveRefreshFinalAck',
+    'DebugMoneroDiagRequest',
+    'DebugMoneroDiagAck',
+    'WebAuthnListResidentCredentials',
+    'WebAuthnAddResidentCredential',
+    'WebAuthnRemoveResidentCredential',
+    'WebAuthnCredential',
+    'WebAuthnCredentials',
+];
+
+module.exports = {
+    RULE_PATCH,
+    TYPE_PATCH,
+    DEFINITION_PATCH,
+    SKIP,
+};

--- a/scripts/protobuf-types.js
+++ b/scripts/protobuf-types.js
@@ -1,0 +1,213 @@
+// flowtype only
+// flowtype doesn't have `enum` declarations like typescript
+
+const fs = require('fs');
+const { RULE_PATCH, TYPE_PATCH, DEFINITION_PATCH, SKIP } = require('./protobuf-patches');
+const json = require('../src/data/messages/messages.json');
+const args = process.argv.slice(2);
+
+const isTypescript = args.includes('typescript');
+
+// proto types to javascript types
+const FIELD_TYPES = {
+    'uint32': 'number',
+    'uint64': 'number',
+    'sint32': 'number',
+    'sint64': 'number',
+    'bool': 'boolean',
+    'bytes': 'string',
+    // 'bytes': 'Uint8Array | number[] | Buffer | string', // protobuf will handle conversion
+};
+
+const types = []; // { type: 'enum | message', name: string, value: string[], exact?: boolean };
+
+// enums used as keys (string), used as values (number) by default
+const ENUM_KEYS = ['InputScriptType', 'OutputScriptType', 'RequestType', 'BackupType', 'Capability'];
+
+const parseEnumTypescript = item => {
+    const value = [];
+    const IS_KEY = ENUM_KEYS.includes(item.name);
+    // declare enum
+    if (IS_KEY) {
+        value.push('export enum Enum_' + item.name + ' {');
+    } else {
+        value.push('export enum ' + item.name + ' {');
+    }
+
+    // declare fields
+    item.values.forEach(field => {
+        value.push('    ' + field.name + ' = ' + field.id + ',');
+    });
+    // close enum declaration
+    value.push('}');
+
+    if (IS_KEY) {
+        value.push('export type ' + item.name + ' = keyof typeof Enum_' + item.name + ';');
+    }
+    // empty line
+    value.push('');
+
+    types.push({
+        type: 'enum',
+        name: item.name,
+        value: value.join('\n'),
+    });
+};
+
+const parseEnum = item => {
+    if (isTypescript) return parseEnumTypescript(item);
+    const value = [];
+    // declare enum
+    value.push('const Enum_' + item.name + ' = Object.freeze({');
+    // declare fields
+    item.values.forEach(field => {
+        value.push('    ' + field.name + ': ' + field.id + ',');
+    });
+    // close enum declaration
+    value.push('});');
+    // declare enum type using Keys or Values
+    const KEY = ENUM_KEYS.includes(item.name) ? 'Keys' : 'Values';
+    value.push('export type ' + item.name + ' = $' + KEY + '<typeof Enum_' + item.name + '>;');
+    // empty line
+    value.push('');
+
+    types.push({
+        type: 'enum',
+        name: item.name,
+        value: value.join('\n'),
+    });
+};
+
+const parseMessage = (message, depth = 0) => {
+    if (!message.name) return;
+
+    const value = [];
+    // add comment line
+    if (!depth) value.push('// ' + message.name);
+    // declare nested enums
+    if (message.enums) {
+        message.enums.forEach(e => parseEnum(e));
+    }
+    // declare nested values
+    if (message.messages) {
+        message.messages.forEach(item => parseMessage(item, depth + 1));
+    }
+    if (!message.fields.length) {
+        // few types are just empty objects, make it one line
+        value.push('export type ' + message.name + ' = {};');
+        value.push('');
+    } else {
+        // find patch
+        const definition = DEFINITION_PATCH[message.name];
+        if (definition) {
+            // replace whole declaration
+            if (isTypescript) {
+                // replace flowtype exact declaration {| ...type |} to typescript { ...type }
+                value.push(definition.replace(/{\|/gi, '{').replace(/\|}/gi, '}'));
+            } else {
+                value.push(definition);
+            }
+        } else {
+            // declare type
+            value.push('export type ' + message.name + ' = {');
+            message.fields.forEach(field => {
+                const fieldKey = message.name + '.' + field.name;
+                // find patch for "rule"
+                const fieldRule = RULE_PATCH[fieldKey] || field.rule;
+                const rule = fieldRule === 'optional' ? '?: ' : ': ';
+                // find patch for "type"
+                let type = TYPE_PATCH[fieldKey] || FIELD_TYPES[field.type] || field.type;
+                // array
+                if (field.rule === 'repeated') {
+                    type = type.split('|').length > 1 ? 'Array<' + type + '>' : type + '[]';
+                }
+                value.push('    ' + field.name + rule + type + ';');
+            });
+            // close type declaration
+            value.push('};');
+            // empty line
+            value.push('');
+        }
+    }
+    // type doest have to be e
+    const exact = message.fields.find(f => f.rule === 'required');
+    types.push({
+        type: 'message',
+        name: message.name,
+        value: value.join('\n'),
+        exact,
+    });
+};
+
+// top level enums
+json.enums.map(e => parseEnum(e));
+// top level messages and nested messages
+json.messages.map(e => parseMessage(e));
+
+// types needs reordering (used before defined)
+const ORDER = {
+    'BinanceCoin': 'BinanceInputOutput',
+    'HDNodeType': 'HDNodePathType',
+};
+Object.keys(ORDER).forEach(key => {
+    // find indexes
+    const indexA = types.findIndex(t => t && t.name === key);
+    const indexB = types.findIndex(t => t && t.name === ORDER[key]);
+    const prevA = types[indexA];
+    // replace values
+    delete types[indexA];
+    types.splice(indexB, 0, prevA);
+});
+
+// skip not needed types
+SKIP.forEach(key => {
+    const index = types.findIndex(t => t && t.name === key);
+    delete types[index];
+});
+
+// create content from types
+const content = types.flatMap(t => t ? [t.value] : []).join('\n');
+
+const lines = []; // string[]
+if (!isTypescript) lines.push('// @flow');
+lines.push('// This file is auto generated from data/messages/message.json');
+lines.push(content);
+
+// create custom definition
+if (!isTypescript) {
+    lines.push('// custom connect definitions');
+    lines.push('export type MessageType = {');
+    types.flatMap(t => t && t.type === 'message' ? [t] : []).forEach(t => {
+        if (t.exact) {
+            lines.push('    ' + t.name + ': $Exact<' + t.name + '>;');
+        } else {
+            lines.push('    ' + t.name + ': ' + t.name + ';');
+        }
+        // lines.push('    ' + t.name + ': $Exact<' + t.name + '>;');
+    });
+    lines.push('};');
+
+    // additional types utilities
+    lines.push(`
+export type MessageKey = $Keys<MessageType>;
+
+export type MessageResponse<T: MessageKey> = {
+    type: T;
+    message: $ElementType<MessageType, T>;
+};
+
+export type TypedCall = <T: MessageKey, R: MessageKey>(
+    type: T,
+    resType: R,
+    message?: $ElementType<MessageType, T>
+) => Promise<MessageResponse<R>>;
+`);
+}
+
+// save to file
+const filePath = isTypescript ? 'src/ts/types/trezor/protobuf.d.ts' : 'src/js/types/trezor/protobuf.js';
+fs.writeFile(filePath, lines.join('\n'), function (err) {
+    // eslint-disable-next-line no-console
+    if (err) return console.log(err);
+});
+

--- a/src/__tests__/core/stellarSignTransaction.spec.js
+++ b/src/__tests__/core/stellarSignTransaction.spec.js
@@ -467,7 +467,6 @@ const manageData = () => {
                     {
                         type: 'manageData',
                         name: 'data',
-                        value: null,
                     },
                 ],
             },

--- a/src/js/core/methods/ApplyFlags.js
+++ b/src/js/core/methods/ApplyFlags.js
@@ -6,21 +6,17 @@ import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
 import type { CoreMessage } from '../../types';
-
-type Params = {
-    flags: number;
-}
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class ApplyFlags extends AbstractMethod {
-    params: Params;
-    run: () => Promise<any>;
+    params: $ElementType<MessageType, 'ApplyFlags'>;
 
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         validateParams(payload, [
             { name: 'flags', type: 'number', obligatory: true },
@@ -52,7 +48,9 @@ export default class ApplyFlags extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async run(): Promise<Object> {
-        return await this.device.getCommands().applyFlags(this.params);
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('ApplyFlags', 'Success', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/ApplySettings.js
+++ b/src/js/core/methods/ApplySettings.js
@@ -6,24 +6,16 @@ import { validateParams } from './helpers/paramsValidator';
 import { UiMessage } from '../../message/builder';
 
 import type { CoreMessage } from '../../types';
-
-type Params = {
-    language?: string;
-    label?: string;
-    use_passphrase?: boolean;
-    homescreen?: string;
-    passphrase_source?: number;
-    auto_lock_delay_ms?: number;
-}
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class ApplySettings extends AbstractMethod {
-    params: Params;
-    run: () => Promise<any>;
+    params: $ElementType<MessageType, 'ApplySettings'>;
+
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         validateParams(payload, [
             { name: 'language', type: 'string' },
@@ -31,8 +23,10 @@ export default class ApplySettings extends AbstractMethod {
             { name: 'use_passphrase', type: 'boolean' },
             { name: 'homescreen', type: 'string' },
             { name: 'passphrase_source', type: 'number' },
+            { name: 'passphrase_always_on_device', type: 'boolean' },
             { name: 'auto_lock_delay_ms', type: 'number' },
             { name: 'display_rotation', type: 'number' },
+            { name: 'safety_checks', type: 'number' },
         ]);
 
         this.params = {
@@ -41,8 +35,10 @@ export default class ApplySettings extends AbstractMethod {
             use_passphrase: payload.use_passphrase,
             homescreen: payload.homescreen,
             passphrase_source: payload.passphrase_source,
+            passphrase_always_on_device: payload.passphrase_always_on_device,
             auto_lock_delay_ms: payload.auto_lock_delay_ms,
             display_rotation: payload.display_rotation,
+            safety_checks: payload.safety_checks,
         };
     }
 
@@ -67,7 +63,9 @@ export default class ApplySettings extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async run(): Promise<Object> {
-        return await this.device.getCommands().applySettings(this.params);
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('ApplySettings', 'Success', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/BackupDevice.js
+++ b/src/js/core/methods/BackupDevice.js
@@ -34,7 +34,9 @@ export default class BackupDevice extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async run(): Promise<Object> {
-        return await this.device.getCommands().backupDevice();
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('BackupDevice', 'Success');
+        return response.message;
     }
 }

--- a/src/js/core/methods/BinanceGetAddress.js
+++ b/src/js/core/methods/BinanceGetAddress.js
@@ -8,22 +8,20 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage, UiPromiseResponse } from '../../types';
+import type { CoreMessage } from '../../types';
 import type { BinanceAddress } from '../../types/networks/binance';
+import type { MessageType } from '../../types/trezor/protobuf';
 
-type Batch = {
-    path: Array<number>;
-    address: ?string;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+type Params = {
+    ...$ElementType<MessageType, 'BinanceGetAddress'>,
+    address?: string;
+};
 
 export default class BinanceGetAddress extends AbstractMethod {
-    confirmed: boolean = false;
-    params: Params;
+    params: Params[] = [];
     hasBundle: boolean;
     progress: number = 0;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -33,7 +31,7 @@ export default class BinanceGetAddress extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -41,7 +39,6 @@ export default class BinanceGetAddress extends AbstractMethod {
             { name: 'useEventListener', type: 'boolean' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -50,27 +47,26 @@ export default class BinanceGetAddress extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
+            this.params.push({
+                address_n: path,
                 address: batch.address,
-                showOnTrezor,
+                show_display: showOnTrezor,
             });
         });
 
-        const useEventListener = payload.useEventListener && bundle.length === 1 && typeof bundle[0].address === 'string' && bundle[0].showOnTrezor;
+        const useEventListener = payload.useEventListener && this.params.length === 1 && typeof this.params[0].address === 'string' && this.params[0].show_display;
         this.confirmed = useEventListener;
         this.useUi = !useEventListener;
-        this.params = bundle;
 
         // set info
-        if (bundle.length === 1) {
-            this.info = `Export Binance address for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+        if (this.params.length === 1) {
+            this.info = `Export Binance address for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         } else {
             this.info = 'Export multiple Binance addresses';
         }
@@ -80,7 +76,7 @@ export default class BinanceGetAddress extends AbstractMethod {
         if (code === 'ButtonRequest_Address') {
             const data = {
                 type: 'address',
-                serializedPath: getSerializedPath(this.params[this.progress].path),
+                serializedPath: getSerializedPath(this.params[this.progress].address_n),
                 address: this.params[this.progress].address || 'not-set',
             };
             return data;
@@ -95,15 +91,14 @@ export default class BinanceGetAddress extends AbstractMethod {
         // initialize user response promise
         const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION, this.device);
 
-        const label: string = this.info;
         // request confirmation view
         this.postMessage(UiMessage(UI.REQUEST_CONFIRMATION, {
             view: 'export-address',
-            label,
+            label: this.info,
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
@@ -121,22 +116,33 @@ export default class BinanceGetAddress extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
         return uiResp.payload;
     }
 
-    async run(): Promise<BinanceAddress | Array<BinanceAddress>> {
-        const responses: Array<BinanceAddress> = [];
+    async _call({
+        address_n,
+        show_display,
+    }: Params) {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('BinanceGetAddress', 'BinanceAddress', {
+            address_n,
+            show_display,
+        });
+        return response.message;
+    }
 
+    async run() {
+        const responses: BinanceAddress[] = [];
         for (let i = 0; i < this.params.length; i++) {
-            const batch: Batch = this.params[i];
+            const batch = this.params[i];
             // silently get address and compare with requested address
             // or display as default inside popup
-            if (batch.showOnTrezor) {
-                const silent = await this.device.getCommands().binanceGetAddress(
-                    batch.path,
-                    false
-                );
+            if (batch.show_display) {
+                const silent = await this._call({
+                    ...batch,
+                    show_display: false,
+                });
                 if (typeof batch.address === 'string') {
                     if (batch.address !== silent.address) {
                         throw ERRORS.TypedError('Method_AddressNotMatch');
@@ -146,13 +152,10 @@ export default class BinanceGetAddress extends AbstractMethod {
                 }
             }
 
-            const response = await this.device.getCommands().binanceGetAddress(
-                batch.path,
-                batch.showOnTrezor
-            );
+            const response = await this._call(batch);
             responses.push({
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
             });
 

--- a/src/js/core/methods/BinanceGetPublicKey.js
+++ b/src/js/core/methods/BinanceGetPublicKey.js
@@ -8,21 +8,14 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { BinancePublicKey } from '../../types/trezor/protobuf';
-import type { BinancePublicKey as BinancePublicKeyResponse } from '../../types/networks/binance';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
-
-type Batch = {
-    path: Array<number>;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+import type { BinancePublicKey } from '../../types/networks/binance';
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class BinanceGetPublicKey extends AbstractMethod {
-    params: Params;
+    params: $ElementType<MessageType, 'BinanceGetPublicKey'>[] = [];
     hasBundle: boolean;
-    confirmed: boolean = false;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -33,14 +26,13 @@ export default class BinanceGetPublicKey extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
             { name: 'bundle', type: 'array' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -48,19 +40,17 @@ export default class BinanceGetPublicKey extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
-                showOnTrezor,
+            this.params.push({
+                address_n: path,
+                show_display: showOnTrezor,
             });
         });
-
-        this.params = bundle;
     }
 
     async confirmation(): Promise<boolean> {
@@ -74,7 +64,7 @@ export default class BinanceGetPublicKey extends AbstractMethod {
         if (this.params.length > 1) {
             label = 'Export multiple Binance public keys';
         } else {
-            label = `Export Binance public key for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+            label = `Export Binance public key for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         }
 
         // request confirmation view
@@ -84,31 +74,29 @@ export default class BinanceGetPublicKey extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
     }
 
-    async run(): Promise<BinancePublicKeyResponse | Array<BinancePublicKeyResponse>> {
-        const responses: Array<BinancePublicKeyResponse> = [];
+    async run() {
+        const responses: BinancePublicKey[] = [];
+        const cmd = this.device.getCommands();
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
-            const response: BinancePublicKey = await this.device.getCommands().binanceGetPublicKey(
-                batch.path,
-                batch.showOnTrezor
-            );
+            const { message } = await cmd.typedCall('BinanceGetPublicKey', 'BinancePublicKey', batch);
             responses.push({
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
-                publicKey: response.public_key,
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
+                publicKey: message.public_key,
             });
 
             if (this.hasBundle) {
                 // send progress
                 this.postMessage(UiMessage(UI.BUNDLE_PROGRESS, {
                     progress: i,
-                    response,
+                    response: message,
                 }));
             }
         }

--- a/src/js/core/methods/BinanceSignTransaction.js
+++ b/src/js/core/methods/BinanceSignTransaction.js
@@ -7,12 +7,7 @@ import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/binanceSignTx';
 
 import type { CoreMessage } from '../../types';
-import type {
-    BinanceSignedTx,
-} from '../../types/trezor/protobuf';
-import type {
-    BinancePreparedTransaction,
-} from '../../types/networks/binance';
+import type { BinancePreparedTransaction } from '../../types/networks/binance';
 
 type Params = {
     path: number[];
@@ -28,7 +23,7 @@ export default class BinanceSignTransaction extends AbstractMethod {
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
         this.info = 'Sign Binance transaction';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', type: 'string', obligatory: true },
@@ -44,7 +39,7 @@ export default class BinanceSignTransaction extends AbstractMethod {
         };
     }
 
-    async run(): Promise<BinanceSignedTx> {
+    async run() {
         return helper.signTx(
             this.device.getCommands().typedCall.bind(this.device.getCommands()),
             this.params.path,

--- a/src/js/core/methods/ChangePin.js
+++ b/src/js/core/methods/ChangePin.js
@@ -1,23 +1,20 @@
 /* @flow */
 
 import AbstractMethod from './AbstractMethod';
-import type { CoreMessage } from '../../types';
 import { validateParams } from './helpers/paramsValidator';
-
-type Params = {
-    remove?: boolean;
-}
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class ChangePin extends AbstractMethod {
-    params: Params;
-    run: () => Promise<any>;
+    params: $ElementType<MessageType, 'ChangePin'>;
 
     constructor(message: CoreMessage) {
         super(message);
+
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 
-        const payload: Object = message.payload;
+        const { payload } = message;
         validateParams(payload, [
             { name: 'remove', type: 'boolean' },
         ]);
@@ -27,7 +24,9 @@ export default class ChangePin extends AbstractMethod {
         };
     }
 
-    async run(): Promise<Object> {
-        return await this.device.getCommands().changePin(this.params);
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('ChangePin', 'Success', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/CustomMessage.js
+++ b/src/js/core/methods/CustomMessage.js
@@ -15,14 +15,13 @@ type Params = {
 
 export default class CustomMessage extends AbstractMethod {
     params: Params;
-    run: () => Promise<any>;
 
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['custom-message', 'read', 'write'];
         this.info = 'Custom message';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(message.payload, [
@@ -49,11 +48,12 @@ export default class CustomMessage extends AbstractMethod {
         return this.params.customMessages;
     }
 
-    async run(): Promise<Object> {
+    async run() {
         if (this.device.features.vendor === 'trezor.io' || this.device.features.vendor === 'bitcointrezor.com') {
             throw ERRORS.TypedError('Runtime', 'Cannot use custom message on device with official firmware. Change device "vendor" field.');
         }
         // call message
+        // $FlowIssue message could be anything, unknown type
         const response = await this.device.getCommands()._commonCall(this.params.message, this.params.params);
         // create ui promise
         const uiPromise = this.createUiPromise(UI.CUSTOM_MESSAGE_RESPONSE, this.device);

--- a/src/js/core/methods/EosGetPublicKey.js
+++ b/src/js/core/methods/EosGetPublicKey.js
@@ -8,36 +8,30 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 import type { EosPublicKey } from '../../types/networks/eos';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
-
-type Batch = {
-    path: Array<number>;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class EosGetPublicKey extends AbstractMethod {
-    params: Params;
+    params: $ElementType<MessageType, 'EosGetPublicKey'>[] = [];
     hasBundle: boolean;
-    confirmed: boolean = false;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
 
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
+        this.info = 'Export Eos public key';
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
             { name: 'bundle', type: 'array' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -45,26 +39,17 @@ export default class EosGetPublicKey extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
-                showOnTrezor,
+            this.params.push({
+                address_n: path,
+                show_display: showOnTrezor,
             });
         });
-
-        // set info
-        if (bundle.length === 1) {
-            this.info = 'Export Eos public key';
-        } else {
-            this.info = 'Export multiple Eos public keys';
-        }
-
-        this.params = bundle;
     }
 
     async confirmation(): Promise<boolean> {
@@ -78,7 +63,7 @@ export default class EosGetPublicKey extends AbstractMethod {
         if (this.params.length > 1) {
             label = 'Export multiple Eos public keys';
         } else {
-            label = `Export Eos public key for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+            label = `Export Eos public key for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         }
 
         // request confirmation view
@@ -88,34 +73,30 @@ export default class EosGetPublicKey extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
     }
 
-    async run(): Promise<EosPublicKey | Array<EosPublicKey>> {
-        const responses: Array<EosPublicKey> = [];
-
+    async run() {
+        const responses: EosPublicKey[] = [];
+        const cmd = this.device.getCommands();
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
-            const response = await this.device.getCommands().eosGetPublicKey(
-                batch.path,
-                batch.showOnTrezor
-            );
-
+            const { message } = await cmd.typedCall('EosGetPublicKey', 'EosPublicKey', batch);
             responses.push({
-                rawPublicKey: response.raw_public_key,
-                wifPublicKey: response.wif_public_key,
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
+                rawPublicKey: message.raw_public_key,
+                wifPublicKey: message.wif_public_key,
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
             });
 
             if (this.hasBundle) {
                 // send progress
                 this.postMessage(UiMessage(UI.BUNDLE_PROGRESS, {
                     progress: i,
-                    response,
+                    response: message,
                 }));
             }
         }

--- a/src/js/core/methods/EosSignTransaction.js
+++ b/src/js/core/methods/EosSignTransaction.js
@@ -6,14 +6,14 @@ import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/eosSignTx';
 
-import type { EosTxHeader, EosTxActionAck, EosSignedTx } from '../../types/trezor/protobuf';
+import type { EosTxHeader, EosTxActionAck } from '../../types/trezor/protobuf';
 import type { CoreMessage } from '../../types';
 
 type Params = {
-    path: Array<number>;
+    path: number[];
     chain_id: string;
-    header: ?EosTxHeader;
-    ack: Array<EosTxActionAck>;
+    header?: EosTxHeader;
+    ack: EosTxActionAck[];
 }
 
 export default class EosSignTransaction extends AbstractMethod {
@@ -25,7 +25,7 @@ export default class EosSignTransaction extends AbstractMethod {
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
         this.info = 'Sign EOS transaction';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },
@@ -43,7 +43,7 @@ export default class EosSignTransaction extends AbstractMethod {
         };
     }
 
-    async run(): Promise<EosSignedTx> {
+    async run() {
         const response = await helper.signTx(
             this.device.getCommands().typedCall.bind(this.device.getCommands()),
             this.params.path,

--- a/src/js/core/methods/EthereumGetPublicKey.js
+++ b/src/js/core/methods/EthereumGetPublicKey.js
@@ -9,8 +9,7 @@ import { getEthereumNetwork, getUniqueNetworks } from '../../data/CoinInfo';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage, UiPromiseResponse, EthereumNetworkInfo } from '../../types';
-import type { HDNodeResponse } from '../../types/trezor/protobuf';
+import type { CoreMessage, UiPromiseResponse, EthereumNetworkInfo, HDNodeResponse } from '../../types';
 
 type Batch = {
     path: Array<number>;

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -6,15 +6,13 @@ import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
 import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
 import { messageToHex } from '../../utils/formatUtils';
-
-import type { MessageSignature } from '../../types/trezor/protobuf';
 import type { CoreMessage, EthereumNetworkInfo } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
-    path: Array<number>;
-    network: ?EthereumNetworkInfo;
-    message: string;
-}
+    ...$ElementType<MessageType, 'EthereumSignMessage'>,
+    network?: EthereumNetworkInfo;
+};
 
 export default class EthereumSignMessage extends AbstractMethod {
     params: Params;
@@ -24,7 +22,7 @@ export default class EthereumSignMessage extends AbstractMethod {
 
         this.requiredPermissions = ['read', 'write'];
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -33,26 +31,28 @@ export default class EthereumSignMessage extends AbstractMethod {
             { name: 'hex', type: 'boolean' },
         ]);
 
-        const path: Array<number> = validatePath(payload.path, 3);
-        const network: ?EthereumNetworkInfo = getEthereumNetwork(path);
+        const path = validatePath(payload.path, 3);
+        const network = getEthereumNetwork(path);
         this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
 
         this.info = getNetworkLabel('Sign #NETWORK message', network);
 
         const messageHex = payload.hex ? messageToHex(payload.message) : Buffer.from(payload.message, 'utf8').toString('hex');
         this.params = {
-            path,
-            network,
+            address_n: path,
             message: messageHex,
+            network,
         };
     }
 
-    async run(): Promise<MessageSignature> {
-        const response: MessageSignature = await this.device.getCommands().ethereumSignMessage(
-            this.params.path,
-            this.params.message
-        );
-        response.address = toChecksumAddress(response.address, this.params.network);
-        return response;
+    async run() {
+        const cmd = this.device.getCommands();
+        const { address_n, message, network } = this.params;
+        const response = await cmd.typedCall('EthereumSignMessage', 'EthereumMessageSignature', {
+            address_n,
+            message,
+        });
+        response.message.address = toChecksumAddress(response.message.address, network);
+        return response.message;
     }
 }

--- a/src/js/core/methods/EthereumSignTransaction.js
+++ b/src/js/core/methods/EthereumSignTransaction.js
@@ -9,11 +9,10 @@ import { stripHexPrefix } from '../../utils/formatUtils';
 import * as helper from './helpers/ethereumSignTx';
 
 import type { CoreMessage } from '../../types';
-import type { EthereumSignedTx } from '../../types/trezor/protobuf';
 import type { EthereumTransaction } from '../../types/networks/ethereum';
 
 type Params = {
-    path: Array<number>;
+    path: number[];
     transaction: EthereumTransaction;
 }
 
@@ -25,7 +24,7 @@ export default class EthereumSignTx extends AbstractMethod {
 
         this.requiredPermissions = ['read', 'write'];
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -33,7 +32,7 @@ export default class EthereumSignTx extends AbstractMethod {
             { name: 'transaction', obligatory: true },
         ]);
 
-        const path: Array<number> = validatePath(payload.path, 3);
+        const path = validatePath(payload.path, 3);
         const network = getEthereumNetwork(path);
         this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
 
@@ -72,9 +71,9 @@ export default class EthereumSignTx extends AbstractMethod {
         };
     }
 
-    async run(): Promise<EthereumSignedTx> {
+    async run() {
         const tx = this.params.transaction;
-        return await helper.ethereumSignTx(
+        return helper.ethereumSignTx(
             this.device.getCommands().typedCall.bind(this.device.getCommands()),
             this.params.path,
             tx.to,

--- a/src/js/core/methods/EthereumVerifyMessage.js
+++ b/src/js/core/methods/EthereumVerifyMessage.js
@@ -2,19 +2,12 @@
 
 import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
-import type { Success } from '../../types/trezor/protobuf';
-import type { CoreMessage } from '../../types';
-
 import { stripHexPrefix, messageToHex } from '../../utils/formatUtils';
-
-type Params = {
-    address: string;
-    signature: string;
-    message: string;
-}
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class EthereumVerifyMessage extends AbstractMethod {
-    params: Params;
+    params: $ElementType<MessageType, 'EthereumVerifyMessage'>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -23,7 +16,7 @@ export default class EthereumVerifyMessage extends AbstractMethod {
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.info = 'Verify message';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -41,11 +34,9 @@ export default class EthereumVerifyMessage extends AbstractMethod {
         };
     }
 
-    async run(): Promise<Success> {
-        return await this.device.getCommands().ethereumVerifyMessage(
-            this.params.address,
-            this.params.signature,
-            this.params.message,
-        );
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('EthereumVerifyMessage', 'Success', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/FirmwareUpdate.js
+++ b/src/js/core/methods/FirmwareUpdate.js
@@ -18,7 +18,6 @@ type Params = {
 
 export default class FirmwareUpdate extends AbstractMethod {
     params: Params;
-    run: () => Promise<any>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -29,7 +28,7 @@ export default class FirmwareUpdate extends AbstractMethod {
         this.useDeviceState = false;
         this.skipFirmwareCheck = true;
 
-        const payload: Params = message.payload;
+        const { payload } = message;
 
         validateParams(payload, [
             { name: 'version', type: 'array' },
@@ -69,7 +68,7 @@ export default class FirmwareUpdate extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async run(): Promise<Object> {
+    async run() {
         const { device } = this;
 
         let binary;
@@ -96,10 +95,7 @@ export default class FirmwareUpdate extends AbstractMethod {
             this.device.getCommands().typedCall.bind(this.device.getCommands()),
             this.postMessage,
             device,
-            {
-                payload: binary,
-                length: binary.byteLength,
-            }
+            { payload: binary }
         );
     }
 }

--- a/src/js/core/methods/GetAccountInfo.js
+++ b/src/js/core/methods/GetAccountInfo.js
@@ -37,7 +37,7 @@ export default class GetAccountInfo extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -64,7 +64,7 @@ export default class GetAccountInfo extends AbstractMethod {
             ]);
 
             // validate coin info
-            const coinInfo: ?CoinInfo = getCoinInfo(batch.coin);
+            const coinInfo = getCoinInfo(batch.coin);
             if (!coinInfo) {
                 throw ERRORS.TypedError('Method_UnknownCoin');
             }

--- a/src/js/core/methods/GetCoinInfo.js
+++ b/src/js/core/methods/GetCoinInfo.js
@@ -20,7 +20,7 @@ export default class GetCoinInfo extends AbstractMethod {
         this.useDevice = false;
         this.useUi = false;
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         validateParams(payload, [
             { name: 'coin', type: 'string', obligatory: true },

--- a/src/js/core/methods/GetDeviceState.js
+++ b/src/js/core/methods/GetDeviceState.js
@@ -9,7 +9,7 @@ export default class GetDeviceState extends AbstractMethod {
         this.requiredPermissions = [];
     }
 
-    async run(): Promise<Object> {
+    async run() {
         return {
             state: this.device.getExternalState(),
         };

--- a/src/js/core/methods/GetPublicKey.js
+++ b/src/js/core/methods/GetPublicKey.js
@@ -9,8 +9,7 @@ import { UiMessage } from '../../message/builder';
 
 import { getBitcoinNetwork } from '../../data/CoinInfo';
 import { getPublicKeyLabel } from '../../utils/pathUtils';
-import type { HDNodeResponse } from '../../types/trezor/protobuf';
-import type { CoreMessage, UiPromiseResponse, BitcoinNetworkInfo } from '../../types';
+import type { CoreMessage, UiPromiseResponse, BitcoinNetworkInfo, HDNodeResponse } from '../../types';
 
 type Batch = {
     path: Array<number>;

--- a/src/js/core/methods/LiskSignMessage.js
+++ b/src/js/core/methods/LiskSignMessage.js
@@ -5,17 +5,12 @@ import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 
-import type { LiskMessageSignature } from '../../types/trezor/protobuf';
 import type { CoreMessage } from '../../types';
-import type { LiskMessageSignature as LiskMessageSignatureResponse } from '../../types/networks/lisk';
-
-type Params = {
-    path: Array<number>;
-    message: string;
-}
+import type { LiskMessageSignature } from '../../types/networks/lisk';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class LiskSignMessage extends AbstractMethod {
-    params: Params;
+    params: $ElementType<MessageType, 'LiskSignMessage'>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -23,7 +18,7 @@ export default class LiskSignMessage extends AbstractMethod {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('Lisk'), this.firmwareRange);
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -31,25 +26,23 @@ export default class LiskSignMessage extends AbstractMethod {
             { name: 'message', type: 'string', obligatory: true },
         ]);
 
-        const path: Array<number> = validatePath(payload.path, 3);
+        const path = validatePath(payload.path, 3);
         this.info = 'Sign Lisk Message';
 
         // TODO: check if message is already in hex format
-        const messageHex: string = Buffer.from(payload.message, 'utf8').toString('hex');
+        const messageHex = Buffer.from(payload.message, 'utf8').toString('hex');
         this.params = {
-            path,
+            address_n: path,
             message: messageHex,
         };
     }
 
-    async run(): Promise<LiskMessageSignatureResponse> {
-        const response: LiskMessageSignature = await this.device.getCommands().liskSignMessage(
-            this.params.path,
-            this.params.message
-        );
+    async run(): Promise<LiskMessageSignature> {
+        const cmd = this.device.getCommands();
+        const { message } = await cmd.typedCall('LiskSignMessage', 'LiskMessageSignature', this.params);
         return {
-            publicKey: response.public_key,
-            signature: response.signature,
+            publicKey: message.public_key,
+            signature: message.signature,
         };
     }
 }

--- a/src/js/core/methods/LiskSignTransaction.js
+++ b/src/js/core/methods/LiskSignTransaction.js
@@ -7,16 +7,10 @@ import { validatePath } from '../../utils/pathUtils';
 import { prepareTx } from './helpers/liskSignTx';
 
 import type { CoreMessage } from '../../types';
-import type { LiskTransaction, LiskSignedTx } from '../../types/trezor/protobuf';
-import type { LiskTransaction as LiskParsedTransaction } from '../../types/networks/lisk';
-
-type Params = {
-    path: Array<number>;
-    transaction: LiskTransaction;
-}
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class LiskSignTransaction extends AbstractMethod {
-    params: Params;
+    params: $ElementType<MessageType, 'LiskSignTx'>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -24,7 +18,7 @@ export default class LiskSignTransaction extends AbstractMethod {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('Lisk'), this.firmwareRange);
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -32,11 +26,11 @@ export default class LiskSignTransaction extends AbstractMethod {
             { name: 'transaction', obligatory: true },
         ]);
 
-        const path: Array<number> = validatePath(payload.path, 3);
+        const path = validatePath(payload.path, 3);
 
         this.info = 'Sign Lisk transaction';
 
-        const tx: LiskParsedTransaction = payload.transaction;
+        const tx = payload.transaction;
         validateParams(tx, [
             { name: 'type', type: 'number', obligatory: true },
             { name: 'fee', type: 'string', obligatory: true },
@@ -47,18 +41,17 @@ export default class LiskSignTransaction extends AbstractMethod {
             { name: 'asset', type: 'object' },
         ]);
 
-        const transaction: LiskTransaction = prepareTx(tx);
+        const transaction = prepareTx(tx);
         if (!transaction.asset) transaction.asset = {};
         this.params = {
-            path,
+            address_n: path,
             transaction,
         };
     }
 
-    async run(): Promise<LiskSignedTx> {
-        return await this.device.getCommands().liskSignTx(
-            this.params.path,
-            this.params.transaction,
-        );
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('LiskSignTx', 'LiskSignedTx', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/NEMSignTransaction.js
+++ b/src/js/core/methods/NEMSignTransaction.js
@@ -6,13 +6,12 @@ import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/nemSignTx';
 
-import type { NEMSignTxMessage, NEMSignedTx } from '../../types/trezor/protobuf';
 import type { NEMTransaction } from '../../types/networks/nem';
 import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class NEMSignTransaction extends AbstractMethod {
-    message: NEMSignTxMessage;
-    run: () => Promise<any>;
+    params: $ElementType<MessageType, 'NEMSignTx'>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -20,7 +19,7 @@ export default class NEMSignTransaction extends AbstractMethod {
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
         this.info = 'Sign NEM transaction';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },
@@ -30,10 +29,12 @@ export default class NEMSignTransaction extends AbstractMethod {
         const path = validatePath(payload.path, 3);
         // incoming data should be in nem-sdk format
         const transaction: NEMTransaction = payload.transaction;
-        this.message = helper.createTx(transaction, path);
+        this.params = helper.createTx(transaction, path);
     }
 
-    async run(): Promise<NEMSignedTx> {
-        return await this.device.getCommands().nemSignTx(this.message);
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('NEMSignTx', 'NEMSignedTx', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/PushTransaction.js
+++ b/src/js/core/methods/PushTransaction.js
@@ -22,7 +22,7 @@ export default class PushTransaction extends AbstractMethod {
         this.useUi = false;
         this.useDevice = false;
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         // validate incoming parameters
         validateParams(payload, [
@@ -30,7 +30,7 @@ export default class PushTransaction extends AbstractMethod {
             { name: 'coin', type: 'string', obligatory: true },
         ]);
 
-        const coinInfo: ?CoinInfo = getCoinInfo(payload.coin);
+        const coinInfo = getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
@@ -47,7 +47,7 @@ export default class PushTransaction extends AbstractMethod {
         };
     }
 
-    async run(): Promise<{ txid: string }> {
+    async run() {
         const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
         const txid: string = await backend.pushTransaction(this.params.tx);
         return {

--- a/src/js/core/methods/RecoveryDevice.js
+++ b/src/js/core/methods/RecoveryDevice.js
@@ -4,20 +4,18 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { validateParams } from './helpers/paramsValidator';
 import { UiMessage } from '../../message/builder';
-
 import type { CoreMessage } from '../../types';
-import type { RecoverDeviceSettings as Params } from '../../types/trezor/protobuf';
+import type { MessageType } from '../../types/trezor/protobuf';
 
 export default class RecoveryDevice extends AbstractMethod {
-    params: Params;
-    run: () => Promise<any>;
+    params: $ElementType<MessageType, 'RecoveryDevice'>;
 
     constructor(message: CoreMessage) {
         super(message);
         this.requiredPermissions = ['management'];
         this.useEmptyPassphrase = true;
 
-        const payload: Object = message.payload;
+        const { payload } = message;
 
         validateParams(payload, [
             { name: 'word_count', type: 'number' },
@@ -67,7 +65,9 @@ export default class RecoveryDevice extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async run(): Promise<Object> {
-        return await this.device.getCommands().recoveryDevice(this.params);
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('RecoveryDevice', 'Success', this.params);
+        return response.message;
     }
 }

--- a/src/js/core/methods/RippleGetAddress.js
+++ b/src/js/core/methods/RippleGetAddress.js
@@ -9,21 +9,19 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { RippleAddress } from '../../types/networks/ripple';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
-type Batch = {
-    path: Array<number>;
-    address: ?string;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+type Params = {
+    ...$ElementType<MessageType, 'RippleGetAddress'>,
+    address?: string;
+};
 
 export default class RippleGetAddress extends AbstractMethod {
-    confirmed: boolean = false;
-    params: Params;
+    params: Params[] = [];
     hasBundle: boolean;
     progress: number = 0;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -33,7 +31,7 @@ export default class RippleGetAddress extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -41,7 +39,6 @@ export default class RippleGetAddress extends AbstractMethod {
             { name: 'useEventListener', type: 'boolean' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -50,27 +47,26 @@ export default class RippleGetAddress extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
+            this.params.push({
+                address_n: path,
                 address: batch.address,
-                showOnTrezor,
+                show_display: showOnTrezor,
             });
         });
 
-        const useEventListener = payload.useEventListener && bundle.length === 1 && typeof bundle[0].address === 'string' && bundle[0].showOnTrezor;
+        const useEventListener = payload.useEventListener && this.params.length === 1 && typeof this.params[0].address === 'string' && this.params[0].show_display;
         this.confirmed = useEventListener;
         this.useUi = !useEventListener;
-        this.params = bundle;
 
         // set info
-        if (bundle.length === 1) {
-            this.info = `Export Ripple address for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+        if (this.params.length === 1) {
+            this.info = `Export Ripple address for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         } else {
             this.info = 'Export multiple Ripple addresses';
         }
@@ -80,7 +76,7 @@ export default class RippleGetAddress extends AbstractMethod {
         if (code === 'ButtonRequest_Address') {
             const data = {
                 type: 'address',
-                serializedPath: getSerializedPath(this.params[this.progress].path),
+                serializedPath: getSerializedPath(this.params[this.progress].address_n),
                 address: this.params[this.progress].address || 'not-set',
             };
             return data;
@@ -103,7 +99,7 @@ export default class RippleGetAddress extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
@@ -121,22 +117,34 @@ export default class RippleGetAddress extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
         return uiResp.payload;
     }
 
-    async run(): Promise<RippleAddress | Array<RippleAddress>> {
-        const responses: Array<RippleAddress> = [];
+    async _call({
+        address_n,
+        show_display,
+    }: Params) {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('RippleGetAddress', 'RippleAddress', {
+            address_n,
+            show_display,
+        });
+        return response.message;
+    }
+
+    async run() {
+        const responses: RippleAddress[] = [];
 
         for (let i = 0; i < this.params.length; i++) {
-            const batch: Batch = this.params[i];
+            const batch = this.params[i];
             // silently get address and compare with requested address
             // or display as default inside popup
-            if (batch.showOnTrezor) {
-                const silent = await this.device.getCommands().rippleGetAddress(
-                    batch.path,
-                    false
-                );
+            if (batch.show_display) {
+                const silent = await this._call({
+                    ...batch,
+                    show_display: false,
+                });
                 if (typeof batch.address === 'string') {
                     if (batch.address !== silent.address) {
                         throw ERRORS.TypedError('Method_AddressNotMatch');
@@ -146,14 +154,11 @@ export default class RippleGetAddress extends AbstractMethod {
                 }
             }
 
-            const response = await this.device.getCommands().rippleGetAddress(
-                batch.path,
-                batch.showOnTrezor
-            );
+            const response = await this._call(batch);
             responses.push({
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
             });
 
             if (this.hasBundle) {

--- a/src/js/core/methods/StellarGetAddress.js
+++ b/src/js/core/methods/StellarGetAddress.js
@@ -9,21 +9,19 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { StellarAddress } from '../../types/networks/stellar';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
-type Batch = {
-    path: Array<number>;
-    address: ?string;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+type Params = {
+    ...$ElementType<MessageType, 'StellarGetAddress'>,
+    address?: string;
+};
 
 export default class StellarGetAddress extends AbstractMethod {
-    confirmed: boolean = false;
-    params: Params;
+    params: Params[] = [];
     hasBundle: boolean;
     progress: number = 0;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -33,7 +31,7 @@ export default class StellarGetAddress extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -41,7 +39,6 @@ export default class StellarGetAddress extends AbstractMethod {
             { name: 'useEventListener', type: 'boolean' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -50,27 +47,26 @@ export default class StellarGetAddress extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
+            this.params.push({
+                address_n: path,
                 address: batch.address,
-                showOnTrezor,
+                show_display: showOnTrezor,
             });
         });
 
-        const useEventListener = payload.useEventListener && bundle.length === 1 && typeof bundle[0].address === 'string' && bundle[0].showOnTrezor;
+        const useEventListener = payload.useEventListener && this.params.length === 1 && typeof this.params[0].address === 'string' && this.params[0].show_display;
         this.confirmed = useEventListener;
         this.useUi = !useEventListener;
-        this.params = bundle;
 
         // set info
-        if (bundle.length === 1) {
-            this.info = `Export Stellar address for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+        if (this.params.length === 1) {
+            this.info = `Export Stellar address for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         } else {
             this.info = 'Export multiple Stellar addresses';
         }
@@ -80,7 +76,7 @@ export default class StellarGetAddress extends AbstractMethod {
         if (code === 'ButtonRequest_Address') {
             const data = {
                 type: 'address',
-                serializedPath: getSerializedPath(this.params[this.progress].path),
+                serializedPath: getSerializedPath(this.params[this.progress].address_n),
                 address: this.params[this.progress].address || 'not-set',
             };
             return data;
@@ -95,15 +91,14 @@ export default class StellarGetAddress extends AbstractMethod {
         // initialize user response promise
         const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION, this.device);
 
-        const label: string = this.info;
         // request confirmation view
         this.postMessage(UiMessage(UI.REQUEST_CONFIRMATION, {
             view: 'export-address',
-            label,
+            label: this.info,
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
@@ -121,22 +116,34 @@ export default class StellarGetAddress extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
         return uiResp.payload;
     }
 
-    async run(): Promise<StellarAddress | Array<StellarAddress>> {
-        const responses: Array<StellarAddress> = [];
+    async _call({
+        address_n,
+        show_display,
+    }: Params) {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('StellarGetAddress', 'StellarAddress', {
+            address_n,
+            show_display,
+        });
+        return response.message;
+    }
+
+    async run() {
+        const responses: StellarAddress[] = [];
 
         for (let i = 0; i < this.params.length; i++) {
-            const batch: Batch = this.params[i];
+            const batch = this.params[i];
             // silently get address and compare with requested address
             // or display as default inside popup
-            if (batch.showOnTrezor) {
-                const silent = await this.device.getCommands().stellarGetAddress(
-                    batch.path,
-                    false
-                );
+            if (batch.show_display) {
+                const silent = await this._call({
+                    ...batch,
+                    show_display: false,
+                });
                 if (typeof batch.address === 'string') {
                     if (batch.address !== silent.address) {
                         throw ERRORS.TypedError('Method_AddressNotMatch');
@@ -146,14 +153,11 @@ export default class StellarGetAddress extends AbstractMethod {
                 }
             }
 
-            const response = await this.device.getCommands().stellarGetAddress(
-                batch.path,
-                batch.showOnTrezor
-            );
+            const response = await this._call(batch);
             responses.push({
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
             });
 
             if (this.hasBundle) {

--- a/src/js/core/methods/StellarSignTransaction.js
+++ b/src/js/core/methods/StellarSignTransaction.js
@@ -6,12 +6,11 @@ import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/stellarSignTx';
 
-import type { StellarSignedTx } from '../../types/trezor/protobuf';
-import type { StellarTransaction, StellarSignedTx as StellarSignedTxResponse } from '../../types/networks/stellar';
+import type { StellarTransaction } from '../../types/networks/stellar';
 import type { CoreMessage } from '../../types';
 
 type Params = {
-    path: Array<number>;
+    path: number[];
     networkPassphrase: string;
     transaction: any;
 }
@@ -25,7 +24,7 @@ export default class StellarSignTransaction extends AbstractMethod {
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('Stellar'), this.firmwareRange);
         this.info = 'Sign Stellar transaction';
 
-        const payload: Object = message.payload;
+        const { payload } = message;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },
@@ -43,8 +42,8 @@ export default class StellarSignTransaction extends AbstractMethod {
         };
     }
 
-    async run(): Promise<StellarSignedTxResponse> {
-        const response: StellarSignedTx = await helper.stellarSignTx(
+    async run() {
+        const response = await helper.stellarSignTx(
             this.device.getCommands().typedCall.bind(this.device.getCommands()),
             this.params.path,
             this.params.networkPassphrase,

--- a/src/js/core/methods/TezosGetAddress.js
+++ b/src/js/core/methods/TezosGetAddress.js
@@ -9,21 +9,19 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { TezosAddress } from '../../types/networks/tezos';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
+import type { CoreMessage } from '../../types';
+import type { MessageType } from '../../types/trezor/protobuf';
 
-type Batch = {
-    path: Array<number>;
-    address: ?string;
-    showOnTrezor: boolean;
-}
-
-type Params = Array<Batch>;
+type Params = {
+    ...$ElementType<MessageType, 'TezosGetAddress'>,
+    address?: string;
+};
 
 export default class TezosGetAddress extends AbstractMethod {
-    confirmed: boolean = false;
-    params: Params;
+    params: Params[] = [];
     hasBundle: boolean;
     progress: number = 0;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -33,7 +31,7 @@ export default class TezosGetAddress extends AbstractMethod {
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload: Object = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
+        const payload = !this.hasBundle ? { ...message.payload, bundle: [ message.payload ] } : message.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -41,7 +39,6 @@ export default class TezosGetAddress extends AbstractMethod {
             { name: 'useEventListener', type: 'boolean' },
         ]);
 
-        const bundle = [];
         payload.bundle.forEach(batch => {
             // validate incoming parameters for each batch
             validateParams(batch, [
@@ -50,27 +47,26 @@ export default class TezosGetAddress extends AbstractMethod {
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
-            const path: Array<number> = validatePath(batch.path, 3);
-            let showOnTrezor: boolean = true;
+            const path = validatePath(batch.path, 3);
+            let showOnTrezor = true;
             if (Object.prototype.hasOwnProperty.call(batch, 'showOnTrezor')) {
                 showOnTrezor = batch.showOnTrezor;
             }
 
-            bundle.push({
-                path,
+            this.params.push({
+                address_n: path,
                 address: batch.address,
-                showOnTrezor,
+                show_display: showOnTrezor,
             });
         });
 
-        const useEventListener = payload.useEventListener && bundle.length === 1 && typeof bundle[0].address === 'string' && bundle[0].showOnTrezor;
+        const useEventListener = payload.useEventListener && this.params.length === 1 && typeof this.params[0].address === 'string' && this.params[0].show_display;
         this.confirmed = useEventListener;
         this.useUi = !useEventListener;
-        this.params = bundle;
 
         // set info
-        if (bundle.length === 1) {
-            this.info = `Export Tezos address for account #${ (fromHardened(this.params[0].path[2]) + 1) }`;
+        if (this.params.length === 1) {
+            this.info = `Export Tezos address for account #${ (fromHardened(this.params[0].address_n[2]) + 1) }`;
         } else {
             this.info = 'Export multiple Tezos addresses';
         }
@@ -80,7 +76,7 @@ export default class TezosGetAddress extends AbstractMethod {
         if (code === 'ButtonRequest_Address') {
             const data = {
                 type: 'address',
-                serializedPath: getSerializedPath(this.params[this.progress].path),
+                serializedPath: getSerializedPath(this.params[this.progress].address_n),
                 address: this.params[this.progress].address || 'not-set',
             };
             return data;
@@ -95,15 +91,14 @@ export default class TezosGetAddress extends AbstractMethod {
         // initialize user response promise
         const uiPromise = this.createUiPromise(UI.RECEIVE_CONFIRMATION, this.device);
 
-        const label: string = this.info;
         // request confirmation view
         this.postMessage(UiMessage(UI.REQUEST_CONFIRMATION, {
             view: 'export-address',
-            label,
+            label: this.info,
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
@@ -121,22 +116,34 @@ export default class TezosGetAddress extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
         return uiResp.payload;
     }
 
-    async run(): Promise<TezosAddress | Array<TezosAddress>> {
-        const responses: Array<TezosAddress> = [];
+    async _call({
+        address_n,
+        show_display,
+    }: Params) {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('TezosGetAddress', 'TezosAddress', {
+            address_n,
+            show_display,
+        });
+        return response.message;
+    }
+
+    async run() {
+        const responses: TezosAddress[] = [];
 
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
             // silently get address and compare with requested address
             // or display as default inside popup
-            if (batch.showOnTrezor) {
-                const silent = await this.device.getCommands().tezosGetAddress(
-                    batch.path,
-                    false
-                );
+            if (batch.show_display) {
+                const silent = await this._call({
+                    ...batch,
+                    show_display: false,
+                });
                 if (typeof batch.address === 'string') {
                     if (batch.address !== silent.address) {
                         throw ERRORS.TypedError('Method_AddressNotMatch');
@@ -146,13 +153,10 @@ export default class TezosGetAddress extends AbstractMethod {
                 }
             }
 
-            const response = await this.device.getCommands().tezosGetAddress(
-                batch.path,
-                batch.showOnTrezor
-            );
+            const response = await this._call(batch);
             responses.push({
-                path: batch.path,
-                serializedPath: getSerializedPath(batch.path),
+                path: batch.address_n,
+                serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
             });
 

--- a/src/js/core/methods/WipeDevice.js
+++ b/src/js/core/methods/WipeDevice.js
@@ -5,11 +5,10 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 import { getFirmwareRange } from './helpers/paramsValidator';
-import type { Success } from '../../types/trezor/protobuf';
-import type { CoreMessage, UiPromiseResponse } from '../../types';
+import type { CoreMessage } from '../../types';
 
 export default class WipeDevice extends AbstractMethod {
-    confirmed: boolean = false;
+    confirmed: ?boolean;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -39,13 +38,15 @@ export default class WipeDevice extends AbstractMethod {
         }));
 
         // wait for user action
-        const uiResp: UiPromiseResponse = await uiPromise.promise;
+        const uiResp = await uiPromise.promise;
 
         this.confirmed = uiResp.payload;
         return this.confirmed;
     }
 
-    async run(): Promise<Success> {
-        return await this.device.getCommands().wipe();
+    async run() {
+        const cmd = this.device.getCommands();
+        const response = await cmd.typedCall('WipeDevice', 'Success');
+        return response.message;
     }
 }

--- a/src/js/core/methods/debuglink/DebugLinkDecision.js
+++ b/src/js/core/methods/debuglink/DebugLinkDecision.js
@@ -4,10 +4,10 @@ import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
 import type { CoreMessage } from '../../../types';
-import type { DebugLinkDecision as $DebugLinkDecision } from '../../../types/trezor/protobuf';
+import type { MessageType } from '../../../types/trezor/protobuf';
 
 export default class DebugLinkDecision extends AbstractMethod {
-    params: $DebugLinkDecision;
+    params: $ElementType<MessageType, 'DebugLinkDecision'>;
 
     constructor(message: CoreMessage) {
         super(message);
@@ -25,12 +25,12 @@ export default class DebugLinkDecision extends AbstractMethod {
 
         this.params = {
             yes_no: payload.yes_no,
-            up_down: payload.up_down,
+            // up_down: payload.up_down,
             input: payload.input,
         };
     }
 
-    async run(): Promise<{ debugLink: true }> {
+    async run() {
         if (!this.device.hasDebugLink) {
             throw ERRORS.TypedError('Runtime', 'Device is not a debug link');
         }
@@ -38,8 +38,8 @@ export default class DebugLinkDecision extends AbstractMethod {
             throw ERRORS.TypedError('Runtime', 'DebugLinkDecision: Device is not acquired!');
         }
 
-        await this.device.getCommands().debugLinkDecision(this.params);
-
+        const cmd = this.device.getCommands();
+        await cmd.typedCall('DebugLinkDecision', 'Success', this.params);
         return {
             debugLink: true,
         };

--- a/src/js/core/methods/helpers/cardanoAddressParameters.js
+++ b/src/js/core/methods/helpers/cardanoAddressParameters.js
@@ -2,7 +2,7 @@
 import { validateParams } from '../helpers/paramsValidator';
 import { validatePath } from '../../../utils/pathUtils';
 
-import type { CardanoAddressParameters as CardanoAddressParametersProto } from '../../../types/trezor/protobuf';
+import type { CardanoAddressParametersType } from '../../../types/trezor/protobuf';
 import type { CardanoAddressParameters } from '../../../types/networks/cardano';
 
 export const validateAddressParameters = (addressParameters: CardanoAddressParameters) => {
@@ -26,7 +26,7 @@ export const validateAddressParameters = (addressParameters: CardanoAddressParam
     }
 };
 
-export const addressParametersToProto = (addressParameters: CardanoAddressParameters): CardanoAddressParametersProto => {
+export const addressParametersToProto = (addressParameters: CardanoAddressParameters): CardanoAddressParametersType => {
     const path = validatePath(addressParameters.path, 3);
 
     let stakingPath = [];
@@ -52,7 +52,7 @@ export const addressParametersToProto = (addressParameters: CardanoAddressParame
     };
 };
 
-export const addressParametersFromProto = (addressParameters: CardanoAddressParametersProto): CardanoAddressParameters => {
+export const addressParametersFromProto = (addressParameters: CardanoAddressParametersType): CardanoAddressParameters => {
     let certificatePointer;
     if (addressParameters.certificate_pointer) {
         certificatePointer = {

--- a/src/js/core/methods/helpers/nemSignTx.js
+++ b/src/js/core/methods/helpers/nemSignTx.js
@@ -1,12 +1,11 @@
 /* @flow */
 
 import type {
-    NEMSignTxMessage,
+    NEMSignTx,
     NEMTransactionCommon,
     NEMTransfer,
     NEMImportanceTransfer,
     NEMAggregateModification,
-    NEMCosignatoryModification,
     NEMProvisionNamespace,
     NEMMosaicCreation,
     NEMMosaicDefinition,
@@ -68,7 +67,7 @@ const getCommon = (tx: $T.NEMTransaction, address_n?: number[]): NEMTransactionC
 };
 
 const transferMessage = (tx: $T.NEMTransferTransaction): NEMTransfer => {
-    const mosaics = tx.mosaics ? tx.mosaics.map((mosaic: $T.NEMMosaic) => ({
+    const mosaics = tx.mosaics ? tx.mosaics.map(mosaic => ({
         namespace: mosaic.mosaicId.namespaceId,
         mosaic: mosaic.mosaicId.name,
         quantity: mosaic.quantity,
@@ -89,7 +88,7 @@ const importanceTransferMessage = (tx: $T.NEMImportanceTransaction): NEMImportan
 });
 
 const aggregateModificationMessage = (tx: $T.NEMAggregateModificationTransaction): NEMAggregateModification => {
-    const modifications: ?Array<NEMCosignatoryModification> = tx.modifications ? tx.modifications.map(modification => ({
+    const modifications = tx.modifications ? tx.modifications.map(modification => ({
         type: NEM_AGGREGATE_MODIFICATION_TYPES[modification.modificationType],
         public_key: modification.cosignatoryAccount,
     })) : undefined;
@@ -159,10 +158,16 @@ const supplyChangeMessage = (tx: $T.NEMSupplyChangeTransaction): NEMMosaicSupply
     delta: tx.delta,
 });
 
-export const createTx = (tx: $T.NEMTransaction, address_n: number[]): NEMSignTxMessage => {
-    let transaction: $T.NEMTransaction = tx;
-    const message: NEMSignTxMessage = {
+export const createTx = (tx: $T.NEMTransaction, address_n: number[]) => {
+    let transaction = tx;
+    const message: NEMSignTx = {
         transaction: getCommon(tx, address_n),
+        transfer: undefined,
+        importance_transfer: undefined,
+        aggregate_modification: undefined,
+        provision_namespace: undefined,
+        mosaic_creation: undefined,
+        supply_change: undefined,
     };
 
     if (tx.type === NEM_COSIGNING || tx.type === NEM_MULTISIG || tx.type === NEM_MULTISIG_SIGNATURE) {

--- a/src/js/core/methods/helpers/signtxVerify.js
+++ b/src/js/core/methods/helpers/signtxVerify.js
@@ -10,12 +10,11 @@ import { ERRORS } from '../../../constants';
 import { getAddressScriptType, getAddressHash } from '../../../utils/addressUtils';
 import { getOutputScriptType } from '../../../utils/pathUtils';
 
-import type { BitcoinNetworkInfo } from '../../../types';
+import type { BitcoinNetworkInfo, HDNodeResponse } from '../../../types';
 
 import type {
     TransactionInput,
     TransactionOutput,
-    HDNodeResponse,
 } from '../../../types/trezor/protobuf';
 
 type GetHDNode = (path: Array<number>, coinInfo: ?BitcoinNetworkInfo, validation?: boolean) => Promise<HDNodeResponse>;

--- a/src/js/core/methods/helpers/tezosSignTx.js
+++ b/src/js/core/methods/helpers/tezosSignTx.js
@@ -3,7 +3,7 @@
 import * as bs58check from 'bs58check';
 import { ERRORS } from '../../../constants';
 import type { TezosOperation } from '../../../types/networks/tezos';
-import type { TezosTransaction } from '../../../types/trezor/protobuf';
+import type { TezosSignTx } from '../../../types/trezor/protobuf';
 import { validateParams } from './../helpers/paramsValidator';
 
 const prefix = {
@@ -21,7 +21,7 @@ const bs58checkDecode = (prefix: Uint8Array, enc: string): Uint8Array => {
     return bs58check.decode(enc).slice(prefix.length);
 };
 
-const concatArray = (first: Uint8Array, second: Uint8Array): Uint8Array => {
+const concatArray = (first: Uint8Array, second: Uint8Array) => {
     const result = new Uint8Array(first.length + second.length);
     result.set(first);
     result.set(second, first.length);
@@ -57,7 +57,7 @@ const publicKeyHash2buffer = (publicKeyHash: string): { originated: number; hash
 };
 
 // convert publicKeyHash to buffer
-const publicKey2buffer = (publicKey: string): Uint8Array => {
+const publicKey2buffer = (publicKey: string) => {
     switch (publicKey.substr(0, 4)) {
         case 'edpk':
             return concatArray(new Uint8Array([0]), bs58checkDecode(prefix.edpk, publicKey));
@@ -70,7 +70,7 @@ const publicKey2buffer = (publicKey: string): Uint8Array => {
     }
 };
 
-export const createTx = (address_n: Array<number>, branch: string, operation: TezosOperation): TezosTransaction => {
+export const createTx = (address_n: number[], branch: string, operation: TezosOperation): TezosSignTx => {
     let message = {
         address_n,
         branch: bs58checkDecode(prefix.B, branch),

--- a/src/js/core/methods/tx/index.js
+++ b/src/js/core/methods/tx/index.js
@@ -2,8 +2,9 @@
 
 import { xpubToHDNodeType } from '../../../utils/hdnode';
 import type { Network } from '@trezor/utxo-lib';
+import type { TxInputType, TxOutputType } from '../../../types/trezor/protobuf';
 
-export const fixPath = (utxo: any): any => {
+export const fixPath = <T: TxInputType | TxOutputType>(utxo: T): T => {
     // make sure bip32 indices are unsigned
     if (utxo.address_n && Array.isArray(utxo.address_n)) {
         utxo.address_n = utxo.address_n.map((i) => i >>> 0);
@@ -11,7 +12,7 @@ export const fixPath = (utxo: any): any => {
     return utxo;
 };
 
-export const convertMultisigPubKey = (network: Network, utxo: any): any => {
+export const convertMultisigPubKey = <T: TxInputType | TxOutputType>(network: Network, utxo: T): T => {
     if (utxo.multisig && utxo.multisig.pubkeys) {
         // convert xpubs to HDNodeTypes
         utxo.multisig.pubkeys.forEach(pk => {

--- a/src/js/core/methods/tx/inputs.js
+++ b/src/js/core/methods/tx/inputs.js
@@ -11,12 +11,12 @@ import type { BuildTxInput } from 'hd-wallet';
 
 // local types
 import type { BitcoinNetworkInfo } from '../../../types';
-import type { TransactionInput } from '../../../types/trezor/protobuf';
+import type { TxInputType } from '../../../types/trezor/protobuf';
 
 /** *****
  * SignTx: validation
  *******/
-export const validateTrezorInputs = (inputs: Array<TransactionInput>, coinInfo: BitcoinNetworkInfo): Array<TransactionInput> => {
+export const validateTrezorInputs = (inputs: TxInputType[], coinInfo: BitcoinNetworkInfo): TxInputType[] => {
     const trezorInputs = inputs.map(fixPath).map(convertMultisigPubKey.bind(null, coinInfo.network));
     for (const input of trezorInputs) {
         validatePath(input.address_n);
@@ -36,12 +36,12 @@ export const validateTrezorInputs = (inputs: Array<TransactionInput>, coinInfo: 
 /** *****
  * Transform from Trezor format to hd-wallet, called from SignTx to get refTxs from bitcore
  *******/
-export const inputToHD = (input: TransactionInput): BuildTxInput => {
+export const inputToHD = (input: TxInputType): BuildTxInput => {
     return {
         hash: reverseBuffer(Buffer.from(input.prev_hash, 'hex')),
         index: input.prev_index,
         path: input.address_n,
-        amount: input.amount,
+        amount: typeof input.amount === 'number' ? input.amount.toString() : input.amount,
         segwit: isSegwitPath(input.address_n),
     };
 };
@@ -49,7 +49,7 @@ export const inputToHD = (input: TransactionInput): BuildTxInput => {
 /** *****
  * Transform from hd-wallet format to Trezor
  *******/
-export const inputToTrezor = (input: BuildTxInput, sequence: number): TransactionInput => {
+export const inputToTrezor = (input: BuildTxInput, sequence: number): TxInputType => {
     const { hash, index, path, amount } = input;
     return {
         address_n: path,

--- a/src/js/core/methods/tx/outputs.js
+++ b/src/js/core/methods/tx/outputs.js
@@ -15,13 +15,13 @@ import type { BuildTxOutput, BuildTxOutputRequest } from 'hd-wallet';
 
 // local types
 import type { BitcoinNetworkInfo } from '../../../types';
-import type { TransactionOutput } from '../../../types/trezor/protobuf';
+import type { TxOutputType } from '../../../types/trezor/protobuf';
 
 /** *****
  * SignTransaction: validation
  *******/
-export const validateTrezorOutputs = (outputs: Array<TransactionOutput>, coinInfo: BitcoinNetworkInfo): Array<TransactionOutput> => {
-    const trezorOutputs: Array<TransactionOutput> = outputs.map(fixPath).map(convertMultisigPubKey.bind(null, coinInfo.network));
+export const validateTrezorOutputs = (outputs: TxOutputType[], coinInfo: BitcoinNetworkInfo): TxOutputType[] => {
+    const trezorOutputs = outputs.map(fixPath).map(convertMultisigPubKey.bind(null, coinInfo.network));
     for (const output of trezorOutputs) {
         validateParams(output, [
             { name: 'address_n', type: 'array' },
@@ -105,7 +105,7 @@ export const validateHDOutput = (output: BuildTxOutputRequest, coinInfo: Bitcoin
 /** *****
  * Transform from hd-wallet format to Trezor
  *******/
-export const outputToTrezor = (output: BuildTxOutput, coinInfo: BitcoinNetworkInfo): TransactionOutput => {
+export const outputToTrezor = (output: BuildTxOutput, coinInfo: BitcoinNetworkInfo): TxOutputType => {
     if (output.opReturnData) {
         if (Object.prototype.hasOwnProperty.call(output, 'value')) {
             throw ERRORS.TypedError('Method_InvalidParameter', 'opReturn output should not contains value');

--- a/src/js/core/methods/tx/refTx.js
+++ b/src/js/core/methods/tx/refTx.js
@@ -5,17 +5,14 @@ import { coins as BitcoinJSCoins } from '@trezor/utxo-lib';
 import { reverseBuffer } from '../../../utils/bufferUtils';
 
 // npm types
-import type {
-    Transaction as BitcoinJsTransaction,
-} from '@trezor/utxo-lib';
-
+import type { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 import type { BuildTxInput } from 'hd-wallet';
 
 // local types
-import type { RefTransaction } from '../../../types/trezor/protobuf';
+import type { RefTransaction } from '../../../types/networks/bitcoin';
 
 // Get array of unique referenced transactions ids
-export const getReferencedTransactions = (inputs: Array<BuildTxInput>): Array<string> => {
+export const getReferencedTransactions = (inputs: BuildTxInput[]): string[] => {
     return inputs.reduce((result: string[], utxo: BuildTxInput) => {
         const hash = reverseBuffer(utxo.hash).toString('hex');
         if (result.includes(hash)) return result;
@@ -24,28 +21,24 @@ export const getReferencedTransactions = (inputs: Array<BuildTxInput>): Array<st
 };
 
 // Transform referenced transactions from Bitcore to Trezor format
-export const transformReferencedTransactions = (txs: Array<BitcoinJsTransaction>): Array<RefTransaction> => {
+export const transformReferencedTransactions = (txs: BitcoinJsTransaction[]): RefTransaction[] => {
     return txs.map(tx => {
         const extraData = tx.getExtraData();
-        const version_group_id = BitcoinJSCoins.isZcashType(tx.network) && typeof tx.versionGroupId === 'number' && tx.version >= 3 ? tx.versionGroupId : null;
+        const version_group_id = BitcoinJSCoins.isZcashType(tx.network) && typeof tx.versionGroupId === 'number' && tx.version >= 3 ? tx.versionGroupId : undefined;
         return {
             version: tx.isDashSpecialTransaction() ? tx.version | tx.type << 16 : tx.version,
             hash: tx.getId(),
-            inputs: tx.ins.map(input => {
-                return {
-                    prev_index: input.index,
-                    sequence: input.sequence,
-                    prev_hash: reverseBuffer(input.hash).toString('hex'),
-                    script_sig: input.script.toString('hex'),
-                };
-            }),
-            bin_outputs: tx.outs.map(output => {
-                return {
-                    amount: typeof output.value === 'number' ? output.value.toString() : output.value,
-                    script_pubkey: output.script.toString('hex'),
-                };
-            }),
-            extra_data: extraData ? extraData.toString('hex') : null,
+            inputs: tx.ins.map(input => ({
+                prev_index: input.index,
+                sequence: input.sequence,
+                prev_hash: reverseBuffer(input.hash).toString('hex'),
+                script_sig: input.script.toString('hex'),
+            })),
+            bin_outputs: tx.outs.map(output => ({
+                amount: typeof output.value === 'number' ? output.value.toString() : output.value,
+                script_pubkey: output.script.toString('hex'),
+            })),
+            extra_data: extraData ? extraData.toString('hex') : undefined,
             lock_time: tx.locktime,
             timestamp: tx.timestamp,
             version_group_id,

--- a/src/js/data/CoinInfo.js
+++ b/src/js/data/CoinInfo.js
@@ -29,8 +29,8 @@ export const getBitcoinNetwork = (pathOrName: number[] | string): ?BitcoinNetwor
     }
 };
 
-export const getEthereumNetwork = (pathOrName: number[] | string): ?EthereumNetworkInfo => {
-    const networks: EthereumNetworkInfo[] = cloneCoinInfo(ethereumNetworks);
+export const getEthereumNetwork = (pathOrName: number[] | string) => {
+    const networks = cloneCoinInfo(ethereumNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
         return networks.find(n => n.name.toLowerCase() === name || n.shortcut.toLowerCase() === name);

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -14,7 +14,7 @@ import Device from './Device';
 
 import { getSegwitNetwork, getBech32Network } from '../data/CoinInfo';
 
-import type { CoinInfo, BitcoinNetworkInfo, EthereumNetworkInfo } from '../types';
+import type { CoinInfo, BitcoinNetworkInfo, EthereumNetworkInfo, HDNodeResponse } from '../types';
 import type { Transport } from 'trezor-link';
 import * as trezor from '../types/trezor/protobuf'; // flowtype only
 
@@ -126,7 +126,7 @@ export default class DeviceCommands {
         coinInfo: ?BitcoinNetworkInfo,
         validation?: boolean = true,
         showOnTrezor?: boolean = false,
-    ): Promise<trezor.HDNodeResponse> {
+    ): Promise<HDNodeResponse> {
         if (!this.device.atLeast(['1.7.2', '2.0.10']) || !coinInfo) {
             return await this.getBitcoinHDNode(path, coinInfo);
         }
@@ -159,7 +159,7 @@ export default class DeviceCommands {
             publicKey = hdnodeUtils.xpubDerive(resKey, childKey, suffix, network, coinInfo.network);
         }
 
-        const response: trezor.HDNodeResponse = {
+        const response: HDNodeResponse = {
             path,
             serializedPath: getSerializedPath(path),
             childNum: publicKey.node.child_num,
@@ -186,7 +186,7 @@ export default class DeviceCommands {
         path: Array<number>,
         coinInfo?: ?BitcoinNetworkInfo,
         validation?: boolean = true
-    ): Promise<trezor.HDNodeResponse> {
+    ): Promise<HDNodeResponse> {
         let publicKey: trezor.PublicKey;
         if (!validation) {
             publicKey = await this.getPublicKey(path, 'Bitcoin');
@@ -199,7 +199,7 @@ export default class DeviceCommands {
             publicKey = hdnodeUtils.xpubDerive(resKey, childKey, suffix);
         }
 
-        const response: trezor.HDNodeResponse = {
+        const response: HDNodeResponse = {
             path,
             serializedPath: getSerializedPath(path),
             childNum: publicKey.node.child_num,
@@ -299,7 +299,7 @@ export default class DeviceCommands {
         return response.message;
     }
 
-    async ethereumGetPublicKey(address_n: Array<number>, showOnTrezor: boolean): Promise<trezor.HDNodeResponse> {
+    async ethereumGetPublicKey(address_n: Array<number>, showOnTrezor: boolean): Promise<HDNodeResponse> {
         if (!this.device.atLeast(['1.8.1', '2.1.0'])) {
             return await this.getHDNode(address_n);
         }

--- a/src/js/types/account.js
+++ b/src/js/types/account.js
@@ -1,5 +1,8 @@
 /* @flow */
-import type { TransactionInput, TransactionOutput } from './trezor/protobuf';
+import type {
+    TxInputType,
+    TxOutputType,
+} from './trezor/protobuf';
 import type { VinVout } from './backend/transactions';
 
 // getAccountInfo params
@@ -229,8 +232,8 @@ export type PrecomposedTransaction =
           feePerByte: string;
           bytes: number;
           transaction: {
-              inputs: TransactionInput[];
-              outputs: TransactionOutput[];
+              inputs: TxInputType[];
+              outputs: TxOutputType[];
           };
       };
 

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -184,8 +184,8 @@ export type API = {
     // Ethereum and Ethereum-like
     ethereumGetAddress: Bundled<Ethereum.EthereumGetAddress, Ethereum.EthereumAddress>;
     ethereumGetPublicKey: Bundled<Ethereum.EthereumGetPublicKey, Bitcoin.HDNodeResponse>;
-    ethereumSignTransaction: Bundled<Ethereum.EthereumSignTransaction, Protobuf.EthereumSignedTx>;
-    ethereumSignMessage: Method<Ethereum.EthereumSignMessage, Protobuf.MessageSignature>;
+    ethereumSignTransaction: Bundled<Ethereum.EthereumSignTransaction, Ethereum.EthereumSignedTx>;
+    ethereumSignMessage: Method<Ethereum.EthereumSignMessage, Protobuf.EthereumMessageSignature>;
     ethereumVerifyMessage: Method<Ethereum.EthereumVerifyMessage, P.DefaultMessage>;
 
     // Lisk

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -118,7 +118,7 @@ export type API = {
      * User is presented with a description of the requested key and asked to
      * confirm the export.
      */
-    getPublicKey: Bundled<Bitcoin.GetPublicKey, Protobuf.HDNodeResponse>;
+    getPublicKey: Bundled<Bitcoin.GetPublicKey, Bitcoin.HDNodeResponse>;
 
     /**
      * Bitcoin and Bitcoin-like
@@ -183,7 +183,7 @@ export type API = {
 
     // Ethereum and Ethereum-like
     ethereumGetAddress: Bundled<Ethereum.EthereumGetAddress, Ethereum.EthereumAddress>;
-    ethereumGetPublicKey: Bundled<Ethereum.EthereumGetPublicKey, Protobuf.HDNodeResponse>;
+    ethereumGetPublicKey: Bundled<Ethereum.EthereumGetPublicKey, Bitcoin.HDNodeResponse>;
     ethereumSignTransaction: Bundled<Ethereum.EthereumSignTransaction, Protobuf.EthereumSignedTx>;
     ethereumSignMessage: Method<Ethereum.EthereumSignMessage, Protobuf.MessageSignature>;
     ethereumVerifyMessage: Method<Ethereum.EthereumVerifyMessage, P.DefaultMessage>;

--- a/src/js/types/networks/bitcoin.js
+++ b/src/js/types/networks/bitcoin.js
@@ -113,7 +113,4 @@ export type VerifyMessage = {
     coin: string;
 };
 
-export type {
-    TxInputType as TransactionInput,
-    TxOutputType as TransactionOutput,
-} from '../trezor/protobuf';
+export type { TxInputType, TxOutputType } from '../trezor/protobuf';

--- a/src/js/types/networks/bitcoin.js
+++ b/src/js/types/networks/bitcoin.js
@@ -28,6 +28,19 @@ export type GetPublicKey = {
     crossChain?: boolean;
 };
 
+// combined Bitcoin.PublicKey and Bitcoin.HDNode
+export type HDNodeResponse = {
+    path: number[];
+    serializedPath: string;
+    childNum: number;
+    xpub: string;
+    xpubSegwit?: string;
+    chainCode: string;
+    publicKey: string;
+    fingerprint: number;
+    depth: number;
+};
+
 // signTransaction params
 export type SignTransaction = {
     inputs: TransactionInput[];

--- a/src/js/types/networks/bitcoin.js
+++ b/src/js/types/networks/bitcoin.js
@@ -1,10 +1,10 @@
 /* @flow */
 import type {
-    TransactionInput,
-    TransactionOutput,
-    RefTransaction,
+    RefTxInputType,
+    TxInputType,
+    TxOutputType,
+    TxOutputBinType,
     Address as ProtobufAddress,
-    SignedTx,
 } from '../trezor/protobuf';
 
 // getAddress params
@@ -18,6 +18,7 @@ export type GetAddress = {
 
 // getAddress response
 export type Address = ProtobufAddress & {
+    path: number[];
     serializedPath: string;
 };
 
@@ -41,10 +42,36 @@ export type HDNodeResponse = {
     depth: number;
 };
 
+// based on PROTO.TransactionType, with required fields
+export type RefTransaction = {
+    hash: string;
+    version?: number;
+    inputs: RefTxInputType[];
+    bin_outputs: TxOutputBinType[];
+    lock_time?: number;
+    extra_data?: string;
+    expiry?: number;
+    overwintered?: boolean;
+    version_group_id?: number;
+    timestamp?: number;
+    branch_id?: number;
+};
+
+// based on PROTO.SignTx, only optional fields
+export type TransactionOptions = {|
+    version?: number;
+    lock_time?: number;
+    expiry?: number;
+    overwintered?: boolean;
+    version_group_id?: number;
+    timestamp?: number;
+    branch_id?: number;
+|};
+
 // signTransaction params
 export type SignTransaction = {
-    inputs: TransactionInput[];
-    outputs: TransactionOutput[];
+    inputs: TxInputType[];
+    outputs: TxOutputType[];
     refTxs?: RefTransaction[];
     coin: string;
     locktime?: number;
@@ -56,7 +83,9 @@ export type SignTransaction = {
     branchId?: number;
     push?: boolean;
 };
-export type SignedTransaction = SignedTx & {
+export type SignedTransaction = {
+    signatures: string[];
+    serializedTx: string;
     txid?: string;
 }
 
@@ -84,4 +113,7 @@ export type VerifyMessage = {
     coin: string;
 };
 
-export type { TransactionInput, TransactionOutput } from '../trezor/protobuf';
+export type {
+    TxInputType as TransactionInput,
+    TxOutputType as TransactionOutput,
+} from '../trezor/protobuf';

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -1,9 +1,7 @@
 /* @flow */
 
-import { ADDRESS_TYPE, CERTIFICATE_TYPE } from '../../constants/cardano';
-
 // Cardano method parameters types
-import type { HDPubNode } from '../trezor/protobuf';
+import type { HDNodeType, CardanoAddressType, CardanoCertificateType } from '../trezor/protobuf';
 
 // GetPublicKey
 
@@ -16,13 +14,10 @@ export type CardanoPublicKey = {
     path: number[];
     serializedPath: string;
     publicKey: string;
-    node: HDPubNode;
+    node: HDNodeType;
 }
 
 // GetAddress
-
-export type CardanoAddressType = $Values<typeof ADDRESS_TYPE>;
-
 export type CardanoCertificatePointer = {
     blockIndex: number;
     txIndex: number;
@@ -55,8 +50,6 @@ export type CardanoAddress = {
 }
 
 // Sign transaction
-
-export type CardanoCertificateType = $Values<typeof CERTIFICATE_TYPE>;
 
 export type CardanoInput = {
     path: string | number[];

--- a/src/js/types/networks/eos.js
+++ b/src/js/types/networks/eos.js
@@ -8,6 +8,7 @@ import type {
     EosActionDeleteAuth,
     EosActionLinkAuth,
     EosActionUnlinkAuth,
+    EosAuthorizationWait,
 } from '../trezor/protobuf';
 
 // get public key
@@ -42,10 +43,7 @@ export type EosAuthorization = {
         permission: EosPermissionLevel;
         weight: number;
     }>;
-    waits: Array<{
-        wait_sec: number;
-        weight: number;
-    }>;
+    waits: EosAuthorizationWait[];
 }
 
 export type EosTxActionCommon = {

--- a/src/js/types/networks/ethereum.js
+++ b/src/js/types/networks/ethereum.js
@@ -41,6 +41,12 @@ export type EthereumSignTransaction = {
     transaction: EthereumTransaction;
 }
 
+export type EthereumSignedTx = {
+    v: string;
+    r: string;
+    s: string;
+};
+
 // sign message
 
 export type EthereumSignMessage = {

--- a/src/js/types/networks/stellar.js
+++ b/src/js/types/networks/stellar.js
@@ -98,7 +98,7 @@ export type StellarManageDataOperation = {
     type: 'manageData'; // Proto: "StellarManageDataOp"
     source?: string; // Proto: "source_account"
     name: string; // Proto: "key"
-    value?: ?(string | Buffer); // Proto: "value"
+    value?: Buffer | string; // Proto: "value"
 }
 
 // (?) Missing in stellar API but present in Proto messages
@@ -149,6 +149,44 @@ export type StellarSignTransaction = {
     networkPassphrase: string;
     transaction: StellarTransaction;
 }
+
+import type {
+    StellarPaymentOp,
+    StellarCreateAccountOp,
+    StellarPathPaymentOp,
+    StellarManageOfferOp,
+    StellarCreatePassiveOfferOp,
+    StellarSetOptionsOp,
+    StellarChangeTrustOp,
+    StellarAllowTrustOp,
+    StellarAccountMergeOp,
+    StellarManageDataOp,
+    StellarBumpSequenceOp,
+} from '../trezor/protobuf';
+
+export type StellarOperationMessage = ({
+    type: 'StellarCreateAccountOp';
+} & StellarCreateAccountOp) | ({
+    type: 'StellarPaymentOp';
+} & StellarPaymentOp) | ({
+    type: 'StellarPathPaymentOp';
+} & StellarPathPaymentOp) | ({
+    type: 'StellarManageOfferOp';
+} & StellarManageOfferOp) | ({
+    type: 'StellarCreatePassiveOfferOp';
+} & StellarCreatePassiveOfferOp) | ({
+    type: 'StellarSetOptionsOp';
+} & StellarSetOptionsOp) | ({
+    type: 'StellarChangeTrustOp';
+} & StellarChangeTrustOp) | ({
+    type: 'StellarAllowTrustOp';
+} & StellarAllowTrustOp) | ({
+    type: 'StellarAccountMergeOp';
+} & StellarAccountMergeOp) | ({
+    type: 'StellarManageDataOp';
+} & StellarManageDataOp) | ({
+    type: 'StellarBumpSequenceOp';
+} & StellarBumpSequenceOp);
 
 export type StellarSignedTx = {
     publicKey: string;

--- a/src/js/types/trezor/device.js
+++ b/src/js/types/trezor/device.js
@@ -1,5 +1,6 @@
 /* @flow */
 import { DEVICE } from '../../constants';
+import type { Features } from './protobuf';
 
 export type DeviceStateResponse = {
     state: string;
@@ -51,42 +52,6 @@ export type FirmwareRelease = {
     isNewer: boolean | null;
 }
 
-export type Features = {
-    bootloader_hash?: string | null;
-    bootloader_mode?: boolean | null;
-    device_id: string | null;
-    firmware_present?: boolean | null;
-    flags: number;
-    fw_major?: number | null;
-    fw_minor?: number | null;
-    fw_patch?: number | null;
-    fw_vendor?: string | null;
-    fw_vendor_keys?: string | null;
-    imported?: boolean | null;
-    initialized: boolean;
-    label: string | null;
-    language?: string | null;
-    major_version: number;
-    minor_version: number;
-    model: string;
-    needs_backup: boolean;
-    no_backup: boolean;
-    passphrase_cached: boolean;
-    passphrase_protection: boolean;
-    patch_version: number;
-    pin_cached: boolean;
-    unlocked?: boolean; // replacement for "pin_cached" since 2.3.2
-    pin_protection: boolean;
-    revision: string;
-    unfinished_backup: boolean;
-    vendor: string;
-    recovery_mode?: boolean;
-    session_id?: string;
-    passphrase_always_on_device?: boolean;
-    capabilities?: string[];
-    backup_type?: 'Bip39' | 'Slip39_Basic' | 'Slip39_Advanced' | null;
-}
-
 export type KnownDevice = {|
     type: 'acquired';
     id: string | null;
@@ -124,3 +89,5 @@ export type DeviceEvent = {
         | typeof DEVICE.DISCONNECT;
     payload: Device;
 };
+
+export type { Features } from './protobuf';

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -1,103 +1,306 @@
-/* @flow */
+// @flow
+// This file is auto generated from data/messages/message.json
+const Enum_InputScriptType = Object.freeze({
+    SPENDADDRESS: 0,
+    SPENDMULTISIG: 1,
+    EXTERNAL: 2,
+    SPENDWITNESS: 3,
+    SPENDP2SHWITNESS: 4,
+});
+export type InputScriptType = $Keys<typeof Enum_InputScriptType>;
 
-// This file has all various types that go into Trezor or out of it.
+const Enum_CardanoAddressType = Object.freeze({
+    BASE: 0,
+    BASE_SCRIPT_KEY: 1,
+    BASE_KEY_SCRIPT: 2,
+    BASE_SCRIPT_SCRIPT: 3,
+    POINTER: 4,
+    POINTER_SCRIPT: 5,
+    ENTERPRISE: 6,
+    ENTERPRISE_SCRIPT: 7,
+    BYRON: 8,
+    REWARD: 14,
+    REWARD_SCRIPT: 15,
+});
+export type CardanoAddressType = $Values<typeof Enum_CardanoAddressType>;
 
-export type CipheredKeyValue = {
-    value: string;
-}
+const Enum_CardanoCertificateType = Object.freeze({
+    STAKE_REGISTRATION: 0,
+    STAKE_DEREGISTRATION: 1,
+    STAKE_DELEGATION: 2,
+});
+export type CardanoCertificateType = $Values<typeof Enum_CardanoCertificateType>;
 
-export type Success = {};
+const Enum_BackupType = Object.freeze({
+    Bip39: 0,
+    Slip39_Basic: 1,
+    Slip39_Advanced: 2,
+});
+export type BackupType = $Keys<typeof Enum_BackupType>;
 
-export type Features = {
-    vendor: string;
-    major_version: number;
-    minor_version: number;
-    patch_version: number;
-    bootloader_mode: boolean;
-    device_id: string;
-    pin_protection: boolean;
-    passphrase_protection: boolean;
-    language: string;
-    label: string;
-    initialized: boolean;
-    revision: string;
-    bootloader_hash: string;
-    imported: boolean;
-    pin_cached: boolean;
-    unlocked?: boolean; // replacement for "pin_cached" since 2.3.2
-    passphrase_cached: boolean;
-    firmware_present: boolean;
-    needs_backup: boolean;
-    flags: number;
-    model: string;
-    fw_major: number;
-    fw_minor: number;
-    fw_patch: number;
-    fw_vendor: string;
-    fw_vendor_keys: string;
-    unfinished_backup: boolean;
-    no_backup: boolean;
+// BinanceGetAddress
+export type BinanceGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
 };
 
-export type HDPrivNode = {
-    depth: number;
-    fingerprint: number;
-    child_num: number;
-    chain_code: string;
-    private_key: string;
+// BinanceAddress
+export type BinanceAddress = {
+    address: string;
 };
 
-export type HDPubNode = {
-    depth: number;
-    fingerprint: number;
-    child_num: number;
-    chain_code: string;
+// BinanceGetPublicKey
+export type BinanceGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// BinancePublicKey
+export type BinancePublicKey = {
     public_key: string;
 };
 
-export type HDNode = HDPubNode | HDPrivNode;
+// BinanceSignTx
+export type BinanceSignTx = {
+    address_n: number[];
+    msg_count?: number;
+    account_number?: number;
+    chain_id?: string;
+    memo?: string;
+    sequence?: number;
+    source?: number;
+};
 
+// BinanceTxRequest
+export type BinanceTxRequest = {};
+
+export type BinanceCoin = {
+    amount?: number;
+    denom?: string;
+};
+
+export type BinanceInputOutput = {
+    address?: string;
+    coins: BinanceCoin[];
+};
+
+// BinanceTransferMsg
+export type BinanceTransferMsg = {
+    inputs: BinanceInputOutput[];
+    outputs: BinanceInputOutput[];
+};
+
+const Enum_BinanceOrderType = Object.freeze({
+    OT_UNKNOWN: 0,
+    MARKET: 1,
+    LIMIT: 2,
+    OT_RESERVED: 3,
+});
+export type BinanceOrderType = $Values<typeof Enum_BinanceOrderType>;
+
+const Enum_BinanceOrderSide = Object.freeze({
+    SIDE_UNKNOWN: 0,
+    BUY: 1,
+    SELL: 2,
+});
+export type BinanceOrderSide = $Values<typeof Enum_BinanceOrderSide>;
+
+const Enum_BinanceTimeInForce = Object.freeze({
+    TIF_UNKNOWN: 0,
+    GTE: 1,
+    TIF_RESERVED: 2,
+    IOC: 3,
+});
+export type BinanceTimeInForce = $Values<typeof Enum_BinanceTimeInForce>;
+
+// BinanceOrderMsg
+export type BinanceOrderMsg = {
+    id?: string;
+    ordertype?: BinanceOrderType;
+    price?: number;
+    quantity?: number;
+    sender?: string;
+    side?: BinanceOrderSide;
+    symbol?: string;
+    timeinforce?: BinanceTimeInForce;
+};
+
+// BinanceCancelMsg
+export type BinanceCancelMsg = {
+    refid?: string;
+    sender?: string;
+    symbol?: string;
+};
+
+// BinanceSignedTx
+export type BinanceSignedTx = {
+    signature: string;
+    public_key: string;
+};
+
+// HDNodeType
+export type HDNodeType = {
+    depth: number;
+    fingerprint: number;
+    child_num: number;
+    chain_code: string;
+    private_key?: string;
+    public_key: string;
+};
+
+export type HDNodePathType = {
+    node: HDNodeType | string;
+    address_n: number[];
+};
+
+// MultisigRedeemScriptType
+export type MultisigRedeemScriptType = {
+    pubkeys: HDNodePathType[];
+    signatures: string[];
+    m?: number;
+    nodes?: HDNodeType[];
+    address_n?: number[];
+};
+
+// GetPublicKey
+export type GetPublicKey = {
+    address_n: number[];
+    ecdsa_curve_name?: string;
+    show_display?: boolean;
+    coin_name?: string;
+    script_type?: InputScriptType;
+};
+
+// PublicKey
 export type PublicKey = {
-    node: HDPubNode;
+    node: HDNodeType;
     xpub: string;
 };
 
-// Bitcoin.getAddress response
+// GetAddress
+export type GetAddress = {
+    address_n: number[];
+    coin_name?: string;
+    show_display?: boolean;
+    multisig?: MultisigRedeemScriptType;
+    script_type?: InputScriptType;
+};
+
+// Address
 export type Address = {
     address: string;
-    path: number[];
-}
+};
 
+// GetOwnershipId
+export type GetOwnershipId = {
+    address_n: number[];
+    coin_name?: string;
+    multisig?: MultisigRedeemScriptType;
+    script_type?: InputScriptType;
+};
+
+// OwnershipId
+export type OwnershipId = {
+    ownership_id: string;
+};
+
+// SignMessage
+export type SignMessage = {
+    address_n: number[];
+    message: string;
+    coin_name?: string;
+    script_type?: InputScriptType;
+};
+
+// MessageSignature
 export type MessageSignature = {
     address: string;
     signature: string;
-}
+};
 
-// Bitcoin.signTransaction
+// VerifyMessage
+export type VerifyMessage = {
+    address?: string;
+    signature?: string;
+    message?: string;
+    coin_name?: string;
+};
 
-export type MultisigRedeemScriptType = {
-    pubkeys: Array<{ node: string | HDPubNode; address_n: number[] }>;
-    signatures: string[];
-    m?: number;
-}
+// SignTx
+export type SignTx = {
+    outputs_count: number;
+    inputs_count: number;
+    coin_name?: string;
+    version?: number;
+    lock_time?: number;
+    expiry?: number;
+    overwintered?: boolean;
+    version_group_id?: number;
+    timestamp?: number;
+    branch_id?: number;
+};
 
-export type InputScriptType = 'SPENDADDRESS' | 'SPENDMULTISIG' | 'SPENDWITNESS' | 'SPENDP2SHWITNESS';
+const Enum_RequestType = Object.freeze({
+    TXINPUT: 0,
+    TXOUTPUT: 1,
+    TXMETA: 2,
+    TXFINISHED: 3,
+    TXEXTRADATA: 4,
+});
+export type RequestType = $Keys<typeof Enum_RequestType>;
 
-// transaction input, parameter of SignTx message, declared by user
-export type TransactionInput = {|
+export type TxRequestDetailsType = {
+    request_index: number;
+    tx_hash?: string;
+    extra_data_len?: number;
+    extra_data_offset?: number;
+};
+
+export type TxRequestSerializedType = {
+    signature_index?: number;
+    signature?: string;
+    serialized_tx?: string;
+};
+
+// TxRequest
+export type TxRequest = {
+    request_type: RequestType;
+    details: TxRequestDetailsType;
+    serialized?: TxRequestSerializedType;
+};
+
+export type TxInputType = {
     address_n: number[];
     prev_hash: string;
     prev_index: number;
-    script_type?: InputScriptType;
+    script_sig?: string;
     sequence?: number;
-    amount?: string; // (segwit, bip143: true, zcash overwinter)
+    script_type?: InputScriptType;
     multisig?: MultisigRedeemScriptType;
-|};
+    amount?: number | string;
+    decred_tree?: number;
+    witness?: string;
+    ownership_proof?: string;
+};
 
-export type OutputScriptType = 'PAYTOADDRESS' | 'PAYTOMULTISIG' | 'PAYTOWITNESS' | 'PAYTOP2SHWITNESS';
+export type TxOutputBinType = {
+    amount: number | string;
+    script_pubkey: string;
+    decred_script_version?: number;
+};
 
-// transaction output, parameter of SignTx message, declared by user
-export type TransactionOutput = {|
+const Enum_OutputScriptType = Object.freeze({
+    PAYTOADDRESS: 0,
+    PAYTOSCRIPTHASH: 1,
+    PAYTOMULTISIG: 2,
+    PAYTOOPRETURN: 3,
+    PAYTOWITNESS: 4,
+    PAYTOP2SHWITNESS: 5,
+});
+export type OutputScriptType = $Keys<typeof Enum_OutputScriptType>;
+
+// - replacement
+export type TxOutputType = {|
     address: string;
     address_n?: typeof undefined;
     script_type: 'PAYTOADDRESS';
@@ -116,88 +319,293 @@ export type TransactionOutput = {|
     op_return_data: string;
     script_type: 'PAYTOOPRETURN';
 |};
+// - replacement end
 
-type TransactionBinOutput = {
-    amount: string;
-    script_pubkey: string;
-};
-
-// transaction input, parameter of TxAck message, declared by user or downloaded from backend
-export type RefTransactionInput = {|
+// TxAck
+// - replacement
+export type RefTxInputType = {|
     prev_hash: string;
     prev_index: number;
     script_sig: string;
     sequence: number;
 |};
 
-export type RefTransaction = {
-    hash: string;
-    version?: ?number;
-    inputs: Array<RefTransactionInput>;
-    bin_outputs: Array<TransactionBinOutput>;
-    lock_time?: ?number;
-    extra_data?: ?string;
-    timestamp?: ?number;
-    version_group_id?: ?number;
-    expiry?: ?number;
-    branch_id?: ?number;
-};
-
-export type TransactionOptions = {
-    lock_time?: ?number;
-    timestamp?: ?number;
-    version?: ?number;
-    expiry?: ?number;
-    overwintered?: ?boolean;
-    version_group_id?: ?number;
-    branch_id?: ?number;
-};
-
-export type TxRequestDetails = {
-    request_index: number;
-    tx_hash?: string;
+export type TxAckResponse = {|
+    inputs: Array<TxInputType | RefTxInputType>;
+|} | {|
+    bin_outputs: TxOutputBinType[];
+|} | {|
+    outputs: TxOutputType[];
+|} | {|
+    extra_data: string;
+|} | {|
+    version?: number;
+    lock_time?: number;
+    inputs_cnt: number;
+    outputs_cnt: number;
+    extra_data?: string;
     extra_data_len?: number;
-    extra_data_offset?: number;
+    timestamp?: number;
+    version_group_id?: number;
+    expiry?: number;
+    branch_id?: number;
+|};
+
+export type TxAck = {
+    tx: TxAckResponse;
+};
+// - replacement end
+
+// GetOwnershipProof
+export type GetOwnershipProof = {
+    address_n: number[];
+    coin_name?: string;
+    script_type?: InputScriptType;
+    multisig?: MultisigRedeemScriptType;
+    user_confirmation?: boolean;
+    ownership_ids: string[];
+    commitment_data?: string;
 };
 
-export type TxRequestSerialized = {
-    signature_index?: number;
-    signature?: string;
-    serialized_tx?: string;
+// OwnershipProof
+export type OwnershipProof = {
+    ownership_proof: string;
+    signature: string;
 };
 
-export type TxRequest = {
-    request_type: 'TXINPUT' | 'TXOUTPUT' | 'TXMETA' | 'TXFINISHED' | 'TXEXTRADATA';
-    details: TxRequestDetails;
-    serialized: TxRequestSerialized;
+// AuthorizeCoinJoin
+export type AuthorizeCoinJoin = {
+    coordinator: string;
+    max_total_fee: number;
+    fee_per_anonymity?: number;
+    address_n: number[];
+    coin_name?: string;
+    script_type?: InputScriptType;
 };
 
-export type SignedTx = {
-    signatures: string[];
-    serializedTx: string;
+// FirmwareErase
+export type FirmwareErase = {
+    length?: number;
 };
 
-// Ethereum.signTransaction
-
-export type EthereumTxRequest = {
-    data_length?: number;
-    signature_v?: number;
-    signature_r?: string;
-    signature_s?: string;
+// FirmwareRequest
+export type FirmwareRequest = {
+    offset?: number;
+    length?: number;
 };
 
-export type EthereumAddress = {
+// FirmwareUpload
+export type FirmwareUpload = {
+    payload: Buffer;
+    hash?: string;
+};
+
+// SelfTest
+export type SelfTest = {
+    payload?: string;
+};
+
+// CardanoBlockchainPointerType
+export type CardanoBlockchainPointerType = {
+    block_index: number;
+    tx_index: number;
+    certificate_index: number;
+};
+
+// CardanoAddressParametersType
+export type CardanoAddressParametersType = {
+    address_type: CardanoAddressType;
+    address_n: number[];
+    address_n_staking: number[];
+    staking_key_hash?: string;
+    certificate_pointer?: CardanoBlockchainPointerType;
+};
+
+// CardanoGetAddress
+export type CardanoGetAddress = {
+    show_display?: boolean;
+    protocol_magic: number;
+    network_id: number;
+    address_parameters: CardanoAddressParametersType;
+};
+
+// CardanoAddress
+export type CardanoAddress = {
     address: string;
 };
 
-export type EthereumSignedTx = {
-    // v: number,
-    v: string;
-    r: string;
-    s: string;
+// CardanoGetPublicKey
+export type CardanoGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
 };
 
-export type Identity = {
+// CardanoPublicKey
+export type CardanoPublicKey = {
+    xpub: string;
+    node: HDNodeType;
+};
+
+export type CardanoTxInputType = {
+    address_n: number[];
+    prev_hash?: string;
+    prev_index?: number;
+};
+
+export type CardanoTxOutputType = {
+    address?: string;
+    amount?: number;
+    address_parameters?: CardanoAddressParametersType;
+};
+
+export type CardanoTxCertificateType = {
+    type?: CardanoCertificateType;
+    path: number[];
+    pool?: string;
+};
+
+export type CardanoTxWithdrawalType = {
+    path: number[];
+    amount?: number;
+};
+
+// CardanoSignTx
+export type CardanoSignTx = {
+    inputs: CardanoTxInputType[];
+    outputs: CardanoTxOutputType[];
+    protocol_magic?: number;
+    fee?: string | number;
+    ttl?: string | number;
+    network_id?: number;
+    certificates: CardanoTxCertificateType[];
+    withdrawals: CardanoTxWithdrawalType[];
+    metadata?: string;
+};
+
+// CardanoSignedTx
+export type CardanoSignedTx = {
+    tx_hash: string;
+    serialized_tx: string;
+};
+
+// Success
+export type Success = {
+    message: string;
+};
+
+const Enum_FailureType = Object.freeze({
+    Failure_UnexpectedMessage: 1,
+    Failure_ButtonExpected: 2,
+    Failure_DataError: 3,
+    Failure_ActionCancelled: 4,
+    Failure_PinExpected: 5,
+    Failure_PinCancelled: 6,
+    Failure_PinInvalid: 7,
+    Failure_InvalidSignature: 8,
+    Failure_ProcessError: 9,
+    Failure_NotEnoughFunds: 10,
+    Failure_NotInitialized: 11,
+    Failure_PinMismatch: 12,
+    Failure_WipeCodeMismatch: 13,
+    Failure_FirmwareError: 99,
+});
+export type FailureType = $Values<typeof Enum_FailureType>;
+
+// Failure
+export type Failure = {
+    code?: FailureType;
+    message?: string;
+};
+
+const Enum_ButtonRequestType = Object.freeze({
+    ButtonRequest_Other: 1,
+    ButtonRequest_FeeOverThreshold: 2,
+    ButtonRequest_ConfirmOutput: 3,
+    ButtonRequest_ResetDevice: 4,
+    ButtonRequest_ConfirmWord: 5,
+    ButtonRequest_WipeDevice: 6,
+    ButtonRequest_ProtectCall: 7,
+    ButtonRequest_SignTx: 8,
+    ButtonRequest_FirmwareCheck: 9,
+    ButtonRequest_Address: 10,
+    ButtonRequest_PublicKey: 11,
+    ButtonRequest_MnemonicWordCount: 12,
+    ButtonRequest_MnemonicInput: 13,
+    _Deprecated_ButtonRequest_PassphraseType: 14,
+    ButtonRequest_UnknownDerivationPath: 15,
+    ButtonRequest_RecoveryHomepage: 16,
+    ButtonRequest_Success: 17,
+    ButtonRequest_Warning: 18,
+    ButtonRequest_PassphraseEntry: 19,
+    ButtonRequest_PinEntry: 20,
+});
+export type ButtonRequestType = $Values<typeof Enum_ButtonRequestType>;
+
+// ButtonRequest
+export type ButtonRequest = {
+    code?: ButtonRequestType;
+};
+
+// ButtonAck
+export type ButtonAck = {};
+
+const Enum_PinMatrixRequestType = Object.freeze({
+    PinMatrixRequestType_Current: 1,
+    PinMatrixRequestType_NewFirst: 2,
+    PinMatrixRequestType_NewSecond: 3,
+    PinMatrixRequestType_WipeCodeFirst: 4,
+    PinMatrixRequestType_WipeCodeSecond: 5,
+});
+export type PinMatrixRequestType = $Values<typeof Enum_PinMatrixRequestType>;
+
+// PinMatrixRequest
+export type PinMatrixRequest = {
+    type?: PinMatrixRequestType;
+};
+
+// PinMatrixAck
+export type PinMatrixAck = {
+    pin: string;
+};
+
+// PassphraseRequest
+export type PassphraseRequest = {
+    _on_device?: boolean;
+};
+
+// PassphraseAck
+export type PassphraseAck = {
+    passphrase?: string;
+    _state?: string;
+    on_device?: boolean;
+};
+
+// Deprecated_PassphraseStateRequest
+export type Deprecated_PassphraseStateRequest = {
+    state?: string;
+};
+
+// Deprecated_PassphraseStateAck
+export type Deprecated_PassphraseStateAck = {};
+
+// CipherKeyValue
+export type CipherKeyValue = {
+    address_n: number[];
+    key?: string;
+    value?: string;
+    encrypt?: boolean;
+    ask_on_encrypt?: boolean;
+    ask_on_decrypt?: boolean;
+    iv?: string;
+};
+
+// CipheredKeyValue
+export type CipheredKeyValue = {
+    value?: string;
+};
+
+// IdentityType
+export type IdentityType = {
     proto?: string;
     user?: string;
     host?: string;
@@ -206,481 +614,167 @@ export type Identity = {
     index?: number;
 };
 
+// SignIdentity
+export type SignIdentity = {
+    identity?: IdentityType;
+    challenge_hidden?: string;
+    challenge_visual?: string;
+    ecdsa_curve_name?: string;
+};
+
+// SignedIdentity
 export type SignedIdentity = {
     address: string;
     public_key: string;
     signature: string;
 };
 
-// this is what Trezor asks for
-export type SignTxInfoToTrezor = {
-    inputs: Array<TransactionInput | RefTransactionInput>;
-} | {
-    bin_outputs: Array<TransactionBinOutput>;
-} | {
-    outputs: Array<TransactionOutput>;
-} | {
-    extra_data: string;
-} | {
-    version: ?number;
-    lock_time: ?number;
-    inputs_cnt: number;
-    outputs_cnt: number;
-    extra_data_len?: number;
-    timestamp: ?number;
-    version_group_id: ?number;
+// GetECDHSessionKey
+export type GetECDHSessionKey = {
+    identity?: IdentityType;
+    peer_public_key?: string;
+    ecdsa_curve_name?: string;
 };
 
-// NEM types
-export type NEMAddress = {
-    address: string;
-}
-
-export type NEMSignedTx = {
-    data: string;
-    signature: string;
-}
-
-export type NEMTransactionCommon = {
-    address_n: ?Array<number>;
-    network: ?number;
-    timestamp: ?number;
-    fee: ?number;
-    deadline: ?number;
-    signer: ?string;
-}
-
-export type NEMMosaic = {
-    namespace: ?string;
-    mosaic: ?string;
-    quantity: ?number;
-}
-
-export type NEMTransfer = {
-    mosaics: ?Array<NEMMosaic>;
-    public_key: ?string;
-    recipient: ?string;
-    amount: number | string;
-    payload: ?string;
-}
-
-export type NEMProvisionNamespace = {
-    namespace: ?string;
-    sink: ?string;
-    fee: ?number;
-    parent: ?string;
-}
-
-export type NEMMosaicLevyType = {
-    id: 1;
-    name: 'MosaicLevy_Absolute';
-} | {
-    id: 2;
-    name: 'MosaicLevy_Percentile';
-}
-
-export type NEMSupplyChangeType = {
-    id: 1;
-    name: 'SupplyChange_Increase';
-} | {
-    id: 2;
-    name: 'SupplyChange_Decrease';
-}
-
-export type NEMModificationType = {
-    id: 1;
-    name: 'CosignatoryModification_Add';
-} | {
-    id: 2;
-    name: 'CosignatoryModification_Delete';
-}
-
-export type NEMImportanceTransferMode = {
-    id: 1;
-    name: 'ImportanceTransfer_Activate';
-} | {
-    id: 2;
-    name: 'ImportanceTransfer_Deactivate';
-}
-
-export type NEMMosaicDefinition = {
-    name?: string;
-    ticker?: string;
-    namespace?: string;
-    mosaic?: string;
-    divisibility?: number;
-    fee?: number;
-    levy?: NEMMosaicLevyType;
-    levy_address?: string;
-    levy_namespace?: string;
-    levy_mosaic?: string;
-    supply?: number;
-    mutable_supply?: boolean;
-    transferable?: boolean;
-    description?: string;
-    networks?: number;
-}
-
-export type NEMMosaicCreation = {
-    definition: ?NEMMosaicDefinition;
-    sink: ?string;
-    fee: ?number;
-}
-
-export type NEMMosaicSupplyChange = {
-    namespace?: string;
-    type?: NEMSupplyChangeType;
-    mosaic?: string;
-    delta?: number;
-}
-
-export type NEMCosignatoryModification = {
-    type?: NEMModificationType;
-    public_key?: string;
-}
-
-export type NEMAggregateModification = {
-    modifications: ?Array<NEMCosignatoryModification>;
-    relative_change: ?number; // TODO: "sint32"
-}
-
-export type NEMImportanceTransfer = {
-    mode?: NEMImportanceTransferMode;
-    public_key?: string;
-}
-
-export type NEMSignTxMessage = {
-    transaction?: NEMTransactionCommon;
-    cosigning?: boolean;
-    multisig?: NEMTransactionCommon;
-    transfer?: NEMTransfer;
-    provision_namespace?: NEMProvisionNamespace;
-    mosaic_creation?: NEMMosaicCreation;
-    supply_change?: NEMMosaicSupplyChange;
-    aggregate_modification?: NEMAggregateModification;
-    importance_transfer?: NEMImportanceTransfer;
-}
-
-// Stellar types
-
-export type StellarAddress = {
-    address: string;
-}
-
-export type StellarSignedTx = {
-    public_key: string;
-    signature: string;
-}
-
-export type StellarPaymentOp = {
-    type: "StellarTxOpRequest";
-    message: {};
-}
-
-export type StellarSignTxMessage = {|
-    address_n: Array<number>;
-    source_account: string;
-    fee: number;
-    sequence_number: string | number;
-    network_passphrase: string;
-    timebounds_start?: number;
-    timebounds_end?: number;
-    memo_type?: number;
-    memo_text?: string | typeof undefined;
-    memo_id?: string | typeof undefined;
-    memo_hash?: string | Buffer | typeof undefined;
-    num_operations: number;
-|}
-
-export type StellarAsset = {
-    type: 0 | 1 | 2;
-    code: string;
-    issuer?: string;
-}
-
-export type StellarOperationMessage = {
-    type: 'StellarCreateAccountOp';
-    source_account?: string;
-    new_account: string;
-    starting_balance: string;
-} | {
-    type: 'StellarPaymentOp';
-    source_account?: string;
-    destination_account: string;
-    asset: StellarAsset | typeof undefined;
-    amount: string;
-} | {
-    type: 'StellarPathPaymentOp';
-    source_account?: string;
-    send_asset: StellarAsset;
-    send_max: string;
-    destination_account: string;
-    destination_asset: StellarAsset;
-    destination_amount: string;
-    paths?: Array<StellarAsset> | typeof undefined;
-} | {
-    type: 'StellarManageOfferOp';
-    source_account?: string;
-    offer_id?: string;
-    amount: string;
-    buying_asset: StellarAsset;
-    selling_asset: StellarAsset;
-    price_n: number;
-    price_d: number;
-} | {
-    type: 'StellarCreatePassiveOfferOp';
-    source_account?: string;
-    offer_id?: string;
-    amount: string;
-    buying_asset: StellarAsset;
-    selling_asset: StellarAsset;
-    price_n: number;
-    price_d: number;
-} | {
-    type: 'StellarSetOptionsOp';
-    source_account?: string;
-    signer_type?: number | typeof undefined;
-    signer_key?: string | Buffer | typeof undefined;
-    signer_weight?: number | typeof undefined;
-    clear_flags: ?number;
-    set_flags: ?number;
-    master_weight: ?(number | string);
-    low_threshold: ?(number | string);
-    medium_threshold: ?(number | string);
-    high_threshold: ?(number | string);
-    home_domain: ?string;
-    inflation_destination_account: ?string;
-} | {
-    type: 'StellarChangeTrustOp';
-    source_account?: string;
-    asset: StellarAsset;
-    limit?: string;
-} | {
-    type: 'StellarAllowTrustOp';
-    source_account?: string;
-    trusted_account: string;
-    asset_type: number;
-    asset_code: string;
-    is_authorized: ?number;
-} | {
-    type: 'StellarAccountMergeOp';
-    source_account?: string;
-    destination_account: string;
-} | {
-    type: 'StellarManageDataOp';
-    source_account?: string;
-    key: string;
-    value: ?(string | Buffer);
-} | {
-    type: 'StellarBumpSequenceOp';
-    source_account?: string;
-    bump_to: string | number;
-}
-
-// Tezos types
-export type TezosAddress = {
-    address: string;
+// ECDHSessionKey
+export type ECDHSessionKey = {
+    session_key?: string;
 };
 
-export type TezosPublicKey = {
-    public_key: string;
+const Enum_DebugSwipeDirection = Object.freeze({
+    UP: 0,
+    DOWN: 1,
+    LEFT: 2,
+    RIGHT: 3,
+});
+export type DebugSwipeDirection = $Values<typeof Enum_DebugSwipeDirection>;
+
+// DebugLinkDecision
+export type DebugLinkDecision = {
+    yes_no?: boolean;
+    swipe?: DebugSwipeDirection;
+    input?: string;
+    x?: number;
+    y?: number;
+    wait?: boolean;
 };
 
-type TezosContractID = {
-    tag: number;
-    hash: Uint8Array;
+// DebugLinkLayout
+export type DebugLinkLayout = {
+    lines: string[];
 };
 
-export type TezosRevealOp = {
-    source: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
-    public_key: Uint8Array;
+// DebugLinkReseedRandom
+export type DebugLinkReseedRandom = {
+    value?: number;
 };
 
-export type TezosManagerTransfer = {
-    amount: number;
-    destination: TezosContractID;
+// DebugLinkRecordScreen
+export type DebugLinkRecordScreen = {
+    target_directory?: string;
 };
 
-export type TezosParametersManager = {
-    set_delegate?: Uint8Array;
-    cancel_delegate?: boolean;
-    transfer?: TezosManagerTransfer;
+const Enum_DebugLinkShowTextStyle = Object.freeze({
+    NORMAL: 0,
+    BOLD: 1,
+    MONO: 2,
+    BR: 4,
+    BR_HALF: 5,
+    SET_COLOR: 6,
+});
+export type DebugLinkShowTextStyle = $Values<typeof Enum_DebugLinkShowTextStyle>;
+
+export type DebugLinkShowTextItem = {
+    style?: DebugLinkShowTextStyle;
+    content?: string;
 };
 
-export type TezosTransactionOp = {
-    source: Uint8Array;
-    destination: TezosContractID;
-    amount: number;
-    counter: number;
-    fee: number;
-    gas_limit: number;
-    storage_limit: number;
-    parameters?: Array<number>;
-    parameters_manager?: TezosParametersManager;
+// DebugLinkShowText
+export type DebugLinkShowText = {
+    header_text?: string;
+    body_text: DebugLinkShowTextItem[];
+    header_icon?: string;
+    icon_color?: string;
 };
 
-export type TezosOriginationOp = {
-    source: Uint8Array;
-    balance: number;
-    delegate?: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
-    script: string | number[];
+// DebugLinkGetState
+export type DebugLinkGetState = {
+    wait_word_list?: boolean;
+    wait_word_pos?: boolean;
+    wait_layout?: boolean;
 };
 
-export type TezosDelegationOp = {
-    source: Uint8Array;
-    delegate: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
+// DebugLinkState
+export type DebugLinkState = {
+    layout?: string;
+    pin?: string;
+    matrix?: string;
+    mnemonic_secret?: string;
+    node?: HDNodeType;
+    passphrase_protection?: boolean;
+    reset_word?: string;
+    reset_entropy?: string;
+    recovery_fake_word?: string;
+    recovery_word_pos?: number;
+    reset_word_pos?: number;
+    mnemonic_type?: number;
+    layout_lines: string[];
 };
 
-export type TezosTransaction = {
-    address_n: Array<number>;
-    branch: Uint8Array;
-    reveal?: TezosRevealOp;
-    transaction?: TezosTransactionOp;
-    origination?: TezosOriginationOp;
-    delegation?: TezosDelegationOp;
+// DebugLinkStop
+export type DebugLinkStop = {};
+
+// DebugLinkLog
+export type DebugLinkLog = {
+    level?: number;
+    bucket?: string;
+    text?: string;
 };
 
-export type TezosSignedTx = {
-    signature: string;
-    sig_op_contents: string;
-    operation_hash: string;
+// DebugLinkMemoryRead
+export type DebugLinkMemoryRead = {
+    address?: number;
+    length?: number;
 };
 
-// Cardano types
-export type CardanoCertificatePointerType = {
-    block_index: number;
-    tx_index: number;
-    certificate_index: number;
-}
+// DebugLinkMemory
+export type DebugLinkMemory = {
+    memory?: string;
+};
 
-export type CardanoAddressParameters = {
-    address_type: 0 | 4 | 6 | 8 | 14;
+// DebugLinkMemoryWrite
+export type DebugLinkMemoryWrite = {
+    address?: number;
+    memory?: string;
+    flash?: boolean;
+};
+
+// DebugLinkFlashErase
+export type DebugLinkFlashErase = {
+    sector?: number;
+};
+
+// DebugLinkEraseSdCard
+export type DebugLinkEraseSdCard = {
+    format?: boolean;
+};
+
+// DebugLinkWatchLayout
+export type DebugLinkWatchLayout = {
+    watch?: boolean;
+};
+
+// EosGetPublicKey
+export type EosGetPublicKey = {
     address_n: number[];
-    address_n_staking: number[];
-    staking_key_hash?: string;
-    certificate_pointer?: CardanoCertificatePointerType;
+    show_display?: boolean;
 };
 
-export type CardanoAddress = {
-    address: string;
-    address_n?: Array<number>;
-};
-
-export type CardanoPublicKey = {
-    xpub: string;
-    node: HDPubNode;
-};
-
-export type CardanoSignedTx = {
-    tx_hash: string;
-    serialized_tx: string;
-};
-export type CardanoTxInput = {
-    tx_hash: string;
-    address_n: Array<number>;
-    output_index: number;
-};
-export type CardanoTxOutput = {
-    address?: string;
-    address_parameters?: CardanoAddressParameters;
-    amount: string;
-};
-export type CardanoTxCertificate = {
-    type: number;
-    path: Array<number>;
-    pool?: string;
-};
-export type CardanoTxWithdrawal = {
-    path: Array<number>;
-    amount: string;
-};
-
-// Lisk types
-export type LiskAddress = {
-    address: string;
-}
-
-export type LiskPublicKey = {
-    public_key: string;
-}
-
-export type LiskMessageSignature = {
-    public_key: string;
-    signature: string;
-};
-
-export type LiskAsset =
-    { data: string } |
-    { votes: Array<string> } |
-    { delegate: { username: string } } |
-    { signature: { public_key: string } } |
-    {
-        multisignature: {
-            min: number;
-            life_time: number;
-            keys_group: Array<string>;
-        };
-    };
-
-export type LiskTransaction = {
-    type: number;
-    fee: string;
-    amount: string;
-    timestamp: number;
-    recipient_id?: string;
-    sender_public_key?: string;
-    requester_public_key?: string;
-    signature?: string;
-    asset?: LiskAsset | {};
-}
-
-export type LiskSignedTx = {
-    signature: string;
-}
-
-// Ripple types
-export type RippleAddress = {
-    address: string;
-}
-
-export type RippleTransaction = {
-    address_n: Array<number>;
-    fee?: number;
-    flags?: number;
-    sequence?: number;
-    last_ledger_sequence?: number;
-    payment: {
-        amount: string;
-        destination: string;
-    };
-}
-
-export type RippleSignedTx = {
-    signature: string;
-    serialized_tx: string;
-}
-
-// EOS types
+// EosPublicKey
 export type EosPublicKey = {
     wif_public_key: string;
     raw_public_key: string;
-}
-
-export type EosTxActionRequest = {
-    data_size: ?number;
-}
+};
 
 export type EosTxHeader = {
     expiration: number;
@@ -689,137 +783,148 @@ export type EosTxHeader = {
     max_net_usage_words: number;
     max_cpu_usage_ms: number;
     delay_sec: number;
-}
+};
 
+// EosSignTx
 export type EosSignTx = {
-    address_n: Array<number>;
-    chain_id: string;
-    header: ?EosTxHeader;
-    num_actions: number;
-}
+    address_n: number[];
+    chain_id?: string;
+    header?: EosTxHeader;
+    num_actions?: number;
+};
+
+// EosTxActionRequest
+export type EosTxActionRequest = {
+    data_size?: number;
+};
 
 export type EosAsset = {
-    amount: string; // uint64 as string
-    symbol: string; // uint64 as string
-}
+    amount?: string;
+    symbol?: string;
+};
 
 export type EosPermissionLevel = {
-    actor: string; // uint64 as string
-    permission: string; // uint64 as string
-}
+    actor?: string;
+    permission?: string;
+};
 
 export type EosAuthorizationKey = {
     type?: number;
     key: string;
-    address_n?: number[]; // this field is not implemented in FW?
+    address_n?: number[];
     weight: number;
-}
+};
+
+export type EosAuthorizationAccount = {
+    account?: EosPermissionLevel;
+    weight?: number;
+};
+
+export type EosAuthorizationWait = {
+    wait_sec?: number;
+    weight?: number;
+};
 
 export type EosAuthorization = {
-    threshold: number;
+    threshold?: number;
     keys: EosAuthorizationKey[];
-    accounts: Array<{
-        account: EosPermissionLevel;
-        weight: number;
-    }>;
-    waits: Array<{
-        wait_sec: number;
-        weight: number;
-    }>;
-}
+    accounts: EosAuthorizationAccount[];
+    waits: EosAuthorizationWait[];
+};
 
 export type EosActionCommon = {
-    account: string; // uint64 as string
-    name: string; // uint64 as string
-    authorization: Array<EosPermissionLevel>;
-}
+    account?: string;
+    name?: string;
+    authorization: EosPermissionLevel[];
+};
 
 export type EosActionTransfer = {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    quantity: EosAsset;
+    sender?: string;
+    receiver?: string;
+    quantity?: EosAsset;
     memo?: string;
-}
+};
 
 export type EosActionDelegate = {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    net_quantity: EosAsset;
-    cpu_quantity: EosAsset;
+    sender?: string;
+    receiver?: string;
+    net_quantity?: EosAsset;
+    cpu_quantity?: EosAsset;
     transfer?: boolean;
-}
+};
 
 export type EosActionUndelegate = {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    net_quantity: EosAsset;
-    cpu_quantity: EosAsset;
-}
-
-export type EosActionBuyRam = {
-    payer: string; // uint64 as string
-    receiver: string; // uint64 as string
-    quantity: EosAsset;
-}
-
-export type EosActionBuyRamBytes = {
-    payer: string; // uint64 as string
-    receiver: string; // uint64 as string
-    bytes: number;
-}
-
-export type EosActionSellRam = {
-    account: string; // uint64 as string
-    bytes: number;
-}
-
-export type EosActionVoteProducer = {
-    voter: string; // uint64 as string
-    proxy: string; // uint64 as string
-    producers: Array<string>; // uint64[] as string
-}
+    sender?: string;
+    receiver?: string;
+    net_quantity?: EosAsset;
+    cpu_quantity?: EosAsset;
+};
 
 export type EosActionRefund = {
-    owner: string; // uint64 as string
-}
+    owner?: string;
+};
+
+export type EosActionBuyRam = {
+    payer?: string;
+    receiver?: string;
+    quantity?: EosAsset;
+};
+
+export type EosActionBuyRamBytes = {
+    payer?: string;
+    receiver?: string;
+    bytes?: number;
+};
+
+export type EosActionSellRam = {
+    account?: string;
+    bytes?: number;
+};
+
+export type EosActionVoteProducer = {
+    voter?: string;
+    proxy?: string;
+    producers: string[];
+};
 
 export type EosActionUpdateAuth = {
-    account: string; // uint64 as string
-    permission: string; // uint64 as string
-    parent: string; // uint64 as string
-    auth: EosAuthorization;
-}
+    account?: string;
+    permission?: string;
+    parent?: string;
+    auth?: EosAuthorization;
+};
 
 export type EosActionDeleteAuth = {
-    account: string; // uint64 as string
-    permission: string; // uint64 as string
-}
+    account?: string;
+    permission?: string;
+};
 
 export type EosActionLinkAuth = {
-    account: string; // uint64 as string
-    code: string; // uint64 as string
-    type: string; // uint64 as string
-    requirement: string; // uint64 as string
-}
+    account?: string;
+    code?: string;
+    type?: string;
+    requirement?: string;
+};
 
 export type EosActionUnlinkAuth = {
-    account: string; // uint64 as string
-    code: string; // uint64 as string
-    type: string; // uint64 as string
-}
+    account?: string;
+    code?: string;
+    type?: string;
+};
 
 export type EosActionNewAccount = {
-    creator: string; // uint64 as string
-    name: string; // uint64 as string
-    owner: EosAuthorization;
-    active: EosAuthorization;
-}
+    creator?: string;
+    name?: string;
+    owner?: EosAuthorization;
+    active?: EosAuthorization;
+};
 
 export type EosActionUnknown = {
     data_size: number;
-    data_chunk: string;
-}
+    data_chunk?: string;
+};
 
+// EosTxActionAck
 export type EosTxActionAck = {
     common?: EosActionCommon;
     transfer?: EosActionTransfer;
@@ -836,74 +941,336 @@ export type EosTxActionAck = {
     unlink_auth?: EosActionUnlinkAuth;
     new_account?: EosActionNewAccount;
     unknown?: EosActionUnknown;
-}
+};
 
+// EosSignedTx
 export type EosSignedTx = {
     signature: string;
-}
+};
 
-// Binance types
-export type BinanceAddress = {
+// EthereumGetPublicKey
+export type EthereumGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// EthereumPublicKey
+export type EthereumPublicKey = {
+    node: HDNodeType;
+    xpub: string;
+};
+
+// EthereumGetAddress
+export type EthereumGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// EthereumAddress
+export type EthereumAddress = {
+    _old_address?: string;
     address: string;
-}
+};
 
-export type BinancePublicKey = {
-    public_key: string;
-}
+// EthereumSignTx
+export type EthereumSignTx = {
+    address_n: number[];
+    nonce?: string;
+    gas_price?: string;
+    gas_limit?: string;
+    to?: string;
+    value?: string;
+    data_initial_chunk?: string;
+    data_length?: number;
+    chain_id?: number;
+    tx_type?: number;
+};
 
-export type BinanceSignTx = {
-    address_n: Array<number>;
-    msg_count: number;
-    chain_id: string;
-    account_number: number;
-    memo?: string;
-    sequence: number;
-    source: number;
-}
+// EthereumTxRequest
+export type EthereumTxRequest = {
+    data_length?: number;
+    signature_v?: number;
+    signature_r?: string;
+    signature_s?: string;
+};
 
-export type BinanceTxRequest = {
+// EthereumTxAck
+export type EthereumTxAck = {
+    data_chunk?: string;
+};
 
-}
+// EthereumSignMessage
+export type EthereumSignMessage = {
+    address_n: number[];
+    message?: string;
+};
 
-export type BinanceInputOutput = {
-    address: string;
-    coins: {
-        amount: number;
-        denom: string;
-    }[];
-}
-
-export type BinanceTransferMsg = {
-    inputs: BinanceInputOutput[];
-    outputs: BinanceInputOutput[];
-}
-
-export type BinanceOrderMsg = {
-    id: string;
-    ordertype: number; // 'OT_UNKNOWN' | 'MARKET' | 'LIMIT' | 'OT_RESERVED',
-    price: number;
-    quantity: number;
-    sender: string;
-    side: number; // 'SIDE_UNKNOWN' | 'BUY' | 'SELL',
-    symbol: string;
-    timeinforce: number; // 'TIF_UNKNOWN' | 'GTE' | 'TIF_RESERVED' | 'IOC',
-}
-
-export type BinanceCancelMsg = {
-    refid: string;
-    sender: string;
-    symbol: string;
-}
-
-export type BinanceMessage = BinanceTransferMsg | BinanceOrderMsg | BinanceCancelMsg;
-
-export type BinanceSignedTx = {
+// EthereumMessageSignature
+export type EthereumMessageSignature = {
     signature: string;
-    public_key: string;
-}
+    address: string;
+};
 
-// Reset device flags
-export type ResetDeviceFlags = {
+// EthereumVerifyMessage
+export type EthereumVerifyMessage = {
+    signature?: string;
+    message?: string;
+    address?: string;
+};
+
+// LiskGetAddress
+export type LiskGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// LiskAddress
+export type LiskAddress = {
+    address: string;
+};
+
+// LiskGetPublicKey
+export type LiskGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// LiskPublicKey
+export type LiskPublicKey = {
+    public_key: string;
+};
+
+const Enum_LiskTransactionType = Object.freeze({
+    Transfer: 0,
+    RegisterSecondPassphrase: 1,
+    RegisterDelegate: 2,
+    CastVotes: 3,
+    RegisterMultisignatureAccount: 4,
+    CreateDapp: 5,
+    TransferIntoDapp: 6,
+    TransferOutOfDapp: 7,
+});
+export type LiskTransactionType = $Values<typeof Enum_LiskTransactionType>;
+
+export type LiskSignatureType = {
+    public_key?: string;
+};
+
+export type LiskDelegateType = {
+    username?: string;
+};
+
+export type LiskMultisignatureType = {
+    min?: number;
+    life_time?: number;
+    keys_group: string[];
+};
+
+export type LiskTransactionAsset = {
+    signature?: LiskSignatureType;
+    delegate?: LiskDelegateType;
+    votes: string[];
+    multisignature?: LiskMultisignatureType;
+    data?: string;
+};
+
+export type LiskTransactionCommon = {
+    type?: LiskTransactionType;
+    amount?: number;
+    fee?: number;
+    recipient_id?: string;
+    sender_public_key?: string;
+    requester_public_key?: string;
+    signature?: string;
+    timestamp?: number;
+    asset?: LiskTransactionAsset;
+};
+
+// LiskSignTx
+export type LiskSignTx = {
+    address_n: number[];
+    transaction: LiskTransactionCommon;
+};
+
+// LiskSignedTx
+export type LiskSignedTx = {
+    signature: string;
+};
+
+// LiskSignMessage
+export type LiskSignMessage = {
+    address_n: number[];
+    message: string;
+};
+
+// LiskMessageSignature
+export type LiskMessageSignature = {
+    public_key: string;
+    signature: string;
+};
+
+// LiskVerifyMessage
+export type LiskVerifyMessage = {
+    public_key?: string;
+    signature?: string;
+    message?: string;
+};
+
+// Initialize
+export type Initialize = {
+    session_id?: string;
+};
+
+// GetFeatures
+export type GetFeatures = {};
+
+const Enum_Capability = Object.freeze({
+    Capability_Bitcoin: 1,
+    Capability_Bitcoin_like: 2,
+    Capability_Binance: 3,
+    Capability_Cardano: 4,
+    Capability_Crypto: 5,
+    Capability_EOS: 6,
+    Capability_Ethereum: 7,
+    Capability_Lisk: 8,
+    Capability_Monero: 9,
+    Capability_NEM: 10,
+    Capability_Ripple: 11,
+    Capability_Stellar: 12,
+    Capability_Tezos: 13,
+    Capability_U2F: 14,
+    Capability_Shamir: 15,
+    Capability_ShamirGroups: 16,
+    Capability_PassphraseEntry: 17,
+});
+export type Capability = $Keys<typeof Enum_Capability>;
+
+// Features
+export type Features = {
+    vendor?: string;
+    major_version: number;
+    minor_version: number;
+    patch_version: number;
+    bootloader_mode?: boolean | null;
+    device_id?: string | null;
+    pin_protection?: boolean;
+    passphrase_protection?: boolean;
+    language?: string;
+    label?: string | null;
+    initialized?: boolean;
+    revision?: string;
+    bootloader_hash?: string | null;
+    imported?: boolean;
+    unlocked?: boolean;
+    firmware_present?: boolean | null;
+    needs_backup?: boolean;
+    flags?: number;
+    model: string;
+    fw_major?: number | null;
+    fw_minor?: number | null;
+    fw_patch?: number | null;
+    fw_vendor?: string | null;
+    fw_vendor_keys?: string;
+    unfinished_backup?: boolean;
+    no_backup?: boolean;
+    recovery_mode?: boolean;
+    capabilities: Capability[];
+    backup_type?: BackupType;
+    sd_card_present?: boolean;
+    sd_protection?: boolean;
+    wipe_code_protection?: boolean;
+    session_id?: string;
+    passphrase_always_on_device?: boolean;
+};
+
+// LockDevice
+export type LockDevice = {};
+
+// EndSession
+export type EndSession = {};
+
+const Enum_SafetyCheckLevel = Object.freeze({
+    Strict: 0,
+    Prompt: 1,
+});
+export type SafetyCheckLevel = $Values<typeof Enum_SafetyCheckLevel>;
+
+// ApplySettings
+export type ApplySettings = {
+    language?: string;
+    label?: string;
+    use_passphrase?: boolean;
+    homescreen?: string;
+    auto_lock_delay_ms?: number;
+    display_rotation?: number;
+    passphrase_always_on_device?: boolean;
+    safety_checks?: SafetyCheckLevel;
+};
+
+// ApplyFlags
+export type ApplyFlags = {
+    flags?: number;
+};
+
+// ChangePin
+export type ChangePin = {
+    remove?: boolean;
+};
+
+// ChangeWipeCode
+export type ChangeWipeCode = {
+    remove?: boolean;
+};
+
+const Enum_SdProtectOperationType = Object.freeze({
+    DISABLE: 0,
+    ENABLE: 1,
+    REFRESH: 2,
+});
+export type SdProtectOperationType = $Values<typeof Enum_SdProtectOperationType>;
+
+// SdProtect
+export type SdProtect = {
+    operation?: SdProtectOperationType;
+};
+
+// Ping
+export type Ping = {
+    message?: string;
+    button_protection?: boolean;
+};
+
+// Cancel
+export type Cancel = {};
+
+// GetEntropy
+export type GetEntropy = {
+    size: number;
+};
+
+// Entropy
+export type Entropy = {
+    entropy: string;
+};
+
+// WipeDevice
+export type WipeDevice = {};
+
+// LoadDevice
+export type LoadDevice = {
+    mnemonics: string[];
+    pin?: string;
+    passphrase_protection?: boolean;
+    language?: string;
+    label?: string;
+    skip_checksum?: boolean;
+    u2f_counter?: number;
+    needs_backup?: boolean;
+    no_backup?: boolean;
+};
+
+// ResetDevice
+export type ResetDevice = {
     display_random?: boolean;
     strength?: number;
     passphrase_protection?: boolean;
@@ -913,97 +1280,754 @@ export type ResetDeviceFlags = {
     u2f_counter?: number;
     skip_backup?: boolean;
     no_backup?: boolean;
-}
-
-export type FirmwareErase = {
-    length?: number;
+    backup_type?: BackupType;
 };
 
-export type FirmwareUpload = {
-    payload: Buffer;
-    length: number;
-}
+// BackupDevice
+export type BackupDevice = {};
 
-export type ChangePin = {
-    remove?: boolean;
-}
+// EntropyRequest
+export type EntropyRequest = {};
 
-export type Flags = {
-    flags: number;
-}
+// EntropyAck
+export type EntropyAck = {
+    entropy?: string;
+};
 
-export type DebugLinkDecision = {|
-    yes_no?: boolean;
-    up_down?: boolean;
-    input?: string;
-|}
+const Enum_RecoveryDeviceType = Object.freeze({
+    RecoveryDeviceType_ScrambledWords: 0,
+    RecoveryDeviceType_Matrix: 1,
+});
+export type RecoveryDeviceType = $Values<typeof Enum_RecoveryDeviceType>;
 
-export type DebugLinkState = {
-    layout: string;
-    pin: string;
-    matrix: string;
-    mnemonic: string;
-    node: HDNode;
-    passphrase_protection: boolean;
-    reset_word: string;
-    reset_entropy: string;
-    recovery_fake_word: string;
-    recovery_word_pos: number;
-    reset_word_pos: number;
-}
-
-export type LoadDeviceFlags = {
-    mnemonics?: Array<string>;
-    mnemonic?: string;
-    node?: HDNode;
-    pin?: string;
-    passphrase_protection?: boolean;
-    language?: string;
-    label?: string;
-    skip_checksum?: boolean;
-    u2f_counter?: number;
-}
-
-export type RecoverDeviceSettings = {
+// RecoveryDevice
+export type RecoveryDevice = {
     word_count?: number;
     passphrase_protection?: boolean;
     pin_protection?: boolean;
     language?: string;
     label?: string;
     enforce_wordlist?: boolean;
-    type?: number;
+    type?: RecoveryDeviceType;
     u2f_counter?: number;
     dry_run?: boolean;
 };
 
-export type LoadDeviceSettings = {
-    pin?: string;
-    passphrase_protection?: boolean;
-    language?: string;
-    label?: string;
-    skip_checksum?: boolean;
-    mnemonics?: Array<string>;
-    mnemonic?: string;
-    node?: HDNode;
-    payload?: string; // will be converted
+const Enum_WordRequestType = Object.freeze({
+    WordRequestType_Plain: 0,
+    WordRequestType_Matrix9: 1,
+    WordRequestType_Matrix6: 2,
+});
+export type WordRequestType = $Values<typeof Enum_WordRequestType>;
 
+// WordRequest
+export type WordRequest = {
+    type?: WordRequestType;
+};
+
+// WordAck
+export type WordAck = {
+    word: string;
+};
+
+// SetU2FCounter
+export type SetU2FCounter = {
     u2f_counter?: number;
 };
 
-export type ResetDeviceSettings = {
-    display_random?: boolean;
-    strength?: number;
-    passphrase_protection?: boolean;
-    pin_protection?: boolean;
-    language?: string;
-    label?: string;
+// GetNextU2FCounter
+export type GetNextU2FCounter = {};
+
+// NextU2FCounter
+export type NextU2FCounter = {
     u2f_counter?: number;
-    skip_backup?: boolean;
 };
 
-export type ApplySettings = {
-    language?: string;
-    label?: string;
-    use_passphrase?: boolean;
-    homescreen?: string;
+// DoPreauthorized
+export type DoPreauthorized = {};
+
+// PreauthorizedRequest
+export type PreauthorizedRequest = {};
+
+// CancelAuthorization
+export type CancelAuthorization = {};
+
+// NEMGetAddress
+export type NEMGetAddress = {
+    address_n: number[];
+    network?: number;
+    show_display?: boolean;
 };
+
+// NEMAddress
+export type NEMAddress = {
+    address: string;
+};
+
+export type NEMTransactionCommon = {
+    address_n?: number[];
+    network?: number;
+    timestamp?: number;
+    fee?: number;
+    deadline?: number;
+    signer?: string;
+};
+
+export type NEMMosaic = {
+    namespace?: string;
+    mosaic?: string;
+    quantity?: number;
+};
+
+export type NEMTransfer = {
+    recipient?: string;
+    amount?: string | number;
+    payload?: string;
+    public_key?: string;
+    mosaics?: NEMMosaic[];
+};
+
+export type NEMProvisionNamespace = {
+    namespace?: string;
+    parent?: string;
+    sink?: string;
+    fee?: number;
+};
+
+const Enum_NEMMosaicLevy = Object.freeze({
+    MosaicLevy_Absolute: 1,
+    MosaicLevy_Percentile: 2,
+});
+export type NEMMosaicLevy = $Values<typeof Enum_NEMMosaicLevy>;
+
+export type NEMMosaicDefinition = {
+    name?: string;
+    ticker?: string;
+    namespace?: string;
+    mosaic?: string;
+    divisibility?: number;
+    levy?: NEMMosaicLevy;
+    fee?: number;
+    levy_address?: string;
+    levy_namespace?: string;
+    levy_mosaic?: string;
+    supply?: number;
+    mutable_supply?: boolean;
+    transferable?: boolean;
+    description?: string;
+    networks?: number[];
+};
+
+export type NEMMosaicCreation = {
+    definition?: NEMMosaicDefinition;
+    sink?: string;
+    fee?: number;
+};
+
+const Enum_NEMSupplyChangeType = Object.freeze({
+    SupplyChange_Increase: 1,
+    SupplyChange_Decrease: 2,
+});
+export type NEMSupplyChangeType = $Values<typeof Enum_NEMSupplyChangeType>;
+
+export type NEMMosaicSupplyChange = {
+    namespace?: string;
+    mosaic?: string;
+    type?: NEMSupplyChangeType;
+    delta?: number;
+};
+
+const Enum_NEMModificationType = Object.freeze({
+    CosignatoryModification_Add: 1,
+    CosignatoryModification_Delete: 2,
+});
+export type NEMModificationType = $Values<typeof Enum_NEMModificationType>;
+
+export type NEMCosignatoryModification = {
+    type?: NEMModificationType;
+    public_key?: string;
+};
+
+export type NEMAggregateModification = {
+    modifications?: NEMCosignatoryModification[];
+    relative_change?: number;
+};
+
+const Enum_NEMImportanceTransferMode = Object.freeze({
+    ImportanceTransfer_Activate: 1,
+    ImportanceTransfer_Deactivate: 2,
+});
+export type NEMImportanceTransferMode = $Values<typeof Enum_NEMImportanceTransferMode>;
+
+export type NEMImportanceTransfer = {
+    mode?: NEMImportanceTransferMode;
+    public_key?: string;
+};
+
+// NEMSignTx
+export type NEMSignTx = {
+    transaction?: NEMTransactionCommon;
+    multisig?: NEMTransactionCommon;
+    transfer?: NEMTransfer;
+    cosigning?: boolean;
+    provision_namespace?: NEMProvisionNamespace;
+    mosaic_creation?: NEMMosaicCreation;
+    supply_change?: NEMMosaicSupplyChange;
+    aggregate_modification?: NEMAggregateModification;
+    importance_transfer?: NEMImportanceTransfer;
+};
+
+// NEMSignedTx
+export type NEMSignedTx = {
+    data: string;
+    signature: string;
+};
+
+// NEMDecryptMessage
+export type NEMDecryptMessage = {
+    address_n: number[];
+    network?: number;
+    public_key?: string;
+    payload?: string;
+};
+
+// NEMDecryptedMessage
+export type NEMDecryptedMessage = {
+    payload?: string;
+};
+
+// RippleGetAddress
+export type RippleGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// RippleAddress
+export type RippleAddress = {
+    address: string;
+};
+
+export type RipplePayment = {
+    amount: string | number;
+    destination?: string;
+    destination_tag?: number;
+};
+
+// RippleSignTx
+export type RippleSignTx = {
+    address_n: number[];
+    fee?: string | number;
+    flags?: number;
+    sequence?: number;
+    last_ledger_sequence?: number;
+    payment?: RipplePayment;
+};
+
+// RippleSignedTx
+export type RippleSignedTx = {
+    signature: string;
+    serialized_tx: string;
+};
+
+// StellarAssetType
+export type StellarAssetType = {
+    type: 0 | 1 | 2;
+    code: string;
+    issuer?: string;
+};
+
+// StellarGetAddress
+export type StellarGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// StellarAddress
+export type StellarAddress = {
+    address: string;
+};
+
+// StellarSignTx
+export type StellarSignTx = {
+    address_n: number[];
+    network_passphrase?: string;
+    source_account?: string;
+    fee?: number;
+    sequence_number?: string | number;
+    timebounds_start?: number;
+    timebounds_end?: number;
+    memo_type?: number;
+    memo_text?: string;
+    memo_id?: string;
+    memo_hash?: Buffer | string;
+    num_operations?: number;
+};
+
+// StellarTxOpRequest
+export type StellarTxOpRequest = {};
+
+// StellarPaymentOp
+export type StellarPaymentOp = {
+    source_account?: string;
+    destination_account?: string;
+    asset?: StellarAssetType;
+    amount?: string | number;
+};
+
+// StellarCreateAccountOp
+export type StellarCreateAccountOp = {
+    source_account?: string;
+    new_account?: string;
+    starting_balance?: string | number;
+};
+
+// StellarPathPaymentOp
+export type StellarPathPaymentOp = {
+    source_account?: string;
+    send_asset?: StellarAssetType;
+    send_max?: string | number;
+    destination_account?: string;
+    destination_asset?: StellarAssetType;
+    destination_amount?: string | number;
+    paths?: StellarAssetType[];
+};
+
+// StellarManageOfferOp
+export type StellarManageOfferOp = {
+    source_account?: string;
+    selling_asset?: StellarAssetType;
+    buying_asset?: StellarAssetType;
+    amount?: string | number;
+    price_n?: number;
+    price_d?: number;
+    offer_id?: string | number;
+};
+
+// StellarCreatePassiveOfferOp
+export type StellarCreatePassiveOfferOp = {
+    source_account?: string;
+    selling_asset?: StellarAssetType;
+    buying_asset?: StellarAssetType;
+    amount?: string | number;
+    price_n?: number;
+    price_d?: number;
+};
+
+// StellarSetOptionsOp
+export type StellarSetOptionsOp = {
+    source_account?: string;
+    inflation_destination_account?: string;
+    clear_flags?: number;
+    set_flags?: number;
+    master_weight?: string | number;
+    low_threshold?: string | number;
+    medium_threshold?: string | number;
+    high_threshold?: string | number;
+    home_domain?: string;
+    signer_type?: number;
+    signer_key?: Buffer | string;
+    signer_weight?: number;
+};
+
+// StellarChangeTrustOp
+export type StellarChangeTrustOp = {
+    source_account?: string;
+    asset?: StellarAssetType;
+    limit?: string | number;
+};
+
+// StellarAllowTrustOp
+export type StellarAllowTrustOp = {
+    source_account?: string;
+    trusted_account?: string;
+    asset_type?: number;
+    asset_code?: string;
+    is_authorized?: number;
+};
+
+// StellarAccountMergeOp
+export type StellarAccountMergeOp = {
+    source_account?: string;
+    destination_account?: string;
+};
+
+// StellarManageDataOp
+export type StellarManageDataOp = {
+    source_account?: string;
+    key?: string;
+    value?: Buffer | string;
+};
+
+// StellarBumpSequenceOp
+export type StellarBumpSequenceOp = {
+    source_account?: string;
+    bump_to?: string | number;
+};
+
+// StellarSignedTx
+export type StellarSignedTx = {
+    public_key: string;
+    signature: string;
+};
+
+// TezosGetAddress
+export type TezosGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// TezosAddress
+export type TezosAddress = {
+    address: string;
+};
+
+// TezosGetPublicKey
+export type TezosGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// TezosPublicKey
+export type TezosPublicKey = {
+    public_key: string;
+};
+
+const Enum_TezosContractType = Object.freeze({
+    Implicit: 0,
+    Originated: 1,
+});
+export type TezosContractType = $Values<typeof Enum_TezosContractType>;
+
+export type TezosContractID = {
+    tag: number;
+    hash: Uint8Array;
+};
+
+export type TezosRevealOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    public_key: Uint8Array;
+};
+
+export type TezosManagerTransfer = {
+    destination?: TezosContractID;
+    amount?: number;
+};
+
+export type TezosParametersManager = {
+    set_delegate?: Uint8Array;
+    cancel_delegate?: boolean;
+    transfer?: TezosManagerTransfer;
+};
+
+export type TezosTransactionOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    amount: number;
+    destination: TezosContractID;
+    parameters?: number[];
+    parameters_manager?: TezosParametersManager;
+};
+
+export type TezosOriginationOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    manager_pubkey?: string;
+    balance: number;
+    spendable?: boolean;
+    delegatable?: boolean;
+    delegate?: Uint8Array;
+    script: string | number[];
+};
+
+export type TezosDelegationOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    delegate: Uint8Array;
+};
+
+export type TezosProposalOp = {
+    source?: string;
+    period?: number;
+    proposals: string[];
+};
+
+const Enum_TezosBallotType = Object.freeze({
+    Yay: 0,
+    Nay: 1,
+    Pass: 2,
+});
+export type TezosBallotType = $Values<typeof Enum_TezosBallotType>;
+
+export type TezosBallotOp = {
+    source?: string;
+    period?: number;
+    proposal?: string;
+    ballot?: TezosBallotType;
+};
+
+// TezosSignTx
+export type TezosSignTx = {
+    address_n: number[];
+    branch: Uint8Array;
+    reveal?: TezosRevealOp;
+    transaction?: TezosTransactionOp;
+    origination?: TezosOriginationOp;
+    delegation?: TezosDelegationOp;
+    proposal?: TezosProposalOp;
+    ballot?: TezosBallotOp;
+};
+
+// TezosSignedTx
+export type TezosSignedTx = {
+    signature: string;
+    sig_op_contents: string;
+    operation_hash: string;
+};
+
+// custom connect definitions
+export type MessageType = {
+    BinanceGetAddress: BinanceGetAddress;
+    BinanceAddress: BinanceAddress;
+    BinanceGetPublicKey: BinanceGetPublicKey;
+    BinancePublicKey: BinancePublicKey;
+    BinanceSignTx: BinanceSignTx;
+    BinanceTxRequest: BinanceTxRequest;
+    BinanceCoin: BinanceCoin;
+    BinanceInputOutput: BinanceInputOutput;
+    BinanceTransferMsg: BinanceTransferMsg;
+    BinanceOrderMsg: BinanceOrderMsg;
+    BinanceCancelMsg: BinanceCancelMsg;
+    BinanceSignedTx: BinanceSignedTx;
+    HDNodeType: $Exact<HDNodeType>;
+    HDNodePathType: $Exact<HDNodePathType>;
+    MultisigRedeemScriptType: MultisigRedeemScriptType;
+    GetPublicKey: GetPublicKey;
+    PublicKey: PublicKey;
+    GetAddress: GetAddress;
+    Address: $Exact<Address>;
+    GetOwnershipId: GetOwnershipId;
+    OwnershipId: $Exact<OwnershipId>;
+    SignMessage: $Exact<SignMessage>;
+    MessageSignature: MessageSignature;
+    VerifyMessage: VerifyMessage;
+    SignTx: $Exact<SignTx>;
+    TxRequestDetailsType: TxRequestDetailsType;
+    TxRequestSerializedType: TxRequestSerializedType;
+    TxRequest: TxRequest;
+    TxInputType: $Exact<TxInputType>;
+    TxOutputBinType: $Exact<TxOutputBinType>;
+    TxOutputType: $Exact<TxOutputType>;
+    TxAck: TxAck;
+    GetOwnershipProof: GetOwnershipProof;
+    OwnershipProof: $Exact<OwnershipProof>;
+    AuthorizeCoinJoin: $Exact<AuthorizeCoinJoin>;
+    FirmwareErase: FirmwareErase;
+    FirmwareRequest: FirmwareRequest;
+    FirmwareUpload: $Exact<FirmwareUpload>;
+    SelfTest: SelfTest;
+    CardanoBlockchainPointerType: CardanoBlockchainPointerType;
+    CardanoAddressParametersType: CardanoAddressParametersType;
+    CardanoGetAddress: CardanoGetAddress;
+    CardanoAddress: CardanoAddress;
+    CardanoGetPublicKey: CardanoGetPublicKey;
+    CardanoPublicKey: CardanoPublicKey;
+    CardanoTxInputType: CardanoTxInputType;
+    CardanoTxOutputType: CardanoTxOutputType;
+    CardanoTxCertificateType: CardanoTxCertificateType;
+    CardanoTxWithdrawalType: CardanoTxWithdrawalType;
+    CardanoSignTx: CardanoSignTx;
+    CardanoSignedTx: CardanoSignedTx;
+    Success: Success;
+    Failure: Failure;
+    ButtonRequest: ButtonRequest;
+    ButtonAck: ButtonAck;
+    PinMatrixRequest: PinMatrixRequest;
+    PinMatrixAck: $Exact<PinMatrixAck>;
+    PassphraseRequest: PassphraseRequest;
+    PassphraseAck: PassphraseAck;
+    Deprecated_PassphraseStateRequest: Deprecated_PassphraseStateRequest;
+    Deprecated_PassphraseStateAck: Deprecated_PassphraseStateAck;
+    CipherKeyValue: CipherKeyValue;
+    CipheredKeyValue: CipheredKeyValue;
+    IdentityType: IdentityType;
+    SignIdentity: SignIdentity;
+    SignedIdentity: SignedIdentity;
+    GetECDHSessionKey: GetECDHSessionKey;
+    ECDHSessionKey: ECDHSessionKey;
+    DebugLinkDecision: DebugLinkDecision;
+    DebugLinkLayout: DebugLinkLayout;
+    DebugLinkReseedRandom: DebugLinkReseedRandom;
+    DebugLinkRecordScreen: DebugLinkRecordScreen;
+    DebugLinkShowTextItem: DebugLinkShowTextItem;
+    DebugLinkShowText: DebugLinkShowText;
+    DebugLinkGetState: DebugLinkGetState;
+    DebugLinkState: DebugLinkState;
+    DebugLinkStop: DebugLinkStop;
+    DebugLinkLog: DebugLinkLog;
+    DebugLinkMemoryRead: DebugLinkMemoryRead;
+    DebugLinkMemory: DebugLinkMemory;
+    DebugLinkMemoryWrite: DebugLinkMemoryWrite;
+    DebugLinkFlashErase: DebugLinkFlashErase;
+    DebugLinkEraseSdCard: DebugLinkEraseSdCard;
+    DebugLinkWatchLayout: DebugLinkWatchLayout;
+    EosGetPublicKey: EosGetPublicKey;
+    EosPublicKey: EosPublicKey;
+    EosTxHeader: $Exact<EosTxHeader>;
+    EosSignTx: EosSignTx;
+    EosTxActionRequest: EosTxActionRequest;
+    EosAsset: EosAsset;
+    EosPermissionLevel: EosPermissionLevel;
+    EosAuthorizationKey: EosAuthorizationKey;
+    EosAuthorizationAccount: EosAuthorizationAccount;
+    EosAuthorizationWait: EosAuthorizationWait;
+    EosAuthorization: EosAuthorization;
+    EosActionCommon: EosActionCommon;
+    EosActionTransfer: EosActionTransfer;
+    EosActionDelegate: EosActionDelegate;
+    EosActionUndelegate: EosActionUndelegate;
+    EosActionRefund: EosActionRefund;
+    EosActionBuyRam: EosActionBuyRam;
+    EosActionBuyRamBytes: EosActionBuyRamBytes;
+    EosActionSellRam: EosActionSellRam;
+    EosActionVoteProducer: EosActionVoteProducer;
+    EosActionUpdateAuth: EosActionUpdateAuth;
+    EosActionDeleteAuth: EosActionDeleteAuth;
+    EosActionLinkAuth: EosActionLinkAuth;
+    EosActionUnlinkAuth: EosActionUnlinkAuth;
+    EosActionNewAccount: EosActionNewAccount;
+    EosActionUnknown: EosActionUnknown;
+    EosTxActionAck: EosTxActionAck;
+    EosSignedTx: EosSignedTx;
+    EthereumGetPublicKey: EthereumGetPublicKey;
+    EthereumPublicKey: EthereumPublicKey;
+    EthereumGetAddress: EthereumGetAddress;
+    EthereumAddress: EthereumAddress;
+    EthereumSignTx: EthereumSignTx;
+    EthereumTxRequest: EthereumTxRequest;
+    EthereumTxAck: EthereumTxAck;
+    EthereumSignMessage: EthereumSignMessage;
+    EthereumMessageSignature: EthereumMessageSignature;
+    EthereumVerifyMessage: EthereumVerifyMessage;
+    LiskGetAddress: LiskGetAddress;
+    LiskAddress: LiskAddress;
+    LiskGetPublicKey: LiskGetPublicKey;
+    LiskPublicKey: LiskPublicKey;
+    LiskSignatureType: LiskSignatureType;
+    LiskDelegateType: LiskDelegateType;
+    LiskMultisignatureType: LiskMultisignatureType;
+    LiskTransactionAsset: LiskTransactionAsset;
+    LiskTransactionCommon: LiskTransactionCommon;
+    LiskSignTx: LiskSignTx;
+    LiskSignedTx: LiskSignedTx;
+    LiskSignMessage: LiskSignMessage;
+    LiskMessageSignature: LiskMessageSignature;
+    LiskVerifyMessage: LiskVerifyMessage;
+    Initialize: Initialize;
+    GetFeatures: GetFeatures;
+    Features: Features;
+    LockDevice: LockDevice;
+    EndSession: EndSession;
+    ApplySettings: ApplySettings;
+    ApplyFlags: ApplyFlags;
+    ChangePin: ChangePin;
+    ChangeWipeCode: ChangeWipeCode;
+    SdProtect: SdProtect;
+    Ping: Ping;
+    Cancel: Cancel;
+    GetEntropy: $Exact<GetEntropy>;
+    Entropy: $Exact<Entropy>;
+    WipeDevice: WipeDevice;
+    LoadDevice: LoadDevice;
+    ResetDevice: ResetDevice;
+    BackupDevice: BackupDevice;
+    EntropyRequest: EntropyRequest;
+    EntropyAck: EntropyAck;
+    RecoveryDevice: RecoveryDevice;
+    WordRequest: WordRequest;
+    WordAck: $Exact<WordAck>;
+    SetU2FCounter: SetU2FCounter;
+    GetNextU2FCounter: GetNextU2FCounter;
+    NextU2FCounter: NextU2FCounter;
+    DoPreauthorized: DoPreauthorized;
+    PreauthorizedRequest: PreauthorizedRequest;
+    CancelAuthorization: CancelAuthorization;
+    NEMGetAddress: NEMGetAddress;
+    NEMAddress: $Exact<NEMAddress>;
+    NEMTransactionCommon: NEMTransactionCommon;
+    NEMMosaic: NEMMosaic;
+    NEMTransfer: NEMTransfer;
+    NEMProvisionNamespace: NEMProvisionNamespace;
+    NEMMosaicDefinition: NEMMosaicDefinition;
+    NEMMosaicCreation: NEMMosaicCreation;
+    NEMMosaicSupplyChange: NEMMosaicSupplyChange;
+    NEMCosignatoryModification: NEMCosignatoryModification;
+    NEMAggregateModification: NEMAggregateModification;
+    NEMImportanceTransfer: NEMImportanceTransfer;
+    NEMSignTx: NEMSignTx;
+    NEMSignedTx: NEMSignedTx;
+    NEMDecryptMessage: NEMDecryptMessage;
+    NEMDecryptedMessage: NEMDecryptedMessage;
+    RippleGetAddress: RippleGetAddress;
+    RippleAddress: RippleAddress;
+    RipplePayment: RipplePayment;
+    RippleSignTx: RippleSignTx;
+    RippleSignedTx: RippleSignedTx;
+    StellarAssetType: StellarAssetType;
+    StellarGetAddress: StellarGetAddress;
+    StellarAddress: StellarAddress;
+    StellarSignTx: StellarSignTx;
+    StellarTxOpRequest: StellarTxOpRequest;
+    StellarPaymentOp: StellarPaymentOp;
+    StellarCreateAccountOp: StellarCreateAccountOp;
+    StellarPathPaymentOp: StellarPathPaymentOp;
+    StellarManageOfferOp: StellarManageOfferOp;
+    StellarCreatePassiveOfferOp: StellarCreatePassiveOfferOp;
+    StellarSetOptionsOp: StellarSetOptionsOp;
+    StellarChangeTrustOp: StellarChangeTrustOp;
+    StellarAllowTrustOp: StellarAllowTrustOp;
+    StellarAccountMergeOp: StellarAccountMergeOp;
+    StellarManageDataOp: StellarManageDataOp;
+    StellarBumpSequenceOp: StellarBumpSequenceOp;
+    StellarSignedTx: StellarSignedTx;
+    TezosGetAddress: TezosGetAddress;
+    TezosAddress: TezosAddress;
+    TezosGetPublicKey: TezosGetPublicKey;
+    TezosPublicKey: TezosPublicKey;
+    TezosContractID: TezosContractID;
+    TezosRevealOp: TezosRevealOp;
+    TezosManagerTransfer: TezosManagerTransfer;
+    TezosParametersManager: TezosParametersManager;
+    TezosTransactionOp: TezosTransactionOp;
+    TezosOriginationOp: TezosOriginationOp;
+    TezosDelegationOp: TezosDelegationOp;
+    TezosProposalOp: TezosProposalOp;
+    TezosBallotOp: TezosBallotOp;
+    TezosSignTx: TezosSignTx;
+    TezosSignedTx: TezosSignedTx;
+};
+
+export type MessageKey = $Keys<MessageType>;
+
+export type MessageResponse<T: MessageKey> = {
+    type: T;
+    message: $ElementType<MessageType, T>;
+};
+
+export type TypedCall = <T: MessageKey, R: MessageKey>(
+    type: T,
+    resType: R,
+    message?: $ElementType<MessageType, T>
+) => Promise<MessageResponse<R>>;

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -62,19 +62,6 @@ export type PublicKey = {
     xpub: string;
 };
 
-// combined Bitcoin.PublicKey and Bitcoin.HDNode
-export type HDNodeResponse = {
-    path: Array<number>;
-    serializedPath: string;
-    childNum: number;
-    xpub: string;
-    xpubSegwit?: string;
-    chainCode: string;
-    publicKey: string;
-    fingerprint: number;
-    depth: number;
-};
-
 // Bitcoin.getAddress response
 export type Address = {
     address: string;

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -81,9 +81,7 @@ describe('utils/deviceFeaturesUtils', () => {
         expect(parseCapabilities({
             major_version: 1,
             capabilities: [1000],
-        })).toEqual([
-            'Capability_Unknown_trezor-connect',
-        ]);
+        })).toEqual([]);
     });
 
     it('getUnavailableCapabilities', () => {

--- a/src/js/utils/deviceFeaturesUtils.js
+++ b/src/js/utils/deviceFeaturesUtils.js
@@ -1,10 +1,10 @@
 /* @flow */
 import { versionCompare } from './versionUtils';
 import type { Features, CoinInfo } from '../types';
+import type { Capability } from '../types/trezor/protobuf';
 
 // From protobuf
-const CAPABILITIES = [
-    undefined,
+const CAPABILITIES: Capability[] = [
     'Capability_Bitcoin',
     'Capability_Bitcoin_like',
     'Capability_Binance',
@@ -27,14 +27,14 @@ const CAPABILITIES = [
 const DEFAULT_CAPABILITIES_T1 = [1, 2, 5, 7, 8, 10, 12, 14];
 const DEFAULT_CAPABILITIES_TT = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
 
-export const parseCapabilities = (features?: Features): string[] => {
+export const parseCapabilities = (features?: Features): Capability[] => {
     if (!features || features.firmware_present === false) return []; // no features or no firmware - no capabilities
     // needs to be "any" since Features.capabilities are declared as string[] but in fact it's a number[]
-    const filter = (c: any) => CAPABILITIES[c] || 'Capability_Unknown_trezor-connect';
+    const filter = (c: any) => CAPABILITIES[c - 1] ? [CAPABILITIES[c - 1]] : [];
     // fallback for older firmware
-    if (!features.capabilities || !features.capabilities.length) return features.major_version === 1 ? DEFAULT_CAPABILITIES_T1.map(filter) : DEFAULT_CAPABILITIES_TT.map(filter);
+    if (!features.capabilities || !features.capabilities.length) return features.major_version === 1 ? DEFAULT_CAPABILITIES_T1.flatMap(filter) : DEFAULT_CAPABILITIES_TT.flatMap(filter);
     // regular capabilities
-    return features.capabilities.map(filter);
+    return features.capabilities.flatMap(filter);
 };
 
 // TODO: support type

--- a/src/js/utils/hdnode.js
+++ b/src/js/utils/hdnode.js
@@ -2,12 +2,12 @@
 import * as bitcoin from '@trezor/utxo-lib';
 import * as ecurve from 'ecurve';
 import { ERRORS } from '../constants';
-import type { PublicKey, HDPubNode } from '../types/trezor/protobuf';
+import type { PublicKey, EthereumPublicKey, HDNodeType } from '../types/trezor/protobuf';
 
 const curve = ecurve.getCurveByName('secp256k1');
 
 const pubNode2bjsNode = (
-    node: HDPubNode,
+    node: HDNodeType,
     network: bitcoin.Network
 ): bitcoin.HDNode => {
     const chainCode = Buffer.from(node.chain_code, 'hex');
@@ -51,13 +51,13 @@ export const convertBitcoinXpub = (xpub: string, network: bitcoin.Network): stri
 // converts from internal PublicKey format to bitcoin.js HDNode
 // network info is necessary. throws error on wrong xpub
 const pubKey2bjsNode = (
-    key: PublicKey,
+    key: PublicKey | EthereumPublicKey,
     network: bitcoin.Network
 ): bitcoin.HDNode => {
-    const keyNode: HDPubNode = key.node;
-    const bjsNode: bitcoin.HDNode = pubNode2bjsNode(keyNode, network);
-    const bjsXpub: string = bjsNode.toBase58();
-    const keyXpub: string = convertXpub(key.xpub, network);
+    const keyNode = key.node;
+    const bjsNode = pubNode2bjsNode(keyNode, network);
+    const bjsXpub = bjsNode.toBase58();
+    const keyXpub = convertXpub(key.xpub, network);
     if (bjsXpub !== keyXpub) {
         throw ERRORS.TypedError('Runtime', `pubKey2bjsNode: Invalid public key transmission detected. Key: ${bjsXpub}, Received: ${keyXpub}`);
     }
@@ -79,8 +79,9 @@ const checkDerivation = (
     }
 };
 
-export const xpubDerive = (xpub: PublicKey,
-    childXPub: PublicKey,
+export const xpubDerive = (
+    xpub: PublicKey | EthereumPublicKey,
+    childXPub: PublicKey | EthereumPublicKey,
     suffix: number,
     network?: bitcoin.Network,
     requestedNetwork?: bitcoin.Network
@@ -92,7 +93,7 @@ export const xpubDerive = (xpub: PublicKey,
     return xpub;
 };
 
-export const xpubToHDNodeType = (xpub: string, network: bitcoin.Network): HDPubNode => {
+export const xpubToHDNodeType = (xpub: string, network: bitcoin.Network): HDNodeType => {
     const hd = bitcoin.HDNode.fromBase58(xpub, network);
     return {
         depth: hd.depth,

--- a/src/ts/types/account.d.ts
+++ b/src/ts/types/account.d.ts
@@ -1,4 +1,4 @@
-import { TransactionInput, TransactionOutput } from './trezor/protobuf';
+import { TxInputType, TxOutputType } from './trezor/protobuf';
 import { VinVout } from './backend/transactions';
 
 // getAccountInfo params
@@ -227,8 +227,8 @@ export type PrecomposedTransaction =
           feePerByte: string;
           bytes: number;
           transaction: {
-              inputs: TransactionInput[];
-              outputs: TransactionOutput[];
+              inputs: TxInputType[];
+              outputs: TxOutputType[];
           };
       };
 

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -227,10 +227,10 @@ export namespace TrezorConnect {
     ): P.BundledResponse<Bitcoin.HDNodeResponse>;
     function ethereumSignTransaction(
         params: P.CommonParams & Ethereum.EthereumSignTransaction,
-    ): P.Response<Protobuf.EthereumSignedTx>;
+    ): P.Response<Ethereum.EthereumSignedTx>;
     function ethereumSignTransaction(
         params: P.CommonParams & P.Bundle<Ethereum.EthereumSignTransaction>,
-    ): P.BundledResponse<Protobuf.EthereumSignedTx>;
+    ): P.BundledResponse<Ethereum.EthereumSignedTx>;
     function ethereumSignMessage(
         params: P.CommonParams & Ethereum.EthereumSignMessage,
     ): P.Response<Protobuf.MessageSignature>;

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -121,10 +121,10 @@ export namespace TrezorConnect {
      * User is presented with a description of the requested key and asked to
      * confirm the export.
      */
-    function getPublicKey(params: P.CommonParams & Bitcoin.GetPublicKey): P.Response<Protobuf.HDNodeResponse>;
+    function getPublicKey(params: P.CommonParams & Bitcoin.GetPublicKey): P.Response<Bitcoin.HDNodeResponse>;
     function getPublicKey(
         params: P.CommonParams & P.Bundle<Bitcoin.GetPublicKey>,
-    ): P.BundledResponse<Protobuf.HDNodeResponse>;
+    ): P.BundledResponse<Bitcoin.HDNodeResponse>;
 
     /**
      * Bitcoin and Bitcoin-like
@@ -221,10 +221,10 @@ export namespace TrezorConnect {
     ): P.BundledResponse<Ethereum.EthereumAddress>;
     function ethereumGetPublicKey(
         params: P.CommonParams & Ethereum.EthereumGetPublicKey,
-    ): P.Response<Protobuf.HDNodeResponse>;
+    ): P.Response<Bitcoin.HDNodeResponse>;
     function ethereumGetPublicKey(
         params: P.CommonParams & P.Bundle<Ethereum.EthereumGetPublicKey>,
-    ): P.BundledResponse<Protobuf.HDNodeResponse>;
+    ): P.BundledResponse<Bitcoin.HDNodeResponse>;
     function ethereumSignTransaction(
         params: P.CommonParams & Ethereum.EthereumSignTransaction,
     ): P.Response<Protobuf.EthereumSignedTx>;

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -112,7 +112,4 @@ export interface VerifyMessage {
     coin: string;
 }
 
-export { 
-    TxInputType as TransactionInput,
-    TxOutputType as TransactionOutput
-} from '../trezor/protobuf';
+export { TxInputType, TxOutputType } from '../trezor/protobuf';

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -1,9 +1,9 @@
 import {
-    TransactionInput,
-    TransactionOutput,
-    RefTransaction,
+    RefTxInputType,
+    TxInputType,
+    TxOutputType,
+    TxOutputBinType,
     Address as ProtobufAddress,
-    SignedTx,
 } from '../trezor/protobuf';
 
 // getAddress params
@@ -17,6 +17,7 @@ export interface GetAddress {
 
 // getAddress response
 export type Address = ProtobufAddress & {
+    path: number[];
     serializedPath: string;
 };
 
@@ -40,10 +41,36 @@ export interface HDNodeResponse {
     depth: number;
 }
 
+// based on PROTO.TransactionType, with required fields
+export type RefTransaction = {
+    hash: string;
+    version?: number;
+    inputs: RefTxInputType[];
+    bin_outputs: TxOutputBinType[];
+    lock_time?: number;
+    extra_data?: string;
+    expiry?: number;
+    overwintered?: boolean;
+    version_group_id?: number;
+    timestamp?: number;
+    branch_id?: number;
+};
+
+// based on PROTO.SignTx, only optional fields
+export type TransactionOptions = {
+    version?: number;
+    lock_time?: number;
+    expiry?: number;
+    overwintered?: boolean;
+    version_group_id?: number;
+    timestamp?: number;
+    branch_id?: number;
+};
+
 // signTransaction params
 export interface SignTransaction {
-    inputs: TransactionInput[];
-    outputs: TransactionOutput[];
+    inputs: TxInputType[];
+    outputs: TxOutputType[];
     refTxs?: RefTransaction[];
     coin: string;
     locktime?: number;
@@ -55,7 +82,9 @@ export interface SignTransaction {
     branchId?: number;
     push?: boolean;
 }
-export type SignedTransaction = SignedTx & {
+export type SignedTransaction = {
+    signatures: string[];
+    serializedTx: string;
     txid?: string;
 };
 
@@ -83,4 +112,7 @@ export interface VerifyMessage {
     coin: string;
 }
 
-export { TransactionInput, TransactionOutput } from '../trezor/protobuf';
+export { 
+    TxInputType as TransactionInput,
+    TxOutputType as TransactionOutput
+} from '../trezor/protobuf';

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -27,6 +27,19 @@ export interface GetPublicKey {
     crossChain?: boolean;
 }
 
+// combined Bitcoin.PublicKey and Bitcoin.HDNode
+export interface HDNodeResponse {
+    path: number[];
+    serializedPath: string;
+    childNum: number;
+    xpub: string;
+    xpubSegwit?: string;
+    chainCode: string;
+    publicKey: string;
+    fingerprint: number;
+    depth: number;
+}
+
 // signTransaction params
 export interface SignTransaction {
     inputs: TransactionInput[];

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -1,7 +1,10 @@
-import { CARDANO } from '../constants';
 
 // Cardano method parameters types
-import { HDPubNode } from '../trezor/protobuf';
+import { 
+    HDNodeType,
+    CardanoAddressType,
+    CardanoCertificateType,
+} from '../trezor/protobuf';
 
 // GetPublicKey
 
@@ -14,7 +17,7 @@ export interface CardanoPublicKey {
     path: number[];
     serializedPath: string;
     publicKey: string;
-    node: HDPubNode;
+    node: HDNodeType;
 }
 
 // GetAddress
@@ -26,7 +29,7 @@ export interface CardanoCertificatePointer {
 }
 
 export interface CardanoAddressParameters {
-    addressType: CARDANO.ADDRESS_TYPE;
+    addressType: CardanoAddressType;
     path: string | number[];
     stakingPath?: string | number[];
     stakingKeyHash?: string;
@@ -68,7 +71,7 @@ export type CardanoOutput =
           amount: string;
       };
 export type CardanoCertificate = {
-    type: CARDANO.CERTIFICATE_TYPE;
+    type: CardanoCertificateType;
     path: string | number[];
     pool?: string;
 }

--- a/src/ts/types/networks/eos.d.ts
+++ b/src/ts/types/networks/eos.d.ts
@@ -7,6 +7,7 @@ import {
     EosActionDeleteAuth,
     EosActionLinkAuth,
     EosActionUnlinkAuth,
+    EosAuthorizationWait,
 } from '../trezor/protobuf';
 
 // get public key
@@ -41,10 +42,7 @@ export interface EosAuthorization {
         permission: EosPermissionLevel;
         weight: number;
     }>;
-    waits: Array<{
-        wait_sec: number;
-        weight: number;
-    }>;
+    waits: EosAuthorizationWait[];
 }
 
 export interface EosTxActionCommon {

--- a/src/ts/types/networks/ethereum.d.ts
+++ b/src/ts/types/networks/ethereum.d.ts
@@ -40,6 +40,12 @@ export interface EthereumSignTransaction {
     transaction: EthereumTransaction;
 }
 
+export interface EthereumSignedTx {
+    v: string;
+    r: string;
+    s: string;
+}
+
 // sign message
 
 export interface EthereumSignMessage {

--- a/src/ts/types/trezor/device.d.ts
+++ b/src/ts/types/trezor/device.d.ts
@@ -1,5 +1,6 @@
 import { getInfo } from '@trezor/rollout';
 import { DEVICE } from '../constants';
+import { Features } from './protobuf';
 
 export interface DeviceStateResponse {
     state: string;
@@ -30,42 +31,6 @@ export interface FirmwareRange {
 }
 
 export type FirmwareRelease = ReturnType<typeof getInfo>;
-
-export interface Features {
-    bootloader_hash?: string | null;
-    bootloader_mode?: boolean | null;
-    device_id: string | null;
-    firmware_present?: boolean | null;
-    flags: number;
-    fw_major?: number | null;
-    fw_minor?: number | null;
-    fw_patch?: number | null;
-    fw_vendor?: string | null;
-    fw_vendor_keys?: string | null;
-    imported?: boolean | null;
-    initialized: boolean;
-    label: string | null;
-    language?: string | null;
-    major_version: number;
-    minor_version: number;
-    model: string;
-    needs_backup: boolean;
-    no_backup: boolean;
-    passphrase_cached: boolean;
-    passphrase_protection: boolean;
-    patch_version: number;
-    pin_cached: boolean;
-    unlocked?: boolean; // replacement for "pin_cached" since 2.3.2
-    pin_protection: boolean;
-    revision: string;
-    unfinished_backup: boolean;
-    vendor: string;
-    recovery_mode?: boolean;
-    session_id?: string;
-    passphrase_always_on_device?: boolean;
-    capabilities?: string[];
-    backup_type?: 'Bip39' | 'Slip39_Basic' | 'Slip39_Advanced' | null;
-}
 
 export type KnownDevice = {
     type: 'acquired';
@@ -101,3 +66,5 @@ export interface DeviceEvent {
     type: typeof DEVICE.CONNECT | typeof DEVICE.CONNECT_UNACQUIRED | typeof DEVICE.CHANGED | typeof DEVICE.DISCONNECT;
     payload: Device;
 }
+
+export type { Features } from './protobuf';

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -62,19 +62,6 @@ export interface PublicKey {
     xpub: string;
 }
 
-// combined Bitcoin.PublicKey and Bitcoin.HDNode
-export interface HDNodeResponse {
-    path: number[];
-    serializedPath: string;
-    childNum: number;
-    xpub: string;
-    xpubSegwit?: string;
-    chainCode: string;
-    publicKey: string;
-    fingerprint: number;
-    depth: number;
-}
-
 // Bitcoin.getAddress response
 export interface Address {
     address: string;

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -1,830 +1,920 @@
-// This file has all various types that go into Trezor or out of it.
+// This file is auto generated from data/messages/message.json
+export enum Enum_InputScriptType {
+    SPENDADDRESS = 0,
+    SPENDMULTISIG = 1,
+    EXTERNAL = 2,
+    SPENDWITNESS = 3,
+    SPENDP2SHWITNESS = 4,
+}
+export type InputScriptType = keyof typeof Enum_InputScriptType;
 
-export interface CipheredKeyValue {
-    value: string;
+export enum CardanoAddressType {
+    BASE = 0,
+    BASE_SCRIPT_KEY = 1,
+    BASE_KEY_SCRIPT = 2,
+    BASE_SCRIPT_SCRIPT = 3,
+    POINTER = 4,
+    POINTER_SCRIPT = 5,
+    ENTERPRISE = 6,
+    ENTERPRISE_SCRIPT = 7,
+    BYRON = 8,
+    REWARD = 14,
+    REWARD_SCRIPT = 15,
 }
 
-export interface Success {
-    __avoid_empty?: null;
+export enum CardanoCertificateType {
+    STAKE_REGISTRATION = 0,
+    STAKE_DEREGISTRATION = 1,
+    STAKE_DELEGATION = 2,
 }
 
-export interface Features {
-    vendor: string;
-    major_version: number;
-    minor_version: number;
-    patch_version: number;
-    bootloader_mode: boolean;
-    device_id: string;
-    pin_protection: boolean;
-    passphrase_protection: boolean;
-    language: string;
-    label: string;
-    initialized: boolean;
-    revision: string;
-    bootloader_hash: string;
-    imported: boolean;
-    pin_cached: boolean;
-    unlocked?: boolean; // replacement for "pin_cached" since 2.3.2
-    passphrase_cached: boolean;
-    firmware_present: boolean;
-    needs_backup: boolean;
-    flags: number;
-    model: string;
-    fw_major: number;
-    fw_minor: number;
-    fw_patch: number;
-    fw_vendor: string;
-    fw_vendor_keys: string;
-    unfinished_backup: boolean;
-    no_backup: boolean;
+export enum Enum_BackupType {
+    Bip39 = 0,
+    Slip39_Basic = 1,
+    Slip39_Advanced = 2,
 }
+export type BackupType = keyof typeof Enum_BackupType;
 
-export interface HDPrivNode {
-    depth: number;
-    fingerprint: number;
-    child_num: number;
-    chain_code: string;
-    private_key: string;
-}
+// BinanceGetAddress
+export type BinanceGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
 
-export interface HDPubNode {
-    depth: number;
-    fingerprint: number;
-    child_num: number;
-    chain_code: string;
+// BinanceAddress
+export type BinanceAddress = {
+    address: string;
+};
+
+// BinanceGetPublicKey
+export type BinanceGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// BinancePublicKey
+export type BinancePublicKey = {
     public_key: string;
+};
+
+// BinanceSignTx
+export type BinanceSignTx = {
+    address_n: number[];
+    msg_count?: number;
+    account_number?: number;
+    chain_id?: string;
+    memo?: string;
+    sequence?: number;
+    source?: number;
+};
+
+// BinanceTxRequest
+export type BinanceTxRequest = {};
+
+export type BinanceCoin = {
+    amount?: number;
+    denom?: string;
+};
+
+export type BinanceInputOutput = {
+    address?: string;
+    coins: BinanceCoin[];
+};
+
+// BinanceTransferMsg
+export type BinanceTransferMsg = {
+    inputs: BinanceInputOutput[];
+    outputs: BinanceInputOutput[];
+};
+
+export enum BinanceOrderType {
+    OT_UNKNOWN = 0,
+    MARKET = 1,
+    LIMIT = 2,
+    OT_RESERVED = 3,
 }
 
-export type HDNode = HDPubNode | HDPrivNode;
-
-export interface PublicKey {
-    node: HDPubNode;
-    xpub: string;
+export enum BinanceOrderSide {
+    SIDE_UNKNOWN = 0,
+    BUY = 1,
+    SELL = 2,
 }
 
-// Bitcoin.getAddress response
-export interface Address {
-    address: string;
-    path: number[];
+export enum BinanceTimeInForce {
+    TIF_UNKNOWN = 0,
+    GTE = 1,
+    TIF_RESERVED = 2,
+    IOC = 3,
 }
 
-export interface MessageSignature {
-    address: string;
+// BinanceOrderMsg
+export type BinanceOrderMsg = {
+    id?: string;
+    ordertype?: BinanceOrderType;
+    price?: number;
+    quantity?: number;
+    sender?: string;
+    side?: BinanceOrderSide;
+    symbol?: string;
+    timeinforce?: BinanceTimeInForce;
+};
+
+// BinanceCancelMsg
+export type BinanceCancelMsg = {
+    refid?: string;
+    sender?: string;
+    symbol?: string;
+};
+
+// BinanceSignedTx
+export type BinanceSignedTx = {
     signature: string;
-}
+    public_key: string;
+};
 
-// Bitcoin.signTransaction
+// HDNodeType
+export type HDNodeType = {
+    depth: number;
+    fingerprint: number;
+    child_num: number;
+    chain_code: string;
+    private_key?: string;
+    public_key: string;
+};
 
-export interface MultisigRedeemScriptType {
-    pubkeys: Array<{ node: string | HDPubNode; address_n: number[] }>;
+export type HDNodePathType = {
+    node: HDNodeType | string;
+    address_n: number[];
+};
+
+// MultisigRedeemScriptType
+export type MultisigRedeemScriptType = {
+    pubkeys: HDNodePathType[];
     signatures: string[];
     m?: number;
-}
+    nodes?: HDNodeType[];
+    address_n?: number[];
+};
 
-export type InputScriptType = 'SPENDADDRESS' | 'SPENDMULTISIG' | 'SPENDWITNESS' | 'SPENDP2SHWITNESS';
-
-// transaction input, parameter of SignTx message, declared by user
-export interface TransactionInput {
+// GetPublicKey
+export type GetPublicKey = {
     address_n: number[];
-    prev_hash: string;
-    prev_index: number;
+    ecdsa_curve_name?: string;
+    show_display?: boolean;
+    coin_name?: string;
     script_type?: InputScriptType;
-    sequence?: number;
-    amount?: string; // (segwit, bip143: true, zcash overwinter)
+};
+
+// PublicKey
+export type PublicKey = {
+    node: HDNodeType;
+    xpub: string;
+};
+
+// GetAddress
+export type GetAddress = {
+    address_n: number[];
+    coin_name?: string;
+    show_display?: boolean;
     multisig?: MultisigRedeemScriptType;
-}
+    script_type?: InputScriptType;
+};
 
-export type OutputScriptType = 'PAYTOADDRESS' | 'PAYTOMULTISIG' | 'PAYTOWITNESS' | 'PAYTOP2SHWITNESS';
+// Address
+export type Address = {
+    address: string;
+};
 
-// transaction output, parameter of SignTx message, declared by user
-export type TransactionOutput =
-    | {
-          address: string;
-          address_n?: undefined;
-          script_type: 'PAYTOADDRESS';
-          amount: string;
-          multisig?: MultisigRedeemScriptType;
-      }
-    | {
-          address?: undefined;
-          address_n: number[];
-          script_type: OutputScriptType;
-          amount: string;
-          multisig?: MultisigRedeemScriptType;
-      }
-    | {
-          address?: undefined;
-          address_n?: undefined;
-          amount: '0';
-          op_return_data: string;
-          script_type: 'PAYTOOPRETURN';
-      };
+// GetOwnershipId
+export type GetOwnershipId = {
+    address_n: number[];
+    coin_name?: string;
+    multisig?: MultisigRedeemScriptType;
+    script_type?: InputScriptType;
+};
 
-export interface TransactionBinOutput {
-    amount: string;
-    script_pubkey: string;
-}
+// OwnershipId
+export type OwnershipId = {
+    ownership_id: string;
+};
 
-// transaction input, parameter of TxAck message, declared by user or downloaded from backend
-export interface RefTransactionInput {
-    prev_hash: string;
-    prev_index: number;
-    script_sig: string;
-    sequence: number;
-}
+// SignMessage
+export type SignMessage = {
+    address_n: number[];
+    message: string;
+    coin_name?: string;
+    script_type?: InputScriptType;
+};
 
-export interface RefTransaction {
-    hash: string;
+// MessageSignature
+export type MessageSignature = {
+    address: string;
+    signature: string;
+};
+
+// VerifyMessage
+export type VerifyMessage = {
+    address?: string;
+    signature?: string;
+    message?: string;
+    coin_name?: string;
+};
+
+// SignTx
+export type SignTx = {
+    outputs_count: number;
+    inputs_count: number;
+    coin_name?: string;
     version?: number;
-    inputs: RefTransactionInput[];
-    bin_outputs: TransactionBinOutput[];
     lock_time?: number;
-    extra_data?: string;
-    timestamp?: number;
-    version_group_id?: number;
-    expiry?: number;
-    branch_id?: number;
-}
-
-export interface TransactionOptions {
-    lock_time?: number;
-    timestamp?: number;
-    version?: number;
     expiry?: number;
     overwintered?: boolean;
     version_group_id?: number;
+    timestamp?: number;
     branch_id?: number;
-}
+};
 
-export interface TxRequestDetails {
+export enum Enum_RequestType {
+    TXINPUT = 0,
+    TXOUTPUT = 1,
+    TXMETA = 2,
+    TXFINISHED = 3,
+    TXEXTRADATA = 4,
+}
+export type RequestType = keyof typeof Enum_RequestType;
+
+export type TxRequestDetailsType = {
     request_index: number;
     tx_hash?: string;
     extra_data_len?: number;
     extra_data_offset?: number;
-}
+};
 
-export interface TxRequestSerialized {
+export type TxRequestSerializedType = {
     signature_index?: number;
     signature?: string;
     serialized_tx?: string;
+};
+
+// TxRequest
+export type TxRequest = {
+    request_type: RequestType;
+    details: TxRequestDetailsType;
+    serialized?: TxRequestSerializedType;
+};
+
+export type TxInputType = {
+    address_n: number[];
+    prev_hash: string;
+    prev_index: number;
+    script_sig?: string;
+    sequence?: number;
+    script_type?: InputScriptType;
+    multisig?: MultisigRedeemScriptType;
+    amount?: number | string;
+    decred_tree?: number;
+    witness?: string;
+    ownership_proof?: string;
+};
+
+export type TxOutputBinType = {
+    amount: number | string;
+    script_pubkey: string;
+    decred_script_version?: number;
+};
+
+export enum Enum_OutputScriptType {
+    PAYTOADDRESS = 0,
+    PAYTOSCRIPTHASH = 1,
+    PAYTOMULTISIG = 2,
+    PAYTOOPRETURN = 3,
+    PAYTOWITNESS = 4,
+    PAYTOP2SHWITNESS = 5,
 }
+export type OutputScriptType = keyof typeof Enum_OutputScriptType;
 
-export interface TxRequest {
-    request_type: 'TXINPUT' | 'TXOUTPUT' | 'TXMETA' | 'TXFINISHED' | 'TXEXTRADATA';
-    details: TxRequestDetails;
-    serialized: TxRequestSerialized;
-}
-
-export interface SignedTx {
-    signatures: string[];
-    serializedTx: string;
-}
-
-// Ethereum.signTransaction
-
-export interface EthereumTxRequest {
-    data_length?: number;
-    signature_v?: number;
-    signature_r?: string;
-    signature_s?: string;
-}
-
-export interface EthereumAddress {
+// - replacement
+export type TxOutputType = {
     address: string;
+    address_n?: typeof undefined;
+    script_type: 'PAYTOADDRESS';
+    amount: string;
+    multisig?: MultisigRedeemScriptType;
+} | {
+    address?: typeof undefined;
+    address_n: number[];
+    script_type: OutputScriptType;
+    amount: string;
+    multisig?: MultisigRedeemScriptType;
+} | {
+    address?: typeof undefined;
+    address_n?: typeof undefined;
+    amount: '0';
+    op_return_data: string;
+    script_type: 'PAYTOOPRETURN';
+};
+// - replacement end
+
+// TxAck
+// - replacement
+export type RefTxInputType = {
+    prev_hash: string;
+    prev_index: number;
+    script_sig: string;
+    sequence: number;
+};
+
+export type TxAckResponse = {
+    inputs: Array<TxInputType | RefTxInputType>;
+} | {
+    bin_outputs: TxOutputBinType[];
+} | {
+    outputs: TxOutputType[];
+} | {
+    extra_data: string;
+} | {
+    version?: number;
+    lock_time?: number;
+    inputs_cnt: number;
+    outputs_cnt: number;
+    extra_data?: string;
+    extra_data_len?: number;
+    timestamp?: number;
+    version_group_id?: number;
+    expiry?: number;
+    branch_id?: number;
+};
+
+export type TxAck = {
+    tx: TxAckResponse;
+};
+// - replacement end
+
+// GetOwnershipProof
+export type GetOwnershipProof = {
+    address_n: number[];
+    coin_name?: string;
+    script_type?: InputScriptType;
+    multisig?: MultisigRedeemScriptType;
+    user_confirmation?: boolean;
+    ownership_ids: string[];
+    commitment_data?: string;
+};
+
+// OwnershipProof
+export type OwnershipProof = {
+    ownership_proof: string;
+    signature: string;
+};
+
+// AuthorizeCoinJoin
+export type AuthorizeCoinJoin = {
+    coordinator: string;
+    max_total_fee: number;
+    fee_per_anonymity?: number;
+    address_n: number[];
+    coin_name?: string;
+    script_type?: InputScriptType;
+};
+
+// FirmwareErase
+export type FirmwareErase = {
+    length?: number;
+};
+
+// FirmwareRequest
+export type FirmwareRequest = {
+    offset?: number;
+    length?: number;
+};
+
+// FirmwareUpload
+export type FirmwareUpload = {
+    payload: Buffer;
+    hash?: string;
+};
+
+// SelfTest
+export type SelfTest = {
+    payload?: string;
+};
+
+// CardanoBlockchainPointerType
+export type CardanoBlockchainPointerType = {
+    block_index: number;
+    tx_index: number;
+    certificate_index: number;
+};
+
+// CardanoAddressParametersType
+export type CardanoAddressParametersType = {
+    address_type: CardanoAddressType;
+    address_n: number[];
+    address_n_staking: number[];
+    staking_key_hash?: string;
+    certificate_pointer?: CardanoBlockchainPointerType;
+};
+
+// CardanoGetAddress
+export type CardanoGetAddress = {
+    show_display?: boolean;
+    protocol_magic: number;
+    network_id: number;
+    address_parameters: CardanoAddressParametersType;
+};
+
+// CardanoAddress
+export type CardanoAddress = {
+    address: string;
+};
+
+// CardanoGetPublicKey
+export type CardanoGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// CardanoPublicKey
+export type CardanoPublicKey = {
+    xpub: string;
+    node: HDNodeType;
+};
+
+export type CardanoTxInputType = {
+    address_n: number[];
+    prev_hash?: string;
+    prev_index?: number;
+};
+
+export type CardanoTxOutputType = {
+    address?: string;
+    amount?: number;
+    address_parameters?: CardanoAddressParametersType;
+};
+
+export type CardanoTxCertificateType = {
+    type?: CardanoCertificateType;
+    path: number[];
+    pool?: string;
+};
+
+export type CardanoTxWithdrawalType = {
+    path: number[];
+    amount?: number;
+};
+
+// CardanoSignTx
+export type CardanoSignTx = {
+    inputs: CardanoTxInputType[];
+    outputs: CardanoTxOutputType[];
+    protocol_magic?: number;
+    fee?: string | number;
+    ttl?: string | number;
+    network_id?: number;
+    certificates: CardanoTxCertificateType[];
+    withdrawals: CardanoTxWithdrawalType[];
+    metadata?: string;
+};
+
+// CardanoSignedTx
+export type CardanoSignedTx = {
+    tx_hash: string;
+    serialized_tx: string;
+};
+
+// Success
+export type Success = {
+    message: string;
+};
+
+export enum FailureType {
+    Failure_UnexpectedMessage = 1,
+    Failure_ButtonExpected = 2,
+    Failure_DataError = 3,
+    Failure_ActionCancelled = 4,
+    Failure_PinExpected = 5,
+    Failure_PinCancelled = 6,
+    Failure_PinInvalid = 7,
+    Failure_InvalidSignature = 8,
+    Failure_ProcessError = 9,
+    Failure_NotEnoughFunds = 10,
+    Failure_NotInitialized = 11,
+    Failure_PinMismatch = 12,
+    Failure_WipeCodeMismatch = 13,
+    Failure_FirmwareError = 99,
 }
 
-export interface EthereumSignedTx {
-    // v: number,
-    v: string;
-    r: string;
-    s: string;
+// Failure
+export type Failure = {
+    code?: FailureType;
+    message?: string;
+};
+
+export enum ButtonRequestType {
+    ButtonRequest_Other = 1,
+    ButtonRequest_FeeOverThreshold = 2,
+    ButtonRequest_ConfirmOutput = 3,
+    ButtonRequest_ResetDevice = 4,
+    ButtonRequest_ConfirmWord = 5,
+    ButtonRequest_WipeDevice = 6,
+    ButtonRequest_ProtectCall = 7,
+    ButtonRequest_SignTx = 8,
+    ButtonRequest_FirmwareCheck = 9,
+    ButtonRequest_Address = 10,
+    ButtonRequest_PublicKey = 11,
+    ButtonRequest_MnemonicWordCount = 12,
+    ButtonRequest_MnemonicInput = 13,
+    _Deprecated_ButtonRequest_PassphraseType = 14,
+    ButtonRequest_UnknownDerivationPath = 15,
+    ButtonRequest_RecoveryHomepage = 16,
+    ButtonRequest_Success = 17,
+    ButtonRequest_Warning = 18,
+    ButtonRequest_PassphraseEntry = 19,
+    ButtonRequest_PinEntry = 20,
 }
 
-export interface Identity {
+// ButtonRequest
+export type ButtonRequest = {
+    code?: ButtonRequestType;
+};
+
+// ButtonAck
+export type ButtonAck = {};
+
+export enum PinMatrixRequestType {
+    PinMatrixRequestType_Current = 1,
+    PinMatrixRequestType_NewFirst = 2,
+    PinMatrixRequestType_NewSecond = 3,
+    PinMatrixRequestType_WipeCodeFirst = 4,
+    PinMatrixRequestType_WipeCodeSecond = 5,
+}
+
+// PinMatrixRequest
+export type PinMatrixRequest = {
+    type?: PinMatrixRequestType;
+};
+
+// PinMatrixAck
+export type PinMatrixAck = {
+    pin: string;
+};
+
+// PassphraseRequest
+export type PassphraseRequest = {
+    _on_device?: boolean;
+};
+
+// PassphraseAck
+export type PassphraseAck = {
+    passphrase?: string;
+    _state?: string;
+    on_device?: boolean;
+};
+
+// Deprecated_PassphraseStateRequest
+export type Deprecated_PassphraseStateRequest = {
+    state?: string;
+};
+
+// Deprecated_PassphraseStateAck
+export type Deprecated_PassphraseStateAck = {};
+
+// CipherKeyValue
+export type CipherKeyValue = {
+    address_n: number[];
+    key?: string;
+    value?: string;
+    encrypt?: boolean;
+    ask_on_encrypt?: boolean;
+    ask_on_decrypt?: boolean;
+    iv?: string;
+};
+
+// CipheredKeyValue
+export type CipheredKeyValue = {
+    value?: string;
+};
+
+// IdentityType
+export type IdentityType = {
     proto?: string;
     user?: string;
     host?: string;
     port?: string;
     path?: string;
     index?: number;
-}
+};
 
-export interface SignedIdentity {
+// SignIdentity
+export type SignIdentity = {
+    identity?: IdentityType;
+    challenge_hidden?: string;
+    challenge_visual?: string;
+    ecdsa_curve_name?: string;
+};
+
+// SignedIdentity
+export type SignedIdentity = {
     address: string;
     public_key: string;
     signature: string;
+};
+
+// GetECDHSessionKey
+export type GetECDHSessionKey = {
+    identity?: IdentityType;
+    peer_public_key?: string;
+    ecdsa_curve_name?: string;
+};
+
+// ECDHSessionKey
+export type ECDHSessionKey = {
+    session_key?: string;
+};
+
+export enum DebugSwipeDirection {
+    UP = 0,
+    DOWN = 1,
+    LEFT = 2,
+    RIGHT = 3,
 }
 
-// this is what Trezor asks for
-export type SignTxInfoToTrezor =
-    | {
-          inputs: Array<TransactionInput | RefTransactionInput>;
-      }
-    | {
-          bin_outputs: TransactionBinOutput[];
-      }
-    | {
-          outputs: TransactionOutput[];
-      }
-    | {
-          extra_data: string;
-      }
-    | {
-          version: number;
-          lock_time: number;
-          inputs_cnt: number;
-          outputs_cnt: number;
-          extra_data_len?: number;
-          timestamp: number;
-          version_group_id: number;
-      };
+// DebugLinkDecision
+export type DebugLinkDecision = {
+    yes_no?: boolean;
+    swipe?: DebugSwipeDirection;
+    input?: string;
+    x?: number;
+    y?: number;
+    wait?: boolean;
+};
 
-// NEM types
-export interface NEMAddress {
-    address: string;
+// DebugLinkLayout
+export type DebugLinkLayout = {
+    lines: string[];
+};
+
+// DebugLinkReseedRandom
+export type DebugLinkReseedRandom = {
+    value?: number;
+};
+
+// DebugLinkRecordScreen
+export type DebugLinkRecordScreen = {
+    target_directory?: string;
+};
+
+export enum DebugLinkShowTextStyle {
+    NORMAL = 0,
+    BOLD = 1,
+    MONO = 2,
+    BR = 4,
+    BR_HALF = 5,
+    SET_COLOR = 6,
 }
 
-export interface NEMSignedTx {
-    data: string;
-    signature: string;
-}
+export type DebugLinkShowTextItem = {
+    style?: DebugLinkShowTextStyle;
+    content?: string;
+};
 
-export interface NEMTransactionCommon {
+// DebugLinkShowText
+export type DebugLinkShowText = {
+    header_text?: string;
+    body_text: DebugLinkShowTextItem[];
+    header_icon?: string;
+    icon_color?: string;
+};
+
+// DebugLinkGetState
+export type DebugLinkGetState = {
+    wait_word_list?: boolean;
+    wait_word_pos?: boolean;
+    wait_layout?: boolean;
+};
+
+// DebugLinkState
+export type DebugLinkState = {
+    layout?: string;
+    pin?: string;
+    matrix?: string;
+    mnemonic_secret?: string;
+    node?: HDNodeType;
+    passphrase_protection?: boolean;
+    reset_word?: string;
+    reset_entropy?: string;
+    recovery_fake_word?: string;
+    recovery_word_pos?: number;
+    reset_word_pos?: number;
+    mnemonic_type?: number;
+    layout_lines: string[];
+};
+
+// DebugLinkStop
+export type DebugLinkStop = {};
+
+// DebugLinkLog
+export type DebugLinkLog = {
+    level?: number;
+    bucket?: string;
+    text?: string;
+};
+
+// DebugLinkMemoryRead
+export type DebugLinkMemoryRead = {
+    address?: number;
+    length?: number;
+};
+
+// DebugLinkMemory
+export type DebugLinkMemory = {
+    memory?: string;
+};
+
+// DebugLinkMemoryWrite
+export type DebugLinkMemoryWrite = {
+    address?: number;
+    memory?: string;
+    flash?: boolean;
+};
+
+// DebugLinkFlashErase
+export type DebugLinkFlashErase = {
+    sector?: number;
+};
+
+// DebugLinkEraseSdCard
+export type DebugLinkEraseSdCard = {
+    format?: boolean;
+};
+
+// DebugLinkWatchLayout
+export type DebugLinkWatchLayout = {
+    watch?: boolean;
+};
+
+// EosGetPublicKey
+export type EosGetPublicKey = {
     address_n: number[];
-    network: number;
-    timestamp: number;
-    fee: number;
-    deadline: number;
-    signer: string;
-}
+    show_display?: boolean;
+};
 
-export interface NEMMosaic {
-    namespace: string;
-    mosaic: string;
-    quantity: number;
-}
-
-export interface NEMTransfer {
-    mosaics: NEMMosaic[];
-    public_key: string;
-    recipient: string;
-    amount: number | string;
-    payload: string;
-}
-
-export interface NEMProvisionNamespace {
-    namespace: string;
-    sink: string;
-    fee: number;
-    parent: string;
-}
-
-export type NEMMosaicLevyType =
-    | {
-          id: 1;
-          name: 'MosaicLevy_Absolute';
-      }
-    | {
-          id: 2;
-          name: 'MosaicLevy_Percentile';
-      };
-
-export type NEMSupplyChangeType =
-    | {
-          id: 1;
-          name: 'SupplyChange_Increase';
-      }
-    | {
-          id: 2;
-          name: 'SupplyChange_Decrease';
-      };
-
-export type NEMModificationType =
-    | {
-          id: 1;
-          name: 'CosignatoryModification_Add';
-      }
-    | {
-          id: 2;
-          name: 'CosignatoryModification_Delete';
-      };
-
-export type NEMImportanceTransferMode =
-    | {
-          id: 1;
-          name: 'ImportanceTransfer_Activate';
-      }
-    | {
-          id: 2;
-          name: 'ImportanceTransfer_Deactivate';
-      };
-
-export interface NEMMosaicDefinition {
-    name?: string;
-    ticker?: string;
-    namespace?: string;
-    mosaic?: string;
-    divisibility?: number;
-    fee?: number;
-    levy?: NEMMosaicLevyType;
-    levy_address?: string;
-    levy_namespace?: string;
-    levy_mosaic?: string;
-    supply?: number;
-    mutable_supply?: boolean;
-    transferable?: boolean;
-    description?: string;
-    networks?: number;
-}
-
-export interface NEMMosaicCreation {
-    definition: NEMMosaicDefinition;
-    sink: string;
-    fee: number;
-}
-
-export interface NEMMosaicSupplyChange {
-    namespace?: string;
-    type?: NEMSupplyChangeType;
-    mosaic?: string;
-    delta?: number;
-}
-
-export interface NEMCosignatoryModification {
-    type?: NEMModificationType;
-    public_key?: string;
-}
-
-export interface NEMAggregateModification {
-    modifications: NEMCosignatoryModification[];
-    relative_change: number; // TODO: "sint32"
-}
-
-export interface NEMImportanceTransfer {
-    mode?: NEMImportanceTransferMode;
-    public_key?: string;
-}
-
-export interface NEMSignTxMessage {
-    transaction?: NEMTransactionCommon;
-    cosigning?: boolean;
-    multisig?: NEMTransactionCommon;
-    transfer?: NEMTransfer;
-    provision_namespace?: NEMProvisionNamespace;
-    mosaic_creation?: NEMMosaicCreation;
-    supply_change?: NEMMosaicSupplyChange;
-    aggregate_modification?: NEMAggregateModification;
-    importance_transfer?: NEMImportanceTransfer;
-}
-
-// Stellar types
-
-export interface StellarAddress {
-    address: string;
-}
-
-export interface StellarSignedTx {
-    public_key: string;
-    signature: string;
-}
-
-export interface StellarPaymentOp {
-    type: 'StellarTxOpRequest';
-    message: {};
-}
-
-export interface StellarSignTxMessage {
-    address_n: number[];
-    source_account: string;
-    fee: number;
-    sequence_number: string | number;
-    network_passphrase: string;
-    timebounds_start?: number;
-    timebounds_end?: number;
-    memo_type?: number;
-    memo_text?: string | typeof undefined;
-    memo_id?: string | typeof undefined;
-    memo_hash?: string | Buffer | typeof undefined;
-    num_operations: number;
-}
-
-export interface StellarAsset {
-    type: 0 | 1 | 2;
-    code: string;
-    issuer?: string;
-}
-
-export type StellarOperationMessage =
-    | {
-          type: 'StellarCreateAccountOp';
-          source_account?: string;
-          new_account: string;
-          starting_balance: string;
-      }
-    | {
-          type: 'StellarPaymentOp';
-          source_account?: string;
-          destination_account: string;
-          asset: StellarAsset | typeof undefined;
-          amount: string;
-      }
-    | {
-          type: 'StellarPathPaymentOp';
-          source_account?: string;
-          send_asset: StellarAsset;
-          send_max: string;
-          destination_account: string;
-          destination_asset: StellarAsset;
-          destination_amount: string;
-          paths?: StellarAsset[] | typeof undefined;
-      }
-    | {
-          type: 'StellarManageOfferOp';
-          source_account?: string;
-          offer_id?: string;
-          amount: string;
-          buying_asset: StellarAsset;
-          selling_asset: StellarAsset;
-          price_n: number;
-          price_d: number;
-      }
-    | {
-          type: 'StellarCreatePassiveOfferOp';
-          source_account?: string;
-          offer_id?: string;
-          amount: string;
-          buying_asset: StellarAsset;
-          selling_asset: StellarAsset;
-          price_n: number;
-          price_d: number;
-      }
-    | {
-          type: 'StellarSetOptionsOp';
-          source_account?: string;
-          signer_type?: number | typeof undefined;
-          signer_key?: string | Buffer | typeof undefined;
-          signer_weight?: number | typeof undefined;
-          clear_flags: number;
-          set_flags: number;
-          master_weight: number | string;
-          low_threshold: number | string;
-          medium_threshold: number | string;
-          high_threshold: number | string;
-          home_domain: string;
-          inflation_destination_account: string;
-      }
-    | {
-          type: 'StellarChangeTrustOp';
-          source_account?: string;
-          asset: StellarAsset;
-          limit?: string;
-      }
-    | {
-          type: 'StellarAllowTrustOp';
-          source_account?: string;
-          trusted_account: string;
-          asset_type: number;
-          asset_code: string;
-          is_authorized: number;
-      }
-    | {
-          type: 'StellarAccountMergeOp';
-          source_account?: string;
-          destination_account: string;
-      }
-    | {
-          type: 'StellarManageDataOp';
-          source_account?: string;
-          key: string;
-          value: string | Buffer;
-      }
-    | {
-          type: 'StellarBumpSequenceOp';
-          source_account?: string;
-          bump_to: string | number;
-      };
-
-// Tezos types
-export interface TezosAddress {
-    address: string;
-}
-
-export interface TezosPublicKey {
-    public_key: string;
-}
-
-export interface TezosContractID {
-    tag: number;
-    hash: Uint8Array;
-}
-
-export interface TezosRevealOp {
-    source: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
-    public_key: Uint8Array;
-}
-
-export interface TezosManagerTransfer {
-    amount: number;
-    destination: TezosContractID;
-}
-
-export interface TezosParametersManager {
-    set_delegate?: Uint8Array;
-    cancel_delegate?: boolean;
-    transfer?: TezosManagerTransfer;
-}
-
-export interface TezosTransactionOp {
-    source: Uint8Array;
-    destination: TezosContractID;
-    amount: number;
-    counter: number;
-    fee: number;
-    gas_limit: number;
-    storage_limit: number;
-    parameters?: number[];
-    parameters_manager?: TezosParametersManager;
-}
-
-export interface TezosOriginationOp {
-    source: Uint8Array;
-    balance: number;
-    delegate?: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
-    script: string | number[];
-}
-
-export interface TezosDelegationOp {
-    source: Uint8Array;
-    delegate: Uint8Array;
-    fee: number;
-    counter: number;
-    gas_limit: number;
-    storage_limit: number;
-}
-
-export interface TezosTransaction {
-    address_n: number[];
-    branch: Uint8Array;
-    reveal?: TezosRevealOp;
-    transaction?: TezosTransactionOp;
-    origination?: TezosOriginationOp;
-    delegation?: TezosDelegationOp;
-}
-
-export interface TezosSignedTx {
-    signature: string;
-    sig_op_contents: string;
-    operation_hash: string;
-}
-
-// Cardano types
-export interface CardanoAddress {
-    address: string;
-    address_n?: number[];
-}
-
-export interface CardanoPublicKey {
-    xpub: string;
-    node: HDPubNode;
-}
-
-export interface CardanoSignedTx {
-    tx_hash: string;
-    serialized_tx: string;
-}
-export interface CardanoTxInput {
-    tx_hash: string;
-    address_n: number[];
-    output_index: number;
-}
-export interface CardanoTxOutput {
-    address?: string;
-    address_n?: number[];
-    amount: string;
-}
-
-// Lisk types
-export interface LiskAddress {
-    address: string;
-}
-
-export interface LiskPublicKey {
-    public_key: string;
-}
-
-export interface LiskMessageSignature {
-    public_key: string;
-    signature: string;
-}
-
-export type LiskAsset =
-    | { data: string }
-    | { votes: string[] }
-    | { delegate: { username: string } }
-    | { signature: { public_key: string } }
-    | {
-          multisignature: {
-              min: number;
-              life_time: number;
-              keys_group: string[];
-          };
-      };
-
-export interface LiskTransaction {
-    type: number;
-    fee: string;
-    amount: string;
-    timestamp: number;
-    recipient_id?: string;
-    sender_public_key?: string;
-    requester_public_key?: string;
-    signature?: string;
-    asset?: LiskAsset | {};
-}
-
-export interface LiskSignedTx {
-    signature: string;
-}
-
-// Ripple types
-export interface RippleAddress {
-    address: string;
-}
-
-export interface RippleTransaction {
-    address_n: number[];
-    fee?: number;
-    flags?: number;
-    sequence?: number;
-    last_ledger_sequence?: number;
-    payment: {
-        amount: string;
-        destination: string;
-    };
-}
-
-export interface RippleSignedTx {
-    signature: string;
-    serialized_tx: string;
-}
-
-// EOS types
-export interface EosPublicKey {
+// EosPublicKey
+export type EosPublicKey = {
     wif_public_key: string;
     raw_public_key: string;
-}
+};
 
-export interface EosTxActionRequest {
-    data_size: number;
-}
-
-export interface EosTxHeader {
+export type EosTxHeader = {
     expiration: number;
     ref_block_num: number;
     ref_block_prefix: number;
     max_net_usage_words: number;
     max_cpu_usage_ms: number;
     delay_sec: number;
-}
+};
 
-export interface EosSignTx {
+// EosSignTx
+export type EosSignTx = {
     address_n: number[];
-    chain_id: string;
-    header: EosTxHeader;
-    num_actions: number;
-}
+    chain_id?: string;
+    header?: EosTxHeader;
+    num_actions?: number;
+};
 
-export interface EosAsset {
-    amount: string; // uint64 as string
-    symbol: string; // uint64 as string
-}
+// EosTxActionRequest
+export type EosTxActionRequest = {
+    data_size?: number;
+};
 
-export interface EosPermissionLevel {
-    actor: string; // uint64 as string
-    permission: string; // uint64 as string
-}
+export type EosAsset = {
+    amount?: string;
+    symbol?: string;
+};
 
-export interface EosAuthorizationKey {
+export type EosPermissionLevel = {
+    actor?: string;
+    permission?: string;
+};
+
+export type EosAuthorizationKey = {
     type?: number;
     key: string;
-    address_n?: number[]; // this field is not implemented in FW?
+    address_n?: number[];
     weight: number;
-}
+};
 
-export interface EosAuthorization {
-    threshold: number;
+export type EosAuthorizationAccount = {
+    account?: EosPermissionLevel;
+    weight?: number;
+};
+
+export type EosAuthorizationWait = {
+    wait_sec?: number;
+    weight?: number;
+};
+
+export type EosAuthorization = {
+    threshold?: number;
     keys: EosAuthorizationKey[];
-    accounts: Array<{
-        account: EosPermissionLevel;
-        weight: number;
-    }>;
-    waits: Array<{
-        wait_sec: number;
-        weight: number;
-    }>;
-}
+    accounts: EosAuthorizationAccount[];
+    waits: EosAuthorizationWait[];
+};
 
-export interface EosActionCommon {
-    account: string; // uint64 as string
-    name: string; // uint64 as string
+export type EosActionCommon = {
+    account?: string;
+    name?: string;
     authorization: EosPermissionLevel[];
-}
+};
 
-export interface EosActionTransfer {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    quantity: EosAsset;
+export type EosActionTransfer = {
+    sender?: string;
+    receiver?: string;
+    quantity?: EosAsset;
     memo?: string;
-}
+};
 
-export interface EosActionDelegate {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    net_quantity: EosAsset;
-    cpu_quantity: EosAsset;
+export type EosActionDelegate = {
+    sender?: string;
+    receiver?: string;
+    net_quantity?: EosAsset;
+    cpu_quantity?: EosAsset;
     transfer?: boolean;
-}
+};
 
-export interface EosActionUndelegate {
-    sender: string; // uint64 as string
-    receiver: string; // uint64 as string
-    net_quantity: EosAsset;
-    cpu_quantity: EosAsset;
-}
+export type EosActionUndelegate = {
+    sender?: string;
+    receiver?: string;
+    net_quantity?: EosAsset;
+    cpu_quantity?: EosAsset;
+};
 
-export interface EosActionBuyRam {
-    payer: string; // uint64 as string
-    receiver: string; // uint64 as string
-    quantity: EosAsset;
-}
+export type EosActionRefund = {
+    owner?: string;
+};
 
-export interface EosActionBuyRamBytes {
-    payer: string; // uint64 as string
-    receiver: string; // uint64 as string
-    bytes: number;
-}
+export type EosActionBuyRam = {
+    payer?: string;
+    receiver?: string;
+    quantity?: EosAsset;
+};
 
-export interface EosActionSellRam {
-    account: string; // uint64 as string
-    bytes: number;
-}
+export type EosActionBuyRamBytes = {
+    payer?: string;
+    receiver?: string;
+    bytes?: number;
+};
 
-export interface EosActionVoteProducer {
-    voter: string; // uint64 as string
-    proxy: string; // uint64 as string
-    producers: string[]; // uint64[] as string
-}
+export type EosActionSellRam = {
+    account?: string;
+    bytes?: number;
+};
 
-export interface EosActionRefund {
-    owner: string; // uint64 as string
-}
+export type EosActionVoteProducer = {
+    voter?: string;
+    proxy?: string;
+    producers: string[];
+};
 
-export interface EosActionUpdateAuth {
-    account: string; // uint64 as string
-    permission: string; // uint64 as string
-    parent: string; // uint64 as string
-    auth: EosAuthorization;
-}
+export type EosActionUpdateAuth = {
+    account?: string;
+    permission?: string;
+    parent?: string;
+    auth?: EosAuthorization;
+};
 
-export interface EosActionDeleteAuth {
-    account: string; // uint64 as string
-    permission: string; // uint64 as string
-}
+export type EosActionDeleteAuth = {
+    account?: string;
+    permission?: string;
+};
 
-export interface EosActionLinkAuth {
-    account: string; // uint64 as string
-    code: string; // uint64 as string
-    type: string; // uint64 as string
-    requirement: string; // uint64 as string
-}
+export type EosActionLinkAuth = {
+    account?: string;
+    code?: string;
+    type?: string;
+    requirement?: string;
+};
 
-export interface EosActionUnlinkAuth {
-    account: string; // uint64 as string
-    code: string; // uint64 as string
-    type: string; // uint64 as string
-}
+export type EosActionUnlinkAuth = {
+    account?: string;
+    code?: string;
+    type?: string;
+};
 
-export interface EosActionNewAccount {
-    creator: string; // uint64 as string
-    name: string; // uint64 as string
-    owner: EosAuthorization;
-    active: EosAuthorization;
-}
+export type EosActionNewAccount = {
+    creator?: string;
+    name?: string;
+    owner?: EosAuthorization;
+    active?: EosAuthorization;
+};
 
-export interface EosActionUnknown {
+export type EosActionUnknown = {
     data_size: number;
-    data_chunk: string;
-}
+    data_chunk?: string;
+};
 
-export interface EosTxActionAck {
+// EosTxActionAck
+export type EosTxActionAck = {
     common?: EosActionCommon;
     transfer?: EosActionTransfer;
     delegate?: EosActionDelegate;
@@ -840,74 +930,333 @@ export interface EosTxActionAck {
     unlink_auth?: EosActionUnlinkAuth;
     new_account?: EosActionNewAccount;
     unknown?: EosActionUnknown;
-}
+};
 
-export interface EosSignedTx {
+// EosSignedTx
+export type EosSignedTx = {
     signature: string;
-}
+};
 
-// Binance types
-export interface BinanceAddress {
-    address: string;
-}
-
-export interface BinancePublicKey {
-    public_key: string;
-}
-
-export interface BinanceSignTx {
+// EthereumGetPublicKey
+export type EthereumGetPublicKey = {
     address_n: number[];
-    msg_count: number;
-    chain_id: string;
-    account_number: number;
-    memo?: string;
-    sequence: number;
-    source: number;
-}
+    show_display?: boolean;
+};
 
-export interface BinanceTxRequest {
-    __avoid_empty?: null;
-}
+// EthereumPublicKey
+export type EthereumPublicKey = {
+    node: HDNodeType;
+    xpub: string;
+};
 
-export interface BinanceInputOutput {
+// EthereumGetAddress
+export type EthereumGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// EthereumAddress
+export type EthereumAddress = {
+    _old_address?: string;
     address: string;
-    coins: Array<{
-        amount: number;
-        denom: string;
-    }>;
-}
+};
 
-export interface BinanceTransferMsg {
-    inputs: BinanceInputOutput[];
-    outputs: BinanceInputOutput[];
-}
+// EthereumSignTx
+export type EthereumSignTx = {
+    address_n: number[];
+    nonce?: string;
+    gas_price?: string;
+    gas_limit?: string;
+    to?: string;
+    value?: string;
+    data_initial_chunk?: string;
+    data_length?: number;
+    chain_id?: number;
+    tx_type?: number;
+};
 
-export interface BinanceOrderMsg {
-    id: string;
-    ordertype: number; // 'OT_UNKNOWN' | 'MARKET' | 'LIMIT' | 'OT_RESERVED',
-    price: number;
-    quantity: number;
-    sender: string;
-    side: number; // 'SIDE_UNKNOWN' | 'BUY' | 'SELL',
-    symbol: string;
-    timeinforce: number; // 'TIF_UNKNOWN' | 'GTE' | 'TIF_RESERVED' | 'IOC',
-}
+// EthereumTxRequest
+export type EthereumTxRequest = {
+    data_length?: number;
+    signature_v?: number;
+    signature_r?: string;
+    signature_s?: string;
+};
 
-export interface BinanceCancelMsg {
-    refid: string;
-    sender: string;
-    symbol: string;
-}
+// EthereumTxAck
+export type EthereumTxAck = {
+    data_chunk?: string;
+};
 
-export type BinanceMessage = BinanceTransferMsg | BinanceOrderMsg | BinanceCancelMsg;
+// EthereumSignMessage
+export type EthereumSignMessage = {
+    address_n: number[];
+    message?: string;
+};
 
-export interface BinanceSignedTx {
+// EthereumMessageSignature
+export type EthereumMessageSignature = {
     signature: string;
+    address: string;
+};
+
+// EthereumVerifyMessage
+export type EthereumVerifyMessage = {
+    signature?: string;
+    message?: string;
+    address?: string;
+};
+
+// LiskGetAddress
+export type LiskGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// LiskAddress
+export type LiskAddress = {
+    address: string;
+};
+
+// LiskGetPublicKey
+export type LiskGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// LiskPublicKey
+export type LiskPublicKey = {
     public_key: string;
+};
+
+export enum LiskTransactionType {
+    Transfer = 0,
+    RegisterSecondPassphrase = 1,
+    RegisterDelegate = 2,
+    CastVotes = 3,
+    RegisterMultisignatureAccount = 4,
+    CreateDapp = 5,
+    TransferIntoDapp = 6,
+    TransferOutOfDapp = 7,
 }
 
-// Reset device flags
-export interface ResetDeviceFlags {
+export type LiskSignatureType = {
+    public_key?: string;
+};
+
+export type LiskDelegateType = {
+    username?: string;
+};
+
+export type LiskMultisignatureType = {
+    min?: number;
+    life_time?: number;
+    keys_group: string[];
+};
+
+export type LiskTransactionAsset = {
+    signature?: LiskSignatureType;
+    delegate?: LiskDelegateType;
+    votes: string[];
+    multisignature?: LiskMultisignatureType;
+    data?: string;
+};
+
+export type LiskTransactionCommon = {
+    type?: LiskTransactionType;
+    amount?: number;
+    fee?: number;
+    recipient_id?: string;
+    sender_public_key?: string;
+    requester_public_key?: string;
+    signature?: string;
+    timestamp?: number;
+    asset?: LiskTransactionAsset;
+};
+
+// LiskSignTx
+export type LiskSignTx = {
+    address_n: number[];
+    transaction: LiskTransactionCommon;
+};
+
+// LiskSignedTx
+export type LiskSignedTx = {
+    signature: string;
+};
+
+// LiskSignMessage
+export type LiskSignMessage = {
+    address_n: number[];
+    message: string;
+};
+
+// LiskMessageSignature
+export type LiskMessageSignature = {
+    public_key: string;
+    signature: string;
+};
+
+// LiskVerifyMessage
+export type LiskVerifyMessage = {
+    public_key?: string;
+    signature?: string;
+    message?: string;
+};
+
+// Initialize
+export type Initialize = {
+    session_id?: string;
+};
+
+// GetFeatures
+export type GetFeatures = {};
+
+export enum Enum_Capability {
+    Capability_Bitcoin = 1,
+    Capability_Bitcoin_like = 2,
+    Capability_Binance = 3,
+    Capability_Cardano = 4,
+    Capability_Crypto = 5,
+    Capability_EOS = 6,
+    Capability_Ethereum = 7,
+    Capability_Lisk = 8,
+    Capability_Monero = 9,
+    Capability_NEM = 10,
+    Capability_Ripple = 11,
+    Capability_Stellar = 12,
+    Capability_Tezos = 13,
+    Capability_U2F = 14,
+    Capability_Shamir = 15,
+    Capability_ShamirGroups = 16,
+    Capability_PassphraseEntry = 17,
+}
+export type Capability = keyof typeof Enum_Capability;
+
+// Features
+export type Features = {
+    vendor?: string;
+    major_version: number;
+    minor_version: number;
+    patch_version: number;
+    bootloader_mode?: boolean | null;
+    device_id?: string | null;
+    pin_protection?: boolean;
+    passphrase_protection?: boolean;
+    language?: string;
+    label?: string | null;
+    initialized?: boolean;
+    revision?: string;
+    bootloader_hash?: string | null;
+    imported?: boolean;
+    unlocked?: boolean;
+    firmware_present?: boolean | null;
+    needs_backup?: boolean;
+    flags?: number;
+    model: string;
+    fw_major?: number | null;
+    fw_minor?: number | null;
+    fw_patch?: number | null;
+    fw_vendor?: string | null;
+    fw_vendor_keys?: string;
+    unfinished_backup?: boolean;
+    no_backup?: boolean;
+    recovery_mode?: boolean;
+    capabilities: Capability[];
+    backup_type?: BackupType;
+    sd_card_present?: boolean;
+    sd_protection?: boolean;
+    wipe_code_protection?: boolean;
+    session_id?: string;
+    passphrase_always_on_device?: boolean;
+};
+
+// LockDevice
+export type LockDevice = {};
+
+// EndSession
+export type EndSession = {};
+
+export enum SafetyCheckLevel {
+    Strict = 0,
+    Prompt = 1,
+}
+
+// ApplySettings
+export type ApplySettings = {
+    language?: string;
+    label?: string;
+    use_passphrase?: boolean;
+    homescreen?: string;
+    auto_lock_delay_ms?: number;
+    display_rotation?: number;
+    passphrase_always_on_device?: boolean;
+    safety_checks?: SafetyCheckLevel;
+};
+
+// ApplyFlags
+export type ApplyFlags = {
+    flags?: number;
+};
+
+// ChangePin
+export type ChangePin = {
+    remove?: boolean;
+};
+
+// ChangeWipeCode
+export type ChangeWipeCode = {
+    remove?: boolean;
+};
+
+export enum SdProtectOperationType {
+    DISABLE = 0,
+    ENABLE = 1,
+    REFRESH = 2,
+}
+
+// SdProtect
+export type SdProtect = {
+    operation?: SdProtectOperationType;
+};
+
+// Ping
+export type Ping = {
+    message?: string;
+    button_protection?: boolean;
+};
+
+// Cancel
+export type Cancel = {};
+
+// GetEntropy
+export type GetEntropy = {
+    size: number;
+};
+
+// Entropy
+export type Entropy = {
+    entropy: string;
+};
+
+// WipeDevice
+export type WipeDevice = {};
+
+// LoadDevice
+export type LoadDevice = {
+    mnemonics: string[];
+    pin?: string;
+    passphrase_protection?: boolean;
+    language?: string;
+    label?: string;
+    skip_checksum?: boolean;
+    u2f_counter?: number;
+    needs_backup?: boolean;
+    no_backup?: boolean;
+};
+
+// ResetDevice
+export type ResetDevice = {
     display_random?: boolean;
     strength?: number;
     passphrase_protection?: boolean;
@@ -917,97 +1266,511 @@ export interface ResetDeviceFlags {
     u2f_counter?: number;
     skip_backup?: boolean;
     no_backup?: boolean;
+    backup_type?: BackupType;
+};
+
+// BackupDevice
+export type BackupDevice = {};
+
+// EntropyRequest
+export type EntropyRequest = {};
+
+// EntropyAck
+export type EntropyAck = {
+    entropy?: string;
+};
+
+export enum RecoveryDeviceType {
+    RecoveryDeviceType_ScrambledWords = 0,
+    RecoveryDeviceType_Matrix = 1,
 }
 
-export interface FirmwareErase {
-    length?: number;
-}
-
-export interface FirmwareUpload {
-    payload: Buffer;
-    length: number;
-    // hash?: string,
-}
-
-export interface ChangePin {
-    remove?: boolean;
-}
-
-export interface Flags {
-    flags: number;
-}
-
-export interface DebugLinkDecision {
-    yes_no?: boolean;
-    up_down?: boolean;
-    input?: string;
-}
-
-export interface DebugLinkState {
-    layout: string;
-    pin: string;
-    matrix: string;
-    mnemonic: string;
-    node: HDNode;
-    passphrase_protection: boolean;
-    reset_word: string;
-    reset_entropy: string;
-    recovery_fake_word: string;
-    recovery_word_pos: number;
-    reset_word_pos: number;
-}
-
-export interface LoadDeviceFlags {
-    mnemonics?: string[];
-    mnemonic?: string;
-    node?: HDNode;
-    pin?: string;
-    passphrase_protection?: boolean;
-    language?: string;
-    label?: string;
-    skip_checksum?: boolean;
-    u2f_counter?: number;
-}
-
-export interface RecoverDeviceSettings {
+// RecoveryDevice
+export type RecoveryDevice = {
     word_count?: number;
     passphrase_protection?: boolean;
     pin_protection?: boolean;
     language?: string;
     label?: string;
     enforce_wordlist?: boolean;
-    type?: number;
+    type?: RecoveryDeviceType;
     u2f_counter?: number;
+    dry_run?: boolean;
+};
+
+export enum WordRequestType {
+    WordRequestType_Plain = 0,
+    WordRequestType_Matrix9 = 1,
+    WordRequestType_Matrix6 = 2,
 }
 
-export interface LoadDeviceSettings {
-    pin?: string;
-    passphrase_protection?: boolean;
-    language?: string;
-    label?: string;
-    skip_checksum?: boolean;
-    mnemonics?: string[];
-    mnemonic?: string;
-    node?: HDNode;
-    payload?: string; // will be converted
+// WordRequest
+export type WordRequest = {
+    type?: WordRequestType;
+};
 
+// WordAck
+export type WordAck = {
+    word: string;
+};
+
+// SetU2FCounter
+export type SetU2FCounter = {
     u2f_counter?: number;
-}
+};
 
-export interface ResetDeviceSettings {
-    display_random?: boolean;
-    strength?: number;
-    passphrase_protection?: boolean;
-    pin_protection?: boolean;
-    language?: string;
-    label?: string;
+// GetNextU2FCounter
+export type GetNextU2FCounter = {};
+
+// NextU2FCounter
+export type NextU2FCounter = {
     u2f_counter?: number;
-    skip_backup?: boolean;
+};
+
+// DoPreauthorized
+export type DoPreauthorized = {};
+
+// PreauthorizedRequest
+export type PreauthorizedRequest = {};
+
+// CancelAuthorization
+export type CancelAuthorization = {};
+
+// NEMGetAddress
+export type NEMGetAddress = {
+    address_n: number[];
+    network?: number;
+    show_display?: boolean;
+};
+
+// NEMAddress
+export type NEMAddress = {
+    address: string;
+};
+
+export type NEMTransactionCommon = {
+    address_n?: number[];
+    network?: number;
+    timestamp?: number;
+    fee?: number;
+    deadline?: number;
+    signer?: string;
+};
+
+export type NEMMosaic = {
+    namespace?: string;
+    mosaic?: string;
+    quantity?: number;
+};
+
+export type NEMTransfer = {
+    recipient?: string;
+    amount?: string | number;
+    payload?: string;
+    public_key?: string;
+    mosaics?: NEMMosaic[];
+};
+
+export type NEMProvisionNamespace = {
+    namespace?: string;
+    parent?: string;
+    sink?: string;
+    fee?: number;
+};
+
+export enum NEMMosaicLevy {
+    MosaicLevy_Absolute = 1,
+    MosaicLevy_Percentile = 2,
 }
 
-export interface ApplySettings {
-    language?: string;
-    label?: string;
-    use_passphrase?: boolean;
-    homescreen?: string;
+export type NEMMosaicDefinition = {
+    name?: string;
+    ticker?: string;
+    namespace?: string;
+    mosaic?: string;
+    divisibility?: number;
+    levy?: NEMMosaicLevy;
+    fee?: number;
+    levy_address?: string;
+    levy_namespace?: string;
+    levy_mosaic?: string;
+    supply?: number;
+    mutable_supply?: boolean;
+    transferable?: boolean;
+    description?: string;
+    networks?: number[];
+};
+
+export type NEMMosaicCreation = {
+    definition?: NEMMosaicDefinition;
+    sink?: string;
+    fee?: number;
+};
+
+export enum NEMSupplyChangeType {
+    SupplyChange_Increase = 1,
+    SupplyChange_Decrease = 2,
 }
+
+export type NEMMosaicSupplyChange = {
+    namespace?: string;
+    mosaic?: string;
+    type?: NEMSupplyChangeType;
+    delta?: number;
+};
+
+export enum NEMModificationType {
+    CosignatoryModification_Add = 1,
+    CosignatoryModification_Delete = 2,
+}
+
+export type NEMCosignatoryModification = {
+    type?: NEMModificationType;
+    public_key?: string;
+};
+
+export type NEMAggregateModification = {
+    modifications?: NEMCosignatoryModification[];
+    relative_change?: number;
+};
+
+export enum NEMImportanceTransferMode {
+    ImportanceTransfer_Activate = 1,
+    ImportanceTransfer_Deactivate = 2,
+}
+
+export type NEMImportanceTransfer = {
+    mode?: NEMImportanceTransferMode;
+    public_key?: string;
+};
+
+// NEMSignTx
+export type NEMSignTx = {
+    transaction?: NEMTransactionCommon;
+    multisig?: NEMTransactionCommon;
+    transfer?: NEMTransfer;
+    cosigning?: boolean;
+    provision_namespace?: NEMProvisionNamespace;
+    mosaic_creation?: NEMMosaicCreation;
+    supply_change?: NEMMosaicSupplyChange;
+    aggregate_modification?: NEMAggregateModification;
+    importance_transfer?: NEMImportanceTransfer;
+};
+
+// NEMSignedTx
+export type NEMSignedTx = {
+    data: string;
+    signature: string;
+};
+
+// NEMDecryptMessage
+export type NEMDecryptMessage = {
+    address_n: number[];
+    network?: number;
+    public_key?: string;
+    payload?: string;
+};
+
+// NEMDecryptedMessage
+export type NEMDecryptedMessage = {
+    payload?: string;
+};
+
+// RippleGetAddress
+export type RippleGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// RippleAddress
+export type RippleAddress = {
+    address: string;
+};
+
+export type RipplePayment = {
+    amount: string | number;
+    destination?: string;
+    destination_tag?: number;
+};
+
+// RippleSignTx
+export type RippleSignTx = {
+    address_n: number[];
+    fee?: string | number;
+    flags?: number;
+    sequence?: number;
+    last_ledger_sequence?: number;
+    payment?: RipplePayment;
+};
+
+// RippleSignedTx
+export type RippleSignedTx = {
+    signature: string;
+    serialized_tx: string;
+};
+
+// StellarAssetType
+export type StellarAssetType = {
+    type: 0 | 1 | 2;
+    code: string;
+    issuer?: string;
+};
+
+// StellarGetAddress
+export type StellarGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// StellarAddress
+export type StellarAddress = {
+    address: string;
+};
+
+// StellarSignTx
+export type StellarSignTx = {
+    address_n: number[];
+    network_passphrase?: string;
+    source_account?: string;
+    fee?: number;
+    sequence_number?: string | number;
+    timebounds_start?: number;
+    timebounds_end?: number;
+    memo_type?: number;
+    memo_text?: string;
+    memo_id?: string;
+    memo_hash?: Buffer | string;
+    num_operations?: number;
+};
+
+// StellarTxOpRequest
+export type StellarTxOpRequest = {};
+
+// StellarPaymentOp
+export type StellarPaymentOp = {
+    source_account?: string;
+    destination_account?: string;
+    asset?: StellarAssetType;
+    amount?: string | number;
+};
+
+// StellarCreateAccountOp
+export type StellarCreateAccountOp = {
+    source_account?: string;
+    new_account?: string;
+    starting_balance?: string | number;
+};
+
+// StellarPathPaymentOp
+export type StellarPathPaymentOp = {
+    source_account?: string;
+    send_asset?: StellarAssetType;
+    send_max?: string | number;
+    destination_account?: string;
+    destination_asset?: StellarAssetType;
+    destination_amount?: string | number;
+    paths?: StellarAssetType[];
+};
+
+// StellarManageOfferOp
+export type StellarManageOfferOp = {
+    source_account?: string;
+    selling_asset?: StellarAssetType;
+    buying_asset?: StellarAssetType;
+    amount?: string | number;
+    price_n?: number;
+    price_d?: number;
+    offer_id?: string | number;
+};
+
+// StellarCreatePassiveOfferOp
+export type StellarCreatePassiveOfferOp = {
+    source_account?: string;
+    selling_asset?: StellarAssetType;
+    buying_asset?: StellarAssetType;
+    amount?: string | number;
+    price_n?: number;
+    price_d?: number;
+};
+
+// StellarSetOptionsOp
+export type StellarSetOptionsOp = {
+    source_account?: string;
+    inflation_destination_account?: string;
+    clear_flags?: number;
+    set_flags?: number;
+    master_weight?: string | number;
+    low_threshold?: string | number;
+    medium_threshold?: string | number;
+    high_threshold?: string | number;
+    home_domain?: string;
+    signer_type?: number;
+    signer_key?: Buffer | string;
+    signer_weight?: number;
+};
+
+// StellarChangeTrustOp
+export type StellarChangeTrustOp = {
+    source_account?: string;
+    asset?: StellarAssetType;
+    limit?: string | number;
+};
+
+// StellarAllowTrustOp
+export type StellarAllowTrustOp = {
+    source_account?: string;
+    trusted_account?: string;
+    asset_type?: number;
+    asset_code?: string;
+    is_authorized?: number;
+};
+
+// StellarAccountMergeOp
+export type StellarAccountMergeOp = {
+    source_account?: string;
+    destination_account?: string;
+};
+
+// StellarManageDataOp
+export type StellarManageDataOp = {
+    source_account?: string;
+    key?: string;
+    value?: Buffer | string;
+};
+
+// StellarBumpSequenceOp
+export type StellarBumpSequenceOp = {
+    source_account?: string;
+    bump_to?: string | number;
+};
+
+// StellarSignedTx
+export type StellarSignedTx = {
+    public_key: string;
+    signature: string;
+};
+
+// TezosGetAddress
+export type TezosGetAddress = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// TezosAddress
+export type TezosAddress = {
+    address: string;
+};
+
+// TezosGetPublicKey
+export type TezosGetPublicKey = {
+    address_n: number[];
+    show_display?: boolean;
+};
+
+// TezosPublicKey
+export type TezosPublicKey = {
+    public_key: string;
+};
+
+export enum TezosContractType {
+    Implicit = 0,
+    Originated = 1,
+}
+
+export type TezosContractID = {
+    tag: number;
+    hash: Uint8Array;
+};
+
+export type TezosRevealOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    public_key: Uint8Array;
+};
+
+export type TezosManagerTransfer = {
+    destination?: TezosContractID;
+    amount?: number;
+};
+
+export type TezosParametersManager = {
+    set_delegate?: Uint8Array;
+    cancel_delegate?: boolean;
+    transfer?: TezosManagerTransfer;
+};
+
+export type TezosTransactionOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    amount: number;
+    destination: TezosContractID;
+    parameters?: number[];
+    parameters_manager?: TezosParametersManager;
+};
+
+export type TezosOriginationOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    manager_pubkey?: string;
+    balance: number;
+    spendable?: boolean;
+    delegatable?: boolean;
+    delegate?: Uint8Array;
+    script: string | number[];
+};
+
+export type TezosDelegationOp = {
+    source: Uint8Array;
+    fee: number;
+    counter: number;
+    gas_limit: number;
+    storage_limit: number;
+    delegate: Uint8Array;
+};
+
+export type TezosProposalOp = {
+    source?: string;
+    period?: number;
+    proposals: string[];
+};
+
+export enum TezosBallotType {
+    Yay = 0,
+    Nay = 1,
+    Pass = 2,
+}
+
+export type TezosBallotOp = {
+    source?: string;
+    period?: number;
+    proposal?: string;
+    ballot?: TezosBallotType;
+};
+
+// TezosSignTx
+export type TezosSignTx = {
+    address_n: number[];
+    branch: Uint8Array;
+    reveal?: TezosRevealOp;
+    transaction?: TezosTransactionOp;
+    origination?: TezosOriginationOp;
+    delegation?: TezosDelegationOp;
+    proposal?: TezosProposalOp;
+    ballot?: TezosBallotOp;
+};
+
+// TezosSignedTx
+export type TezosSignedTx = {
+    signature: string;
+    sig_op_contents: string;
+    operation_hash: string;
+};


### PR DESCRIPTION
Replace manually added/created protobuf types with types generated by script from messages.json file.
Almost every method is affected by this change, method params are now exact with protobuf (snake case, names etc)

- `DeviceCommands.typedCall` strongly typed params
- most of `DeviceCommands.coinSpecificMethod` are removed in favour of `typedCall`
- removed useless types across all the methods 