### PR TITLE
fix: device features revision inconsistency between T1 and T2

### DIFF
--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -18,7 +18,11 @@ import { create as createDeferred } from '../utils/deferred';
 import DataManager from '../data/DataManager';
 import { getAllNetworks } from '../data/CoinInfo';
 import { getFirmwareStatus, getRelease } from '../data/FirmwareInfo';
-import { parseCapabilities, getUnavailableCapabilities } from '../utils/deviceFeaturesUtils';
+import {
+    parseCapabilities,
+    getUnavailableCapabilities,
+    parseRevision,
+} from '../utils/deviceFeaturesUtils';
 import { versionCompare } from '../utils/versionUtils';
 import { initLog } from '../utils/debug';
 
@@ -445,6 +449,10 @@ class Device extends EventEmitter {
         } else {
             feat.unlocked = true;
         }
+        // fix inconsistency of revision attribute between T1 and T2
+        const revision = parseRevision(feat);
+        feat.revision = revision;
+
         this.features = feat;
         this.featuresNeedsReload = false;
     }

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -2,7 +2,11 @@ import coinsJSON from '../../../data/coins.json';
 import configJSON from '../../../data/config.json';
 import { parseCoinsJson, getAllNetworks } from '../../data/CoinInfo';
 
-import { parseCapabilities, getUnavailableCapabilities } from '../deviceFeaturesUtils';
+import {
+    parseCapabilities,
+    getUnavailableCapabilities,
+    parseRevision,
+} from '../deviceFeaturesUtils';
 
 describe('utils/deviceFeaturesUtils', () => {
     beforeAll(() => {
@@ -175,5 +179,27 @@ describe('utils/deviceFeaturesUtils', () => {
 
         // without capabilities
         expect(getUnavailableCapabilities({}, coins, support)).toEqual({});
+    });
+
+    describe('parseRevision', () => {
+        it('parses hexadecimal raw bytes to the standard hexadecimal notation', () => {
+            expect(parseRevision({ revision: '6466303936336563' })).toEqual('df0963ec');
+        });
+
+        it('does nothing when standard hexadecimal notation is parsed', () => {
+            expect(parseRevision({ revision: 'f4424ece1ccb7fc0d6cad00ff840fac287a34f07' })).toEqual(
+                'f4424ece1ccb7fc0d6cad00ff840fac287a34f07',
+            );
+        });
+
+        it('does nothing when standard hexadecimal notation with only 0-9 symbols is parsed', () => {
+            expect(parseRevision({ revision: '2442434213337100161230033840333287234307' })).toEqual(
+                '2442434213337100161230033840333287234307',
+            );
+        });
+
+        it('passes null, caused by bootloader mode, through', () => {
+            expect(parseRevision({ revision: null })).toEqual(null);
+        });
     });
 });


### PR DESCRIPTION
**Original pull request [here](https://github.com/trezor/connect/pull/819). I accidentally deleted the branch it was based on before changing it.**

Device features revision fix related to [trezor-suite #3774](https://github.com/trezor/trezor-suite/pull/3774) and [trezor-firmware](https://github.com/trezor/trezor-firmware/issues/1620).

The problem is that T2 uses a different encoding of revision than T1.

Examples of revisions:
T2: 6466303936336563, 623139636266363763 (correct revision encoding from fw point of view)
T1: df0963ec48f01f3d07ffca556e21ff0070cab099, f4424ece1ccb7fc0d6cad00ff840fac287a34f07 (correct revision encoding we want to distribute from trezor-connect to apps to avoid unnecessary encoding)

Useful tools:
Hex to utf8: https://onlineutf8tools.com/convert-hexadecimal-to-utf8
utf8 to hex: https://onlineutf8tools.com/convert-utf8-to-hexadecimal
Regex tester: https://regex101.com/

Before:
https://github.com/trezor/trezor-firmware/commit/6466303936336563

After:
https://github.com/trezor/trezor-firmware/commit/df0963ec
![Screenshot 2021-05-25 at 12 47 04](https://user-images.githubusercontent.com/33235762/119485405-51f8db00-bd57-11eb-88f7-cbf7c4f0cdce.png)