### PR TITLE
feat: configure dev webpack server https certificate with basicConstraints CA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ coverage
 
 # Cache
 __pycache__
+
+# dev
+webpack/connect_dev.crt
+webpack/connect_dev.key

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "./lib/env/node/networkUtils": "./lib/env/react-native/networkUtils"
     },
     "scripts": {
+        "predev": "node webpack/generate_dev_cert.js",
         "dev": "webpack-dev-server --config ./webpack/config.dev.babel.js --mode development",
         "build": "rm -rf build && webpack --config ./webpack/config.prod.babel.js --progress",
         "build:node": "rm -rf build && webpack --config ./webpack/config.nodejs.babel.js --progress",

--- a/webpack/config.dev.babel.js
+++ b/webpack/config.dev.babel.js
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import { SRC, HTML_SRC, JS_SRC, LIB_NAME, PORT } from './constants';
+import { ABSOLUTE_BASE, SRC, HTML_SRC, JS_SRC, LIB_NAME, PORT } from './constants';
 
 module.exports = {
     watch: true,
@@ -25,7 +25,11 @@ module.exports = {
     devServer: {
         contentBase: SRC,
         hot: false,
-        https: true,
+        https: {
+            // https://webpack.js.org/configuration/dev-server/#devserverhttps
+            key: `${ABSOLUTE_BASE}/webpack/connect_dev.key`,
+            cert: `${ABSOLUTE_BASE}/webpack/connect_dev.crt`,
+        },
         port: PORT,
         // stats: 'minimal',
         inline: true,

--- a/webpack/generate_dev_cert.js
+++ b/webpack/generate_dev_cert.js
@@ -1,0 +1,44 @@
+const selfsigned = require('selfsigned');
+const path = require('path');
+const fs = require('fs');
+
+const crtPath = path.join(__dirname, 'connect_dev.crt');
+const keyPath = path.join(__dirname, 'connect_dev.key');
+
+if (!fs.existsSync(crtPath) || !fs.existsSync(keyPath)) {
+    const pems = selfsigned.generate(
+        [
+            { name: 'commonName', value: 'localhost' },
+            { name: 'organizationName', value: 'INSECURE AUTHORITY' },
+            { name: 'organizationalUnitName', value: 'DEVELOPMENT' },
+        ],
+        {
+            keySize: 4096,
+            days: 3650,
+            algorithm: 'sha256',
+            extensions: [
+                {
+                    name: 'keyUsage',
+                    critical: true,
+                    keyCertSign: true,
+                    digitalSignature: true,
+                    nonRepudiation: true,
+                    keyEncipherment: true,
+                    dataEncipherment: true,
+                },
+                { name: 'extKeyUsage', critical: false, serverAuth: true },
+                { name: 'basicConstraints', critical: true, cA: true, pathLenConstraint: 0 },
+                {
+                    name: 'subjectAltName',
+                    critical: false,
+                    altNames: [{ type: 2 /* DNS */, value: 'localhost' }],
+                },
+            ],
+        },
+    );
+    fs.writeFileSync(crtPath, pems.cert, { encoding: 'utf8' });
+    fs.writeFileSync(keyPath, pems.private, { encoding: 'utf8' });
+    console.log('new key and crt files generated');
+} else {
+    console.log('key and crt files exist');
+}


### PR DESCRIPTION
This scratches one of my own itches. In short, this sets a self-signed cert for the dev connect server that has the basicConstraints CAset to true so that Chrome will allow importing.

More detailed explanation:
I've had to make some connect changes and test them locally.
These changes are used via my local trezor-suite server.
So, I point my trezor-suite at my localdev connect server and then access the suite in my fresh browser instance.
Of course, the the browser blocks the request because the cert of the connect server is not trusted.
I can manually open https://localhost:8088/ in another tab and accept the security warning. But, I have to do this each time I kill the browser and start again.
Normally, I'd import the connect server's cert into Chrome and be done with it. But, the cert does not have the CA basic constraint set to true and thus the current Chrome version blocks that action.

The cert was generated with:

`openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout connect_dev.key -out connect_dev.crt -subj '/O=INSECURE AUTHORITY/OU=DEVELOPMENT/CN=localhost' -extensions san -config <( echo '[req]'; echo 'distinguished_name=req'; echo '[san]'; echo 'subjectAltName=DNS:localhost'; echo 'basicConstraints=critical,CA:true,pathlen:0';)`

