### PR TITLE
Validate firmware version for newly added fields in CardanoSignTransaction

### DIFF
--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -41,11 +41,11 @@ export default class CardanoSignTransaction extends AbstractMethod {
             { name: 'inputs', type: 'array', obligatory: true },
             { name: 'outputs', type: 'array', obligatory: true, allowEmpty: true },
             { name: 'fee', type: 'amount', obligatory: true },
-            { name: 'ttl', type: 'string' },
+            { name: 'ttl', type: 'amount' },
             { name: 'certificates', type: 'array', allowEmpty: true },
             { name: 'withdrawals', type: 'array', allowEmpty: true },
             { name: 'metadata', type: 'string' },
-            { name: 'validityIntervalStart', type: 'string' },
+            { name: 'validityIntervalStart', type: 'amount' },
             { name: 'protocolMagic', type: 'number', obligatory: true },
             { name: 'networkId', type: 'number', obligatory: true },
         ]);

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -58,7 +58,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             validateParams(output, [
                 { name: 'address', type: 'string' },
                 { name: 'amount', type: 'amount', obligatory: true },
-                { name: 'token_bundle', type: 'array', allowEmpty: true },
+                { name: 'tokenBundle', type: 'array', allowEmpty: true },
             ]);
 
             const result: CardanoTxOutputType = {

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -8,9 +8,7 @@ import { addressParametersToProto, validateAddressParameters } from './helpers/c
 import { transformCertificate } from './helpers/cardanoCertificate';
 import { validateTokenBundle, tokenBundleToProto } from './helpers/cardanoTokens';
 import { ERRORS } from '../../constants';
-import Device from '../../device/Device';
 import { CERTIFICATE_TYPE } from '../../constants/cardano';
-
 
 import type {
     MessageType,
@@ -23,10 +21,10 @@ import type { CoreMessage } from '../../types';
 
 // todo: remove when listed firmwares become mandatory for cardanoSignTransaction
 const CardanoSignTransactionFeatures = Object.freeze({
-    SignStakePoolRegistrationAsOwner: ['', '2.3.5'],
-    ValidityIntervalStart: ['0', '2.3.5'],
-    MultiassetOutputs: ['0', '2.3.5'],
-})
+    SignStakePoolRegistrationAsOwner: ['0', '2.3.6'],
+    ValidityIntervalStart: ['0', '2.3.6'],
+    MultiassetOutputs: ['0', '2.3.6'],
+});
 
 export default class CardanoSignTransaction extends AbstractMethod {
     params: $ElementType<MessageType, 'CardanoSignTx'>;
@@ -127,7 +125,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
 
     _ensureFeatureIsSupported(feature: $Keys<typeof CardanoSignTransactionFeatures>) {
         if (!this.device.atLeast(CardanoSignTransactionFeatures[feature])) {
-            throw ERRORS.TypedError('Method_InvalidParameter', `Feature ${feature} not supported by device firmware`)
+            throw ERRORS.TypedError('Method_InvalidParameter', `Feature ${feature} not supported by device firmware`);
         }
     }
 
@@ -144,7 +142,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             this._ensureFeatureIsSupported('ValidityIntervalStart');
         }
 
-        params.outputs.map((output) => { 
+        params.outputs.map((output) => {
             if (output.token_bundle) {
                 this._ensureFeatureIsSupported('MultiassetOutputs');
             }


### PR DESCRIPTION
Motivation: In Cardano we recently added multiasset support/minValidity field (#745) which extends the existing protobuf messages with new fields. This works nice with old trezor-firmware (2.3.4) until a user attempts to sign a transaction containing those new fields. The expected behavior would be that Trezor rejects such transaction as it contains unknown fields that it cannot serialize into the tx, but instead (due to the way protobuf is designed) it proceeds to gracefully sign a transaction without those fields which is invalid at best and lacking some crucial information at worst (e.g. the min validity start field, effectively disabling the time lock on the signed tx).

Changes:
* add checks for firmware version to prevent previous Trezor firmware versions from leading the user to accidentally sign a transaction with those fields missing, giving a comprehensive error message
* fix tokenBundle validation (validating the non-existing snake_case property instead of camelCase)

Another valid approach would be globally forcing trezor firmware version 2.3.5 for cardanoSignTransaction but given the relatively short window between it's expected launch (Feb 10th) and the upcoming hard fork in Cardano (~Feb 26th) it's probably more sensible to have sooner a version of connect working both with 2.3.4 and 2.3.5 at the same time and enforce 2.3.5 (or something higher) globally later on with another batch of less critical changes.

Testing:
* `./tests/run.sh -i cardanoSignTransaction -g` passes
* `./tests/run.sh -i cardanoSignTransaction -g -f 2.3.4` fails with the fixtures concerning changes added after fw version 2.3.4 was launched, as expected

closes https://github.com/trezor/connect/issues/751