### PR TITLE
fix: BroadcastChannel fallback, update for f526cb

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -140,7 +140,9 @@ const handleMessage = (event: PostMessageEvent) => {
 // handle POPUP.INIT message from window.opener
 const init = async (payload?: $PropertyType<PopupInit, 'payload'>) => {
     if (!payload) return;
-    const { settings, useBroadcastChannel } = payload;
+    const { settings } = payload;
+    // npm version < 8.1.20 doesn't have it in POPUP.INIT message
+    const useBroadcastChannel = typeof payload.useBroadcastChannel === 'boolean' ? payload.useBroadcastChannel : true;
 
     try {
         // load config only to get supported browsers list


### PR DESCRIPTION
fix of fix :)
npm version < 8.1.20 will not send `useBroadcastChannel` to the popup