### PR TITLE
fix: signtransaction missing amount fallback

### DIFF
--- a/src/js/core/methods/SignTransaction.js
+++ b/src/js/core/methods/SignTransaction.js
@@ -14,6 +14,7 @@ import verifyTx from './helpers/signtxVerify';
 
 import {
     validateTrezorInputs,
+    enhanceTrezorInputs,
     validateTrezorOutputs,
     getReferencedTransactions,
     transformReferencedTransactions,
@@ -137,6 +138,7 @@ export default class SignTransaction extends AbstractMethod {
                 isBackendSupported(params.coinInfo);
                 const blockchain = await initBlockchain(params.coinInfo, this.postMessage);
                 const rawTxs = await blockchain.getTransactions(refTxsIds);
+                enhanceTrezorInputs(this.params.inputs, rawTxs);
                 refTxs = transformReferencedTransactions(rawTxs, params.coinInfo);
 
                 const origTxsIds = getOrigTransactions(params.inputs, params.outputs);


### PR DESCRIPTION
fix for breaking change introduced by 2.3.6 FW (connect@8.1.20) where amounts are required for all inputs, not only segwit-types.

if amount in input parameter object is not present it will be added from referenced transaction object dowloaded from blockbook