### PR TITLE
feat: update ltc and tltc fee options

### DIFF
--- a/src/js/core/methods/tx/Fees.js
+++ b/src/js/core/methods/tx/Fees.js
@@ -16,6 +16,20 @@ const BLOCKS = {
         economy: 36,
         low: 144,
     },
+    ltc: {
+        // blocktime ~ 150sec.
+        high: 1,
+        normal: 24,
+        economy: 144,
+        low: 576,
+    },
+    tltc: {
+        // blocktime ~ 150sec.
+        high: 1,
+        normal: 24,
+        economy: 144,
+        low: 576,
+    },
     bch: {
         // blocktime ~ 600sec.
         high: 1,


### PR DESCRIPTION
this does a couple things.

first, this sets a blockbook node for litecoin testnet. **this assumes that trezor would run a litecoin testnet blockbook node**. if not, i'd probably suggest using `https://tltc1.test` as that is one of the special use domains unless (someone else wants to setup and run a blockbook node). i've been using `tltc1.test` with a mapping in my `/etc/hosts` file while testing trezor-suite changes.

second, this configures the fee options to what both networks currently support. i've been able to successfully send 1 sat/vbyte transactions on both networks with no problem.