### PR TITLE
fix: faulty check for token bundle presence in Cardano protobuf message

### DIFF
--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -143,7 +143,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
         }
 
         params.outputs.map((output) => {
-            if (output.token_bundle) {
+            if (output.token_bundle.length > 0) {
                 this._ensureFeatureIsSupported('MultiassetOutputs');
             }
         });

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -143,7 +143,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
         }
 
         params.outputs.map((output) => {
-            if (output.token_bundle.length > 0) {
+            if (output.token_bundle && output.token_bundle.length > 0) {
                 this._ensureFeatureIsSupported('MultiassetOutputs');
             }
         });


### PR DESCRIPTION
Motivation: the check for presence of token_bundle in tx outputs turned out to be incorrect as it gets translated to an empty array which is truthy.Therefore Trezor fails with `Feature MultiassetOutputs not supported by device firmware` error for any transaction, not just those actually containing tokens. This is a fix for this by checking explicitly for the length of the array

Testing:
* `./tests/run.sh -i cardanoSignTransaction -g -f 2.3.4` fails with the 2.3.6 specific features only and the rest passes
* `./tests/run.sh -i cardanoSignTransaction -g` passes

@szymonlesisz - this is urgent as it started affecting adalite users given that the connect instance deployed on the web already has the newest version with this bug, sorry for the hassle