### PR TITLE
fix: BroadcastChannel fallback

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -140,7 +140,7 @@ const handleMessage = (event: PostMessageEvent) => {
 // handle POPUP.INIT message from window.opener
 const init = async (payload?: $PropertyType<PopupInit, 'payload'>) => {
     if (!payload) return;
-    const { settings } = payload;
+    const { settings, useBroadcastChannel } = payload;
 
     try {
         // load config only to get supported browsers list
@@ -148,7 +148,7 @@ const init = async (payload?: $PropertyType<PopupInit, 'payload'>) => {
         // settings will be replaced later on, after POPUP.HANDSHAKE event from iframe
         await DataManager.load(parseSettings(settings), false);
         // initialize message channel
-        const broadcastID = `${settings.env}-${settings.timestamp}`;
+        const broadcastID = useBroadcastChannel ? `${settings.env}-${settings.timestamp}` : undefined;
         initMessageChannel(broadcastID, handleMessage);
         // reset loading hash
         window.location.hash = '';

--- a/src/js/popup/view/common.js
+++ b/src/js/popup/view/common.js
@@ -78,11 +78,15 @@ export const getIframeElement = (): any => {
 };
 
 // initialize message channel with iframe element
-export const initMessageChannel = (id: string, handler: any): void => {
+export const initMessageChannel = (id: ?string, handler: any): void => {
     const hasIframe = getIframeElement();
-    if (typeof BroadcastChannel !== 'undefined') {
-        broadcast = new BroadcastChannel(id);
-        broadcast.onmessage = handler;
+    if (id && typeof BroadcastChannel !== 'undefined') {
+        try {
+            broadcast = new BroadcastChannel(id);
+            broadcast.onmessage = handler;
+        } catch (error) {
+            // silent error. use MessageChannel as fallback communication
+        }
         return;
     }
     if (!hasIframe) {

--- a/src/js/types/events.js
+++ b/src/js/types/events.js
@@ -49,7 +49,6 @@ export type TransportEvent =
 export type MessageWithoutPayload = {
     type: typeof UI.REQUEST_UI_WINDOW |
         typeof POPUP.CANCEL_POPUP_REQUEST |
-        typeof IFRAME.LOADED |
         typeof POPUP.LOADED |
         typeof UI.TRANSPORT |
         typeof UI.CHANGE_ACCOUNT |
@@ -103,10 +102,18 @@ export type IFrameError = {
     };
 }
 
+export type IFrameLoaded = {
+    type: typeof IFRAME.LOADED;
+    payload: {
+        useBroadcastChannel: boolean;
+    };
+}
+
 export type PopupInit = {
     type: typeof POPUP.INIT;
     payload: {
         settings: ConnectSettings; // those are settings from window.opener
+        useBroadcastChannel: boolean;
     };
 }
 
@@ -327,7 +334,9 @@ export interface UiMessageBuilder {
     (type: FT<DeviceMessage>, payload: FP<DeviceMessage>): CoreMessage;
     (type: FT<ButtonRequestMessage>, payload: FP<ButtonRequestMessage>): CoreMessage;
     (type: FT<AddressValidationMessage>, payload: FP<AddressValidationMessage>): CoreMessage;
+    (type: FT<IFrameFailure>): CoreMessage;
     (type: FT<IFrameError>, payload: FP<IFrameError>): CoreMessage;
+    (type: FT<IFrameLoaded>, payload: FP<IFrameLoaded>): CoreMessage;
     (type: FT<PopupError>, payload: FP<PopupError>): CoreMessage;
     (type: FT<PopupHandshake>, payload: FP<PopupHandshake>): CoreMessage;
     (type: FT<RequestPermission>, payload: FP<RequestPermission>): CoreMessage;
@@ -341,7 +350,6 @@ export interface UiMessageBuilder {
     (type: FT<BundleProgress<any>>, payload: FP<BundleProgress<any>>): CoreMessage;
     (type: FT<FirmwareProgress>, payload: FP<FirmwareProgress>): CoreMessage;
     (type: FT<CustomMessageRequest>, payload: FP<CustomMessageRequest>): CoreMessage;
-    (type: FT<IFrameFailure>): CoreMessage;
     // ui response
     (type: FT<ReceivePermission>, payload: FP<ReceivePermission>): CoreMessage;
     (type: FT<ReceiveConfirmation>, payload: FP<ReceiveConfirmation>): CoreMessage;

--- a/src/ts/types/events.d.ts
+++ b/src/ts/types/events.d.ts
@@ -45,7 +45,6 @@ export interface MessageWithoutPayload {
     type:
         | typeof UI.REQUEST_UI_WINDOW
         | typeof POPUP.CANCEL_POPUP_REQUEST
-        | typeof IFRAME.LOADED
         | typeof POPUP.LOADED
         | typeof UI.TRANSPORT
         | typeof UI.CHANGE_ACCOUNT
@@ -88,7 +87,7 @@ export interface AddressValidationMessage {
     payload?: ButtonRequestData;
 }
 
-export interface FrameError {
+export interface IFrameError {
     type: typeof IFRAME.ERROR;
     payload: {
         error: string;
@@ -96,10 +95,18 @@ export interface FrameError {
     };
 }
 
+export type IFrameLoaded = {
+    type: typeof IFRAME.LOADED;
+    payload: {
+        useBroadcastChannel: boolean;
+    };
+}
+
 export interface PopupInit {
     type: typeof POPUP.INIT;
     payload: {
         settings: ConnectSettings; // those are settings from window.opener
+        useBroadcastChannel: boolean;
     };
 }
 


### PR DESCRIPTION
fix for issue [reported here](https://github.com/trezor/connect/issues/731)
Custom privacy settings in Firefox (Privacy & Security > block cookies from unvisited websites)
throws `DOMException: The operation is insecure.` when initializing BroadcastChannel in iframe