### PR TITLE
chore: update blockchain-link@1.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@babel/plugin-transform-runtime": "^7.12.10",
         "@babel/preset-env": "^7.12.10",
         "@babel/preset-flow": "^7.12.1",
-        "@trezor/blockchain-link": "^1.0.15",
+        "@trezor/blockchain-link": "^1.0.16",
         "@trezor/rollout": "1.0.7",
         "@trezor/utxo-lib": "^0.1.2",
         "babel-collect-imports": "https://github.com/szymonlesisz/babel-collect-imports",
@@ -117,7 +117,7 @@
         "whatwg-fetch": "^3.5.0"
     },
     "extendedDependencies": {
-        "@trezor/blockchain-link": "^1.0.15",
+        "@trezor/blockchain-link": "^1.0.16",
         "@trezor/rollout": "1.0.7",
         "@trezor/utxo-lib": "^0.1.2",
         "bchaddrjs": "0.4.9",

--- a/src/js/types/account.js
+++ b/src/js/types/account.js
@@ -3,7 +3,7 @@ import type {
     TxInputType,
     TxOutputType,
 } from './trezor/protobuf';
-import type { VinVout } from './backend/transactions';
+import type { VinVout, BlockbookTransaction } from './backend/transactions';
 
 // getAccountInfo params
 export type GetAccountInfo = {
@@ -85,7 +85,7 @@ type TransactionTarget = {
 
 // Transaction from @trezor/blockchain-link
 export type AccountTransaction = {
-    type: 'sent' | 'recv' | 'self' | 'unknown';
+    type: 'sent' | 'recv' | 'self' | 'failed' | 'unknown';
 
     txid: string;
     blockTime?: number;
@@ -99,13 +99,7 @@ export type AccountTransaction = {
     targets: TransactionTarget[];
     tokens: TokenTransfer[];
     rbf?: boolean;
-    ethereumSpecific?: {
-        status: number;
-        nonce: number;
-        gasLimit: number;
-        gasUsed?: number;
-        gasPrice: string;
-    };
+    ethereumSpecific?: $ElementType<BlockbookTransaction, 'ethereumSpecific'>;
     details: {
         vin: VinVout[];
         vout: VinVout[];

--- a/src/js/types/backend/blockchain.js
+++ b/src/js/types/backend/blockchain.js
@@ -127,6 +127,7 @@ export type BlockchainEstimateFee = {
             data?: string;
             from?: string;
             to?: string;
+            value?: string;
             txsize?: number;
         };
         feeLevels?: 'preloaded' | 'smart';

--- a/src/js/types/backend/transactions.js
+++ b/src/js/types/backend/transactions.js
@@ -30,6 +30,7 @@ export type BlockbookTransaction = {
     ethereumSpecific?: {
         status: number;
         nonce: number;
+        data?: string;
         gasLimit: number;
         gasUsed?: number;
         gasPrice: string;

--- a/src/ts/types/account.d.ts
+++ b/src/ts/types/account.d.ts
@@ -1,5 +1,5 @@
 import { TxInputType, TxOutputType } from './trezor/protobuf';
-import { VinVout } from './backend/transactions';
+import { VinVout, BlockbookTransaction } from './backend/transactions';
 
 // getAccountInfo params
 export interface GetAccountInfo {
@@ -80,7 +80,7 @@ export interface TransactionTarget {
 }
 
 export interface AccountTransaction {
-    type: 'sent' | 'recv' | 'self' | 'unknown';
+    type: 'sent' | 'recv' | 'self' | 'failed' | 'unknown';
 
     txid: string;
     blockTime?: number;
@@ -94,13 +94,7 @@ export interface AccountTransaction {
     targets: TransactionTarget[];
     tokens: TokenTransfer[];
     rbf?: boolean;
-    ethereumSpecific?: {
-        status: number;
-        nonce: number;
-        gasLimit: number;
-        gasUsed?: number;
-        gasPrice: string;
-    };
+    ethereumSpecific?: BlockbookTransaction['ethereumSpecific'];
     details: {
         vin: VinVout[];
         vout: VinVout[];

--- a/src/ts/types/backend/blockchain.d.ts
+++ b/src/ts/types/backend/blockchain.d.ts
@@ -76,6 +76,7 @@ export interface BlockchainEstimateFee {
             data?: string;
             from?: string;
             to?: string;
+            value?: string;
             txsize?: number;
         };
         feeLevels?: 'preloaded' | 'smart';

--- a/src/ts/types/backend/transactions.d.ts
+++ b/src/ts/types/backend/transactions.d.ts
@@ -27,6 +27,7 @@ export interface BlockbookTransaction {
     ethereumSpecific?: {
         status: number;
         nonce: number;
+        data?: string;
         gasLimit: number;
         gasUsed?: number;
         gasPrice: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,10 +1788,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@trezor/blockchain-link@^1.0.15":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@trezor/blockchain-link/-/blockchain-link-1.0.15.tgz#a3f7c1122d568a1a945f7f0c43de217cdc2d3c7a"
-  integrity sha512-qcGHa1OXHdQb6SoPW6yfXyomkKwtd/JpFXL4eSGvAl08roxtgmtXNHmQaJ8F0oRSClbPEprqf/qR3BPdK33HoQ==
+"@trezor/blockchain-link@^1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@trezor/blockchain-link/-/blockchain-link-1.0.16.tgz#842d2846385deef7a179df74c1d157332708934c"
+  integrity sha512-K5HHgAFWrQEODsarEV55efk+Iamf96n56B8PAxMNaKRwj04i6LpQ8uyHSJf7hVZQ+z4lMXG+Qw7vijS17qooRw==
   dependencies:
     bignumber.js "^9.0.1"
     es6-promise "^4.2.8"


### PR DESCRIPTION
blockchain-ink@1.0.16
- Fixed an issue where account with non-zero balance could be marked as empty (eth)
- Pending ETH transaction fee calculated from ethereumSpecific field
- Added missing types (data) to ethereumSpecific field


connect:
add missing types (ethereumSpecific.data, estimateFee.value, new transaction.type: failed)
