### PR TITLE
fix(types): OutputScriptType + Features fix

### DIFF
--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -54,9 +54,20 @@ const RULE_PATCH = {
     'LiskSignMessage.message': 'required',
     'LiskMessageSignature.public_key': 'required',
     'LiskMessageSignature.signature': 'required',
+    'Features.vendor': 'required',
+    'Features.device_id': 'required',
     'Features.major_version': 'required',
     'Features.minor_version': 'required',
     'Features.patch_version': 'required',
+    'Features.pin_protection': 'required',
+    'Features.passphrase_protection': 'required',
+    'Features.label': 'required',
+    'Features.initialized': 'required',
+    'Features.revision': 'required',
+    'Features.needs_backup': 'required',
+    'Features.flags': 'required',
+    'Features.unfinished_backup': 'required',
+    'Features.no_backup': 'required',
     'Features.model': 'required',
     'NEMSignedTx.data': 'required',
     'NEMSignedTx.signature': 'required',
@@ -214,6 +225,10 @@ const DEFINITION_PATCH = {
 `// - TxOutputType replacement
 // TxOutputType needs more exact types
 // differences: external output (no address_n), opreturn output (no address_n, no address)
+// eslint-disable-next-line no-unused-vars
+type Exclude<A, B> = $Keys<$Diff<typeof Enum_OutputScriptType, { PAYTOOPRETURN: 3 }>>; // flowtype equivalent of typescript Exclude
+export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
+
 export type TxOutputType = {|
     address: string;
     address_n?: typeof undefined;
@@ -225,7 +240,7 @@ export type TxOutputType = {|
 |} | {|
     address?: typeof undefined;
     address_n: number[];
-    script_type: OutputScriptType;
+    script_type: ChangeOutputScriptType;
     amount: string;
     multisig?: MultisigRedeemScriptType;
     orig_hash?: string;

--- a/scripts/protobuf-types.js
+++ b/scripts/protobuf-types.js
@@ -103,7 +103,12 @@ const parseMessage = (message, depth = 0) => {
             // replace whole declaration
             if (isTypescript) {
                 // replace flowtype exact declaration {| ...type |} to typescript { ...type }
-                value.push(definition.replace(/{\|/gi, '{').replace(/\|}/gi, '}'));
+                let cleanTS = definition.replace(/{\|/gi, '{').replace(/\|}/gi, '}');
+                // comment out flowtype Exclude type/helper (typescript build-in)
+                if (cleanTS.indexOf('type Exclude') >= 0) {
+                    cleanTS = cleanTS.replace('type Exclude', '// type Exclude');
+                }
+                value.push(cleanTS);
             } else {
                 value.push(definition);
             }

--- a/src/js/types/__tests__/bitcoin.js
+++ b/src/js/types/__tests__/bitcoin.js
@@ -294,14 +294,39 @@ export const signTransaction = async () => {
                 ],
                 outputs: [
                     {
+                        address: 'a',
+                        amount: '100',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOSCRIPTHASH',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOMULTISIG',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOWITNESS',
+                    },
+                    {
                         address_n: [0],
                         amount: '100',
                         script_type: 'PAYTOP2SHWITNESS',
                     },
                     {
-                        address: 'a',
-                        amount: '100',
-                        script_type: 'PAYTOADDRESS',
+                        amount: '0',
+                        op_return_data: 'deadbeef',
+                        script_type: 'PAYTOOPRETURN',
                     },
                 ],
                 lock_time: 1,
@@ -357,7 +382,28 @@ export const signTransaction = async () => {
             // $FlowExpectedError: invalid script_type
             script_type: 'SPENDADDRESS-2',
         }],
-        outputs: [],
+        outputs: [
+            {
+                // $FlowExpectedError: unexpected address_n
+                address_n: [0],
+                amount: '0',
+                op_return_data: 'deadbeef',
+                script_type: 'PAYTOOPRETURN',
+            },
+            // $FlowExpectedError: unexpected script_type
+            {
+                address: 'abcd',
+                amount: '100',
+                script_type: 'PAYTOP2SHWITNESS',
+            },
+            // $FlowExpectedError: unexpected address
+            {
+                address: 'abcd',
+                amount: '0',
+                op_return_data: 'deadbeef',
+                script_type: 'PAYTOOPRETURN',
+            },
+        ],
         coin: 'btc',
     });
 };

--- a/src/js/types/__tests__/index.js
+++ b/src/js/types/__tests__/index.js
@@ -80,6 +80,22 @@ export const events = async () => {
             (payload.mode: 'normal' | 'bootloader' | 'initialize' | 'seedless');
             (payload.firmware: 'valid' | 'outdated' | 'required' | 'unknown' | 'none');
             (payload.status: 'available' | 'occupied' | 'used');
+            // features
+            (payload.features.vendor: string | null);
+            (payload.features.device_id: string | null);
+            (payload.features.major_version: number | null);
+            (payload.features.minor_version: number | null);
+            (payload.features.patch_version: number | null);
+            (payload.features.pin_protection: boolean);
+            (payload.features.passphrase_protection: boolean | null);
+            (payload.features.label: string | null);
+            (payload.features.initialized: boolean);
+            (payload.features.revision: string | null);
+            (payload.features.needs_backup: boolean);
+            (payload.features.flags: number);
+            (payload.features.unfinished_backup: boolean);
+            (payload.features.no_backup: boolean);
+            (payload.features.model: string);
         }
     });
     TrezorConnect.off(DEVICE_EVENT, () => {});

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -334,6 +334,10 @@ export type TxOutputBinType = {
 // - TxOutputType replacement
 // TxOutputType needs more exact types
 // differences: external output (no address_n), opreturn output (no address_n, no address)
+// eslint-disable-next-line no-unused-vars
+type Exclude<A, B> = $Keys<$Diff<typeof Enum_OutputScriptType, { PAYTOOPRETURN: 3 }>>; // flowtype equivalent of typescript Exclude
+export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
+
 export type TxOutputType = {|
     address: string;
     address_n?: typeof undefined;
@@ -345,7 +349,7 @@ export type TxOutputType = {|
 |} | {|
     address?: typeof undefined;
     address_n: number[];
-    script_type: OutputScriptType;
+    script_type: ChangeOutputScriptType;
     amount: string;
     multisig?: MultisigRedeemScriptType;
     orig_hash?: string;
@@ -1339,32 +1343,32 @@ export type Capability = $Keys<typeof Enum_Capability>;
 
 // Features
 export type Features = {
-    vendor?: string;
+    vendor: string;
     major_version: number;
     minor_version: number;
     patch_version: number;
     bootloader_mode?: boolean | null;
-    device_id?: string | null;
-    pin_protection?: boolean;
-    passphrase_protection?: boolean;
+    device_id: string | null;
+    pin_protection: boolean;
+    passphrase_protection: boolean;
     language?: string;
-    label?: string | null;
-    initialized?: boolean;
-    revision?: string;
+    label: string | null;
+    initialized: boolean;
+    revision: string;
     bootloader_hash?: string | null;
     imported?: boolean;
     unlocked?: boolean;
     firmware_present?: boolean | null;
-    needs_backup?: boolean;
-    flags?: number;
+    needs_backup: boolean;
+    flags: number;
     model: string;
     fw_major?: number | null;
     fw_minor?: number | null;
     fw_patch?: number | null;
     fw_vendor?: string | null;
     fw_vendor_keys?: string;
-    unfinished_backup?: boolean;
-    no_backup?: boolean;
+    unfinished_backup: boolean;
+    no_backup: boolean;
     recovery_mode?: boolean;
     capabilities: Capability[];
     backup_type?: BackupType;

--- a/src/js/utils/pathUtils.js
+++ b/src/js/utils/pathUtils.js
@@ -3,7 +3,7 @@
 import { getCoinName } from '../data/CoinInfo';
 import { ERRORS } from '../constants';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types';
-import type { InputScriptType, OutputScriptType } from '../types/trezor/protobuf';
+import type { InputScriptType, ChangeOutputScriptType } from '../types/trezor/protobuf';
 
 export const HD_HARDENED: number = 0x80000000;
 export const toHardened = (n: number): number => (n | HD_HARDENED) >>> 0;
@@ -63,7 +63,7 @@ export const getScriptType = (path: ?Array<number>): InputScriptType => {
     }
 };
 
-export const getOutputScriptType = (path: ?Array<number>): OutputScriptType => {
+export const getOutputScriptType = (path?: number[]): ChangeOutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
 
     // compatibility for Casa - allow an unhardened 49 path to use PAYTOP2SHWITNESS

--- a/src/ts/types/__tests__/bitcoin.ts
+++ b/src/ts/types/__tests__/bitcoin.ts
@@ -272,14 +272,39 @@ export const signTransaction = async () => {
                 ],
                 outputs: [
                     {
+                        address: 'a',
+                        amount: '100',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOSCRIPTHASH',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOMULTISIG',
+                    },
+                    {
+                        address_n: [0],
+                        amount: '100',
+                        script_type: 'PAYTOWITNESS',
+                    },
+                    {
                         address_n: [0],
                         amount: '100',
                         script_type: 'PAYTOP2SHWITNESS',
                     },
                     {
-                        address: 'a',
-                        amount: '100',
-                        script_type: 'PAYTOADDRESS',
+                        amount: '0',
+                        op_return_data: 'deadbeef',
+                        script_type: 'PAYTOOPRETURN',
                     },
                 ],
                 lock_time: 1,
@@ -338,7 +363,28 @@ export const signTransaction = async () => {
                 script_type: 'SPENDADDRESS-2',
             },
         ],
-        outputs: [],
+        outputs: [
+            // @ts-ignore unexpected address_n
+            {
+                address_n: [0],
+                amount: '0',
+                op_return_data: 'deadbeef',
+                script_type: 'PAYTOOPRETURN',
+            },
+            // @ts-ignore unexpected script_type
+            {
+                address: 'abcd',
+                amount: '100',
+                script_type: 'PAYTOP2SHWITNESS',
+            },
+            // @ts-ignore unexpected address
+            {
+                address: 'abcd',
+                amount: '0',
+                op_return_data: 'deadbeef',
+                script_type: 'PAYTOOPRETURN',
+            },
+        ],
         coin: 'btc',
     });
 };

--- a/src/ts/types/__tests__/index.ts
+++ b/src/ts/types/__tests__/index.ts
@@ -70,6 +70,23 @@ export const events = async () => {
             payload.mode;
             payload.firmware;
             payload.status;
+
+            // features
+            payload.features.vendor;
+            payload.features.device_id;
+            payload.features.major_version;
+            payload.features.minor_version;
+            payload.features.patch_version;
+            payload.features.pin_protection;
+            payload.features.passphrase_protection;
+            payload.features.label;
+            payload.features.initialized;
+            payload.features.revision;
+            payload.features.needs_backup;
+            payload.features.flags;
+            payload.features.unfinished_backup;
+            payload.features.no_backup;
+            payload.features.model;
         }
     });
     TrezorConnect.off(DEVICE_EVENT, () => {});

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -325,6 +325,10 @@ export type TxOutputBinType = {
 // - TxOutputType replacement
 // TxOutputType needs more exact types
 // differences: external output (no address_n), opreturn output (no address_n, no address)
+// eslint-disable-next-line no-unused-vars
+// type Exclude<A, B> = $Keys<$Diff<typeof Enum_OutputScriptType, { PAYTOOPRETURN: 3 }>>; // flowtype equivalent of typescript Exclude
+export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
+
 export type TxOutputType = {
     address: string;
     address_n?: typeof undefined;
@@ -336,7 +340,7 @@ export type TxOutputType = {
 } | {
     address?: typeof undefined;
     address_n: number[];
-    script_type: OutputScriptType;
+    script_type: ChangeOutputScriptType;
     amount: string;
     multisig?: MultisigRedeemScriptType;
     orig_hash?: string;
@@ -1324,32 +1328,32 @@ export type Capability = keyof typeof Enum_Capability;
 
 // Features
 export type Features = {
-    vendor?: string;
+    vendor: string;
     major_version: number;
     minor_version: number;
     patch_version: number;
     bootloader_mode?: boolean | null;
-    device_id?: string | null;
-    pin_protection?: boolean;
-    passphrase_protection?: boolean;
+    device_id: string | null;
+    pin_protection: boolean;
+    passphrase_protection: boolean;
     language?: string;
-    label?: string | null;
-    initialized?: boolean;
-    revision?: string;
+    label: string | null;
+    initialized: boolean;
+    revision: string;
     bootloader_hash?: string | null;
     imported?: boolean;
     unlocked?: boolean;
     firmware_present?: boolean | null;
-    needs_backup?: boolean;
-    flags?: number;
+    needs_backup: boolean;
+    flags: number;
     model: string;
     fw_major?: number | null;
     fw_minor?: number | null;
     fw_patch?: number | null;
     fw_vendor?: string | null;
     fw_vendor_keys?: string;
-    unfinished_backup?: boolean;
-    no_backup?: boolean;
+    unfinished_backup: boolean;
+    no_backup: boolean;
     recovery_mode?: boolean;
     capabilities: Capability[];
     backup_type?: BackupType;


### PR DESCRIPTION
fix for bug introduced by generated protobuf types:
https://github.com/trezor/trezor-suite/blob/develop/patches/trezor-connect%2B8.1.21-extended.patch

- patch required fields in `Features`
- exclude `PAYTOOPRETURN` script type from `ChangeOutputScriptType`