### PR TITLE
fix: unacquired device should use default protobuf set

### DIFF
--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -133,7 +133,8 @@ export default class DataManager {
     }
 
     static getProtobufMessages(version?: number[]): JSON {
-        if (!version) return this.messages['default'];
+        // empty array = unacquired device
+        if (!version || !version.length) return this.messages['default'];
         const model = version[0] - 1;
         const messages = this.config.messages.find(m => {
             const min = m.range.min[model];


### PR DESCRIPTION
potential fix for trezor/trezor-suite#4874
i've noticed the same behaviour in suite.

steps to reproduce:
- open first instance of suite (passphrase enabled)
- when you are asked for a passphrase, dont do it, open second tab, second instance of suite
- device should appear as "unacquired"
- acquire it, there should be "passphrase on device" button but it's not (sometimes)

explanation:
there was invalid condition in protobuf set evaluation function, whenever device was unacquired (version array is empty) it was falling back to previous/older set (v6) which doesn't have `capabilities` declared and defaults was used instead (no Capability_PassphraseEntry there)