### PR TITLE
tests: add health check tests

### DIFF
--- a/.github/workflows/fixup_check.yml
+++ b/.github/workflows/fixup_check.yml
@@ -1,0 +1,11 @@
+name: Fixup check
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn test:health
     - run: yarn flow
     - run: yarn typescript
     - run: yarn lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ before_script:
 verify:
   stage: build
   script:
+    - nix-shell --run "yarn test:health"
     - nix-shell --run "yarn flow"
     - nix-shell --run "yarn typescript"
     - nix-shell --run "yarn lint"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "stats": "webpack --config ./webpack/config.prod.babel.js --json > build/stats.json",
         "test:unit": "jest --verbose -c jest.config.unit.js",
         "test:integration": "jest --verbose -c jest.config.integration.js --detectOpenHandles --forceExit",
+        "test:health": "babel-node ./scripts/check-extended-dependencies.js",
         "flow": "flow check .",
         "typescript": "tsc --project src/ts/types/tsconfig.json",
         "lint": "eslint .",

--- a/scripts/check-extended-dependencies.js
+++ b/scripts/check-extended-dependencies.js
@@ -1,0 +1,15 @@
+import packageJSON from '../package.json';
+
+// Verify that dependencies listed in packageJSON.extendedDependencies (used in npm-extended build)
+// are corresponding with real dependencies
+
+Object.keys(packageJSON.extendedDependencies).forEach(pkg => {
+    const version = packageJSON.extendedDependencies[pkg];
+    const dependency = packageJSON.dependencies[pkg] || packageJSON.devDependencies[pkg];
+    if (!dependency) {
+        throw new Error(`${pkg} not found in package.json dependencies or devDependencies`);
+    }
+    if (version !== dependency) {
+        throw new Error(`${pkg} version mismatch ${version} != ${dependency}`);
+    }
+});


### PR DESCRIPTION
- checking `extendedDependencies` in package.json, to [prevent this](https://github.com/trezor/connect/commit/05bf0b19363390fbbb5ca8e7df9a1ad30da57583) 
- checking `!fixup` commits, like in trezor-suite