### PR TITLE
Chore/update protobuf messages

### DIFF
--- a/scripts/protobuf-types.js
+++ b/scripts/protobuf-types.js
@@ -30,6 +30,9 @@ const ENUM_KEYS = [
     'BackupType',
     'Capability',
     'SafetyCheckLevel',
+    'ButtonRequestType',
+    'PinMatrixRequestType',
+    'WordRequestType',
 ];
 
 const parseEnumTypescript = item => {

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1726,7 +1726,8 @@
                 }
             ],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1761,7 +1762,8 @@
                 }
             ],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1779,7 +1781,8 @@
             "enums": [],
             "messages": [],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1814,7 +1817,8 @@
                 }
             ],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1849,7 +1853,8 @@
                 }
             ],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1884,7 +1889,8 @@
                 }
             ],
             "options": {
-                "(wire_type)": 22
+                "(wire_type)": 22,
+                "(include_in_bitcoin_only)": true
             },
             "oneofs": {}
         },
@@ -1996,7 +2002,9 @@
                 },
                 {
                     "rule": "optional",
-                    "options": {},
+                    "options": {
+                        "default": 0
+                    },
                     "type": "uint32",
                     "name": "fee_per_anonymity",
                     "id": 3
@@ -2942,6 +2950,20 @@
                     "type": "ButtonRequestType",
                     "name": "code",
                     "id": 1
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "pages",
+                    "id": 2
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "page_number",
+                    "id": 3
                 }
             ],
             "enums": [
@@ -3824,7 +3846,7 @@
                 {
                     "rule": "optional",
                     "options": {},
-                    "type": "uint32",
+                    "type": "BackupType",
                     "name": "mnemonic_type",
                     "id": 12
                 },
@@ -5990,7 +6012,9 @@
                             "id": 17
                         }
                     ],
-                    "options": {}
+                    "options": {
+                        "(has_bitcoin_only_values)": true
+                    }
                 }
             ],
             "messages": [],
@@ -8939,6 +8963,25 @@
                     "type": "bool",
                     "name": "wire_no_fsm",
                     "id": 50008
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bool",
+                    "name": "bitcoin_only",
+                    "id": 60000
+                }
+            ]
+        },
+        {
+            "ref": "google.protobuf.EnumOptions",
+            "fields": [
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bool",
+                    "name": "has_bitcoin_only_values",
+                    "id": 51001
                 }
             ]
         },
@@ -8950,14 +8993,21 @@
                     "options": {},
                     "type": "bool",
                     "name": "unstable",
-                    "id": 50001
+                    "id": 52001
                 },
                 {
                     "rule": "optional",
                     "options": {},
                     "type": "uint32",
                     "name": "wire_type",
-                    "id": 50002
+                    "id": 52002
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bool",
+                    "name": "include_in_bitcoin_only",
+                    "id": 60000
                 }
             ]
         },
@@ -8969,7 +9019,7 @@
                     "options": {},
                     "type": "bool",
                     "name": "experimental",
-                    "id": 52001
+                    "id": 53001
                 }
             ]
         },
@@ -10886,20 +10936,8 @@
                     "id": 55
                 },
                 {
-                    "name": "MessageType_SetU2FCounter",
-                    "id": 63
-                },
-                {
                     "name": "MessageType_SdProtect",
                     "id": 79
-                },
-                {
-                    "name": "MessageType_GetNextU2FCounter",
-                    "id": 80
-                },
-                {
-                    "name": "MessageType_NextU2FCounter",
-                    "id": 81
                 },
                 {
                     "name": "MessageType_ChangeWipeCode",
@@ -10924,6 +10962,18 @@
                 {
                     "name": "MessageType_RebootToBootloader",
                     "id": 87
+                },
+                {
+                    "name": "MessageType_SetU2FCounter",
+                    "id": 63
+                },
+                {
+                    "name": "MessageType_GetNextU2FCounter",
+                    "id": 80
+                },
+                {
+                    "name": "MessageType_NextU2FCounter",
+                    "id": 81
                 },
                 {
                     "name": "MessageType_Deprecated_PassphraseStateRequest",
@@ -11574,7 +11624,9 @@
                     "id": 803
                 }
             ],
-            "options": {}
+            "options": {
+                "(has_bitcoin_only_values)": true
+            }
         }
     ],
     "imports": [],

--- a/src/js/core/methods/helpers/uploadFirmware.js
+++ b/src/js/core/methods/helpers/uploadFirmware.js
@@ -13,7 +13,7 @@ import type { IDevice } from '../../../device/Device';
 const postConfirmationMessage = (device: IDevice) => {
     // only if firmware is already installed. fresh device does not require button confirmation
     if (device.features.firmware_present) {
-        device.emit(DEVICE.BUTTON, device, 'ButtonRequest_FirmwareUpdate');
+        device.emit(DEVICE.BUTTON, device, { code: 'ButtonRequest_FirmwareUpdate' });
     }
 };
 

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -398,7 +398,7 @@ export default class DeviceCommands {
             if (res.message.code === 'ButtonRequest_PassphraseEntry') {
                 this.device.emit(DEVICE.PASSPHRASE_ON_DEVICE, this.device);
             } else {
-                this.device.emit(DEVICE.BUTTON, this.device, res.message.code);
+                this.device.emit(DEVICE.BUTTON, this.device, res.message);
             }
             return this._commonCall('ButtonAck', {});
         }

--- a/src/js/types/__tests__/index.js
+++ b/src/js/types/__tests__/index.js
@@ -136,6 +136,18 @@ export const events = () => {
             event.payload.data;
             event.payload.device;
         }
+        if (event.type === UI.REQUEST_PIN) {
+            event.payload.type;
+            event.payload.device;
+        }
+        if (event.type === UI.INVALID_PIN) {
+            (event.payload.type: void);
+            event.payload.device;
+        }
+        if (event.type === UI.REQUEST_WORD) {
+            event.payload.type;
+            event.payload.device;
+        }
     });
     TrezorConnect.off(UI_EVENT, () => {});
 

--- a/src/js/types/events.js
+++ b/src/js/types/events.js
@@ -2,6 +2,7 @@
 import { TRANSPORT, UI, IFRAME, POPUP } from '../constants';
 import type { ConnectSettings, CoreMessage } from './params';
 import type { Device } from './trezor/device';
+import type { ButtonRequest, PinMatrixRequestType, WordRequestType } from './trezor/protobuf';
 import type { DiscoveryAccount, SelectFeeLevel } from './account';
 import type { CoinInfo, BitcoinNetworkInfo } from './networks/coinInfo';
 
@@ -65,19 +66,32 @@ export type MessageWithoutPayload = {
         | typeof UI.LOGIN_CHALLENGE_REQUEST,
 };
 
-export type DeviceMessage = {
-    type:
-        | typeof UI.REQUEST_PIN
-        | typeof UI.INVALID_PIN
-        | typeof UI.REQUEST_PASSPHRASE_ON_DEVICE
-        | typeof UI.REQUEST_PASSPHRASE
-        | typeof UI.INVALID_PASSPHRASE
-        | typeof UI.REQUEST_WORD,
-    payload: {
-        device: Device,
-        type?: string, // todo: better flow enum
-    },
-};
+export type DeviceMessage =
+    | {
+          type: typeof UI.REQUEST_PIN,
+          payload: {
+              device: Device,
+              type: PinMatrixRequestType,
+          },
+      }
+    | {
+          type: typeof UI.REQUEST_WORD,
+          payload: {
+              device: Device,
+              type: WordRequestType,
+          },
+      }
+    | {
+          type:
+              | typeof UI.INVALID_PIN
+              | typeof UI.REQUEST_PASSPHRASE_ON_DEVICE
+              | typeof UI.REQUEST_PASSPHRASE
+              | typeof UI.INVALID_PASSPHRASE,
+          payload: {
+              device: Device,
+              type?: typeof undefined,
+          },
+      };
 
 export type ButtonRequestData = {
     type: 'address',
@@ -85,14 +99,16 @@ export type ButtonRequestData = {
     address: string,
 };
 
-export type ButtonRequestMessage = {
-    type: typeof UI.REQUEST_BUTTON,
-    payload: {
+// ButtonRequest_FirmwareUpdate is a artificial button request thrown by "uploadFirmware" method
+// at the beginning of the uploading process
+export interface ButtonRequestMessage {
+    type: typeof UI.REQUEST_BUTTON;
+    payload: ButtonRequest & {
+        code?: $PropertyType<ButtonRequest, 'code'> | 'ButtonRequest_FirmwareUpdate',
         device: Device,
-        code: string,
         data: ?ButtonRequestData,
-    },
-};
+    };
+}
 
 export type AddressValidationMessage = {
     type: typeof UI.ADDRESS_VALIDATION,

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -766,11 +766,13 @@ export const Enum_ButtonRequestType = Object.freeze({
     ButtonRequest_PassphraseEntry: 19,
     ButtonRequest_PinEntry: 20,
 });
-export type ButtonRequestType = $Values<typeof Enum_ButtonRequestType>;
+export type ButtonRequestType = $Keys<typeof Enum_ButtonRequestType>;
 
 // ButtonRequest
 export type ButtonRequest = {
     code?: ButtonRequestType,
+    pages?: number,
+    page_number?: number,
 };
 
 // ButtonAck
@@ -783,7 +785,7 @@ export const Enum_PinMatrixRequestType = Object.freeze({
     PinMatrixRequestType_WipeCodeFirst: 4,
     PinMatrixRequestType_WipeCodeSecond: 5,
 });
-export type PinMatrixRequestType = $Values<typeof Enum_PinMatrixRequestType>;
+export type PinMatrixRequestType = $Keys<typeof Enum_PinMatrixRequestType>;
 
 // PinMatrixRequest
 export type PinMatrixRequest = {
@@ -923,7 +925,7 @@ export type DebugLinkState = {
     recovery_fake_word?: string,
     recovery_word_pos?: number,
     reset_word_pos?: number,
-    mnemonic_type?: number,
+    mnemonic_type?: BackupType,
     layout_lines: string[],
 };
 
@@ -1523,7 +1525,7 @@ export const Enum_WordRequestType = Object.freeze({
     WordRequestType_Matrix9: 1,
     WordRequestType_Matrix6: 2,
 });
-export type WordRequestType = $Values<typeof Enum_WordRequestType>;
+export type WordRequestType = $Keys<typeof Enum_WordRequestType>;
 
 // WordRequest
 export type WordRequest = {

--- a/src/ts/types/__tests__/index.ts
+++ b/src/ts/types/__tests__/index.ts
@@ -122,8 +122,24 @@ export const events = async () => {
         }
         if (event.type === UI.REQUEST_BUTTON) {
             event.payload.code;
+            event.payload.code === 'ButtonRequest_ConfirmOutput';
+            event.payload.code === 'ButtonRequest_FirmwareUpdate';
+            // @ts-expect-error
+            event.payload.code === 'foo';
             event.payload.data;
             event.payload.device;
+        }
+
+        if (event.type === UI.REQUEST_PIN) {
+            event.payload.type === 'PinMatrixRequestType_Current';
+            // @ts-expect-error
+            event.payload.type === 'foo';
+        }
+
+        if (event.type === UI.REQUEST_WORD) {
+            event.payload.type === 'WordRequestType_Plain';
+            // @ts-expect-error
+            event.payload.type === 'foo';
         }
     });
     TrezorConnect.off(UI_EVENT, () => {});

--- a/src/ts/types/events.d.ts
+++ b/src/ts/types/events.d.ts
@@ -1,6 +1,7 @@
 import { TRANSPORT, UI, IFRAME, POPUP } from './constants';
 import { ConnectSettings } from './params';
 import { Device } from './trezor/device';
+import { ButtonRequest, PinMatrixRequestType, WordRequestType } from './trezor/protobuf';
 import { DiscoveryAccount, SelectFeeLevel } from './account';
 import { CoinInfo, BitcoinNetworkInfo } from './networks/coinInfo';
 
@@ -66,19 +67,32 @@ export interface MessageWithoutPayload {
         | typeof UI.LOGIN_CHALLENGE_REQUEST;
 }
 
-export interface DeviceMessage {
-    type:
-        | typeof UI.REQUEST_PIN
-        | typeof UI.INVALID_PIN
-        | typeof UI.REQUEST_PASSPHRASE_ON_DEVICE
-        | typeof UI.REQUEST_PASSPHRASE
-        | typeof UI.INVALID_PASSPHRASE
-        | typeof UI.REQUEST_WORD;
-    payload: {
-        device: Device;
-        type?: string; // todo: better flow enum
-    };
-}
+export type DeviceMessage =
+    | {
+          type: typeof UI.REQUEST_PIN;
+          payload: {
+              device: Device;
+              type: PinMatrixRequestType;
+          };
+      }
+    | {
+          type: typeof UI.REQUEST_WORD;
+          payload: {
+              device: Device;
+              type: WordRequestType;
+          };
+      }
+    | {
+          type:
+              | typeof UI.INVALID_PIN
+              | typeof UI.REQUEST_PASSPHRASE_ON_DEVICE
+              | typeof UI.REQUEST_PASSPHRASE
+              | typeof UI.INVALID_PASSPHRASE;
+          payload: {
+              device: Device;
+              type?: typeof undefined;
+          };
+      };
 
 export interface ButtonRequestData {
     type: 'address';
@@ -86,11 +100,13 @@ export interface ButtonRequestData {
     address: string;
 }
 
+// ButtonRequest_FirmwareUpdate is a artificial button request thrown by "uploadFirmware" method
+// at the beginning of the uploading process
 export interface ButtonRequestMessage {
     type: typeof UI.REQUEST_BUTTON;
-    payload: {
+    payload: Omit<ButtonRequest, 'code'> & {
+        code?: ButtonRequest['code'] | 'ButtonRequest_FirmwareUpdate';
         device: Device;
-        code: string;
         data?: ButtonRequestData;
     };
 }

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -726,7 +726,7 @@ export type Failure = {
     message?: string;
 };
 
-export enum ButtonRequestType {
+export enum Enum_ButtonRequestType {
     ButtonRequest_Other = 1,
     ButtonRequest_FeeOverThreshold = 2,
     ButtonRequest_ConfirmOutput = 3,
@@ -748,22 +748,26 @@ export enum ButtonRequestType {
     ButtonRequest_PassphraseEntry = 19,
     ButtonRequest_PinEntry = 20,
 }
+export type ButtonRequestType = keyof typeof Enum_ButtonRequestType;
 
 // ButtonRequest
 export type ButtonRequest = {
     code?: ButtonRequestType;
+    pages?: number;
+    page_number?: number;
 };
 
 // ButtonAck
 export type ButtonAck = {};
 
-export enum PinMatrixRequestType {
+export enum Enum_PinMatrixRequestType {
     PinMatrixRequestType_Current = 1,
     PinMatrixRequestType_NewFirst = 2,
     PinMatrixRequestType_NewSecond = 3,
     PinMatrixRequestType_WipeCodeFirst = 4,
     PinMatrixRequestType_WipeCodeSecond = 5,
 }
+export type PinMatrixRequestType = keyof typeof Enum_PinMatrixRequestType;
 
 // PinMatrixRequest
 export type PinMatrixRequest = {
@@ -902,7 +906,7 @@ export type DebugLinkState = {
     recovery_fake_word?: string;
     recovery_word_pos?: number;
     reset_word_pos?: number;
-    mnemonic_type?: number;
+    mnemonic_type?: BackupType;
     layout_lines: string[];
 };
 
@@ -1494,11 +1498,12 @@ export type RecoveryDevice = {
     dry_run?: boolean;
 };
 
-export enum WordRequestType {
+export enum Enum_WordRequestType {
     WordRequestType_Plain = 0,
     WordRequestType_Matrix9 = 1,
     WordRequestType_Matrix6 = 2,
 }
+export type WordRequestType = keyof typeof Enum_WordRequestType;
 
 // WordRequest
 export type WordRequest = {


### PR DESCRIPTION
new messages taken from trezor-firmware repo, commit [66bf309fbf98d3c3d8209285bf40e7e4a33c47cc](https://github.com/trezor/trezor-firmware/commit/66bf309fbf98d3c3d8209285bf40e7e4a33c47cc)
main changes: added "pages" and "page_number" fields in ButtonRequests

- expose whole ButtonRequest object in UI.REQUEST_BUTTON event (previously only "code" was exposed)
- `ButtonRequestMessage` and `DeviceMessage` (events) are now strongly typed by enum from protobuf, (previously it was `string`)
