### PR TITLE
Fix: safety checks type

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: yarn flow
+    - run: yarn typescript
     - run: yarn lint
     - run: yarn test:unit
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,15 +8,14 @@ stages:
 before_script:
   - nix-shell --run "yarn"
 
-# Build & Lint
-flow lint:
+verify:
   stage: build
   script:
     - nix-shell --run "yarn flow"
+    - nix-shell --run "yarn typescript"
     - nix-shell --run "yarn lint"
     - nix-shell --run "yarn test:unit"
 
-# Build & Lint
 build:
   stage: build
   script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Not Yet Released
+
+### Fixed
+- Incorrect typescript type of the `binary` field of the `firmwareUpdate`'s params'.
+
 # 8.1.25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Not Yet Released
 
+### Added
+- `safety_checks` field to the `ApplySettings` interface which lets you set the `safety_checks` Trezor feature.
+
 ### Fixed
 - Incorrect type of the `safety_checks` Trezor feature.
 - Incorrect typescript type of the `binary` field of the `firmwareUpdate`'s params'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Not Yet Released
 
 ### Fixed
+- Incorrect type of the `safety_checks` Trezor feature.
 - Incorrect typescript type of the `binary` field of the `firmwareUpdate`'s params'.
 
 # 8.1.25

--- a/docs/protobuf-type-definitions.md
+++ b/docs/protobuf-type-definitions.md
@@ -1,0 +1,48 @@
+# From Protobuf to TypeScript and Flow
+
+This document describes how the definitions of protobuf messages maintained in the
+firmware repo are semi-automatically translated to Flow and TypeScript definitions that are used in Connect codebase and by Connect users respectively.
+
+## The Pipeline
+
+The beginning and source of truth are the `.proto` definitions in the [firmware repository](https://github.com/trezor/trezor-firmware/tree/master/common/protob). These are duplicated as read-only in the [trezor-common](https://github.com/trezor/trezor-common) repository.
+
+`trezor-common` is included in Connect as a git submodule mounted at `submodules/trezor-common`.
+
+Here, `.proto` definitions are translated to a JSON format using [proto2js](https://www.npmjs.com/package/proto2js) package. This JSON is used on runtime by the [trezor-link](https://github.com/trezor/trezor-link/) (de)serialization logic and to generate the Flow and Typescript definitions.
+
+The JSON is transformed to Flow and/or TypeScript definitions by a script in `scripts/protobuf-types.js`. The script also applies 'patches' I.e. after-the-fact fixes manually described in `scripts/protobuf-patches.js`. The patches compensate for/fix
+- The source `.proto` definitions that do not reflect the actual business logic. Usually fields marked as required which are in fact optional.
+- Fields typed as `uint32`, `uint64`, `sint32`, `sint64` in protobuf that need to be represented as strings in runtime because of javascript number's insufficient range. Runtime conversion is handled automatically by `trezor-link`.
+- Similarly, fields typed as `bytes` in protobuf may be represented as hexadecimal `string`, `Buffer`, `Uint8Array` or `Array<number>` in runtime.
+- Optional protobuf fields that get typed as `<T> | undefined` but are in fact deserialized as `<T> | null`. This could be handled globally by `trezor-link`. The patches exist mainly for historical reasons.
+
+All these steps are done manually and all the generated files are tracked in git. It's also not uncommon to circumvent
+some step by eg. generating the messages.json file not from the Common submodule but directly from the firmware repo.
+
+## Example
+
+```bash
+# Clone the connect repo.
+git clone git@github.com:trezor/connect.git
+cd connect
+# Fetch all git submodules.
+make submodules
+# Install the node modules - including the `proto2js` package required in the next step.
+yarn
+# Transform the .proto definitions to JSON.
+# JSON goes to `src/data/messages/messagesN.json`.
+# Note: This make target also immediately runs the flow/TS type generation,
+# but because it implicitly reads from the old JSON it's basically a noop.
+# The flow/TS generation must be run again once the JSON is moved to the expected location.
+make protobuf
+# Observe the diff.
+git diff --no-index -- src/data/messages/messages.json src/data/messages/messagesN.json
+# Replace the old JSON with the new one.
+# In case of breaking changes this workflow is more complicated as it must account for versioning.
+# See the Versions section in ../README.md.
+mv src/data/messages/messagesN.json  src/data/messages/messages.json
+# Generate Flow and TypeScript definitions. (Implicitly reads from `src/data/messages/messages.json`)
+node scripts/protobuf-types.js
+node scripts/protobuf-types.js typescript
+```

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "test:unit": "jest --verbose -c jest.config.unit.js",
         "test:integration": "./tests/run.sh",
         "flow": "flow check .",
+        "typescript": "tsc --project src/ts/types/tsconfig.json",
         "lint": "eslint .",
         "lint:fix": "eslint --fix ."
     },
@@ -105,6 +106,7 @@
         "terser-webpack-plugin": "4.2.2",
         "tiny-worker": "^2.3.0",
         "trezor-link": "1.7.3",
+        "typescript": "^4.2.4",
         "uglify-es": "3.3.9",
         "version-bump-prompt": "6.1.0",
         "webpack": "4.44.2",

--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -53,6 +53,7 @@ const TYPE_PATCH = {
     'Features.fw_minor': 'number | null',
     'Features.fw_patch': 'number | null',
     'Features.fw_vendor': 'string | null',
+    'Features.safety_checks': 'SafetyCheckLevel | null',
     'HDNodePathType.node': 'HDNodeType | string',
     'TxInputType.amount': 'number | string',
     'TxOutputBinType.amount': 'number | string',

--- a/scripts/protobuf-types.js
+++ b/scripts/protobuf-types.js
@@ -29,6 +29,7 @@ const ENUM_KEYS = [
     'RequestType',
     'BackupType',
     'Capability',
+    'SafetyCheckLevel',
 ];
 
 const parseEnumTypescript = item => {

--- a/src/js/core/methods/ApplySettings.js
+++ b/src/js/core/methods/ApplySettings.js
@@ -26,7 +26,7 @@ export default class ApplySettings extends AbstractMethod {
             { name: 'passphrase_always_on_device', type: 'boolean' },
             { name: 'auto_lock_delay_ms', type: 'number' },
             { name: 'display_rotation', type: 'number' },
-            { name: 'safety_checks', type: 'number' },
+            { name: 'safety_checks', type: 'string' },
         ]);
 
         this.params = {

--- a/src/js/types/trezor/management.js
+++ b/src/js/types/trezor/management.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type { SafetyCheckLevel } from './protobuf';
+
 export type ResetDevice = {
     strength?: number,
     label?: string,
@@ -17,6 +19,7 @@ export type ApplySettings = {
     use_passphrase?: boolean,
     label?: string,
     auto_lock_delay_ms?: number,
+    safety_checks?: SafetyCheckLevel,
 };
 
 export type ApplyFlags = {

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -75,7 +75,7 @@ const Enum_SafetyCheckLevel = Object.freeze({
     PromptAlways: 1,
     PromptTemporarily: 2,
 });
-export type SafetyCheckLevel = $Values<typeof Enum_SafetyCheckLevel>;
+export type SafetyCheckLevel = $Keys<typeof Enum_SafetyCheckLevel>;
 
 // BinanceGetAddress
 export type BinanceGetAddress = {
@@ -1381,7 +1381,7 @@ export type Features = {
     wipe_code_protection?: boolean,
     session_id?: string,
     passphrase_always_on_device?: boolean,
-    safety_checks?: SafetyCheckLevel,
+    safety_checks?: SafetyCheckLevel | null,
     auto_lock_delay_ms?: number,
     display_rotation?: number,
     experimental_features?: boolean,

--- a/src/ts/types/__tests__/management.ts
+++ b/src/ts/types/__tests__/management.ts
@@ -23,6 +23,7 @@ export const management = async () => {
         display_rotation: 180,
         use_passphrase: true,
         label: 'My Trezor',
+        safety_checks: 'Strict',
     });
 
     TrezorConnect.backupDevice({});

--- a/src/ts/types/__tests__/management.ts
+++ b/src/ts/types/__tests__/management.ts
@@ -32,7 +32,7 @@ export const management = async () => {
     });
 
     TrezorConnect.firmwareUpdate({
-        payload: new ArrayBuffer(0),
+        binary: Buffer.from('abcd'),
     });
 
     TrezorConnect.recoveryDevice({

--- a/src/ts/types/trezor/management.d.ts
+++ b/src/ts/types/trezor/management.d.ts
@@ -1,3 +1,5 @@
+import type { SafetyCheckLevel } from './protobuf';
+
 export interface ResetDevice {
     strength?: number;
     label?: string;
@@ -15,6 +17,7 @@ export interface ApplySettings {
     use_passphrase?: boolean;
     label?: string;
     auto_lock_delay_ms?: number;
+    safety_checks?: SafetyCheckLevel;
 }
 
 export interface ApplyFlags {

--- a/src/ts/types/trezor/management.d.ts
+++ b/src/ts/types/trezor/management.d.ts
@@ -26,7 +26,7 @@ export interface ChangePin {
 }
 
 export interface FirmwareUpdateBinary {
-    binary: number[];
+    binary: Buffer;
 }
 
 export interface FirmwareUpdate {

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -64,11 +64,12 @@ export enum Enum_BackupType {
 }
 export type BackupType = keyof typeof Enum_BackupType;
 
-export enum SafetyCheckLevel {
+export enum Enum_SafetyCheckLevel {
     Strict = 0,
     PromptAlways = 1,
     PromptTemporarily = 2,
 }
+export type SafetyCheckLevel = keyof typeof Enum_SafetyCheckLevel;
 
 // BinanceGetAddress
 export type BinanceGetAddress = {
@@ -1358,7 +1359,7 @@ export type Features = {
     wipe_code_protection?: boolean;
     session_id?: string;
     passphrase_always_on_device?: boolean;
-    safety_checks?: SafetyCheckLevel;
+    safety_checks?: SafetyCheckLevel | null;
     auto_lock_delay_ms?: number;
     display_rotation?: number;
     experimental_features?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,7 +3104,6 @@ bitcoin-ops@^1.3.0:
 
 "blake2b@https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac":
   version "2.1.3"
-  uid "6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
   resolved "https://github.com/BitGo/blake2b#6268e6dd678661e0acc4359e9171b97eb1ebf8ac"
   dependencies:
     blake2b-wasm "https://github.com/BitGo/blake2b-wasm#193cdb71656c1a6c7f89b05d0327bb9b758d071b"
@@ -11029,6 +11028,11 @@ typeforce@^1.11.3:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
+
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes the type of the `SafetyChecksLevel` enum and documents the process of transforming `.proto` definitions to Flow/TypeScript type definitions.

Exposes `safety_checks` on `ApplySetting` a prerequisite for https://github.com/trezor/trezor-suite/pull/3590/commits/c5b45260832d560bd642d68c017c11809cc15012.