### PR TITLE
fix: restore Ropsten blockchain_link

### DIFF
--- a/src/data/coins.json
+++ b/src/data/coins.json
@@ -2197,7 +2197,13 @@
             "url": "https://expanse.tech"
         },
         {
-            "blockchain_link": null,
+            "blockchain_link": {
+                "type": "blockbook",
+                "url": [
+                    "https://ropsten1.trezor.io",
+                    "https://ropsten2.trezor.io"
+                ]
+            },
             "chain": "rop",
             "chain_id": 3,
             "name": "Ethereum Testnet Ropsten",
@@ -2206,7 +2212,7 @@
             "slip44": 1,
             "support": {
                 "connect": true,
-                "suite": false,
+                "suite": true,
                 "trezor1": "1.6.2",
                 "trezor2": "2.0.7"
             },
@@ -2546,7 +2552,7 @@
             "slip44": 1,
             "support": {
                 "connect": true,
-                "suite": false,
+                "suite": true,
                 "trezor1": false,
                 "trezor2": "2.0.8"
             }
@@ -2581,7 +2587,7 @@
             "slip44": 144,
             "support": {
                 "connect": true,
-                "suite": false,
+                "suite": true,
                 "trezor1": false,
                 "trezor2": "2.0.8"
             }


### PR DESCRIPTION
blockchain_link field was accidentally removed by f2dc37500c9567e41f1310745e4a126cbaf7b0f8.

the reason was invalid key used in trezor-common.
fixing here:
https://github.com/trezor/trezor-firmware/commit/94588ffd8ae964371ad803f2db2f3f4871dfdbcf