### PR TITLE
fix: device features unlocked type

### DIFF
--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -76,6 +76,7 @@ const TYPE_PATCH = {
     'Features.revision': 'string | null',
     'Features.bootloader_hash': 'string | null',
     'Features.imported': 'boolean | null',
+    'Features.unlocked': 'boolean | null',
     'Features.firmware_present': 'boolean | null',
     'Features.needs_backup': 'boolean | null',
     'Features.flags': 'number | null',

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -1367,7 +1367,7 @@ export type Features = {
     revision: string | null,
     bootloader_hash: string | null,
     imported: boolean | null,
-    unlocked: boolean,
+    unlocked: boolean | null,
     firmware_present: boolean | null,
     needs_backup: boolean | null,
     flags: number | null,

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -1345,7 +1345,7 @@ export type Features = {
     revision: string | null;
     bootloader_hash: string | null;
     imported: boolean | null;
-    unlocked: boolean;
+    unlocked: boolean | null;
     firmware_present: boolean | null;
     needs_backup: boolean | null;
     flags: number | null;


### PR DESCRIPTION
Fixing forgotten change of unlocked attribute in device features.

`unlocked` can be either `boolean` or `null`