### PR TITLE
fix: RBF (transformOrigTransactions) use all account addresses

### DIFF
--- a/src/js/core/methods/tx/refTx.js
+++ b/src/js/core/methods/tx/refTx.js
@@ -81,7 +81,7 @@ export const transformOrigTransactions = (
         if (coinInfo.type !== 'bitcoin' || raw.type !== 'blockbook' || !addresses) return [];
         const { hex, vin, vout } = raw.tx;
         const tx = BitcoinJsTransaction.fromHex(hex, coinInfo.network);
-        const inputAddresses = addresses.used.concat(addresses.change);
+        const inputAddresses = addresses.used.concat(addresses.change).concat(addresses.unused);
 
         // inputs, required by TXORIGINPUT (TxAckInput) request from Trezor
         const inputsMap = (input: BitcoinJsInput, i: number) => {


### PR DESCRIPTION
addresses.unused field should be also searched while transforming original tx.
if utxo is not confirmed yet, then the addess is not marked as "used".

issue reported [on slack](https://satoshilabs.slack.com/archives/CKN5C51CJ/p1625056238037200), and fix already tested