### PR TITLE
Fix/dispose method

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "build:npm-extended": "rm -rf npm-extended && babel-node ./scripts/build-npm-extended.js && babel ./npm-extended/lib --out-dir ./npm-extended/lib",
         "stats": "webpack --config ./webpack/config.prod.babel.js --json > build/stats.json",
         "test:unit": "jest --verbose -c jest.config.unit.js",
-        "test:integration": "jest --verbose -c jest.config.integration.js --detectOpenHandles --forceExit",
+        "test:integration": "jest --verbose -c jest.config.integration.js",
         "test:health": "babel-node ./scripts/check-extended-dependencies.js",
         "flow": "flow check .",
         "typescript": "tsc --project src/ts/types/tsconfig.json",

--- a/src/js/backend/BlockchainLink.js
+++ b/src/js/backend/BlockchainLink.js
@@ -329,3 +329,9 @@ export const initBlockchain = async (
     }
     return backend;
 };
+
+export const dispose = () => {
+    while (instances.length > 0) {
+        instances[0].disconnect();
+    }
+};

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -23,6 +23,7 @@ import { find as findMethod } from './methods';
 import { create as createDeferred } from '../utils/deferred';
 import { resolveAfter } from '../utils/promiseUtils';
 import { initLog } from '../utils/debug';
+import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import InteractionTimeout from '../utils/interactionTimeout';
 
 import type { IDevice } from '../device/Device';
@@ -943,7 +944,7 @@ const initDeviceList = async (settings: ConnectSettings) => {
             _log.error('TRANSPORT ERROR', error);
             if (_deviceList) {
                 _deviceList.disconnectDevices();
-                _deviceList.removeAllListeners();
+                _deviceList.onBeforeUnload();
             }
 
             _deviceList = null;
@@ -991,6 +992,7 @@ export class Core extends EventEmitter {
         if (_deviceList) {
             _deviceList.onBeforeUnload();
         }
+        disposeBackend();
         this.removeAllListeners();
     }
 

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -944,7 +944,7 @@ const initDeviceList = async (settings: ConnectSettings) => {
             _log.error('TRANSPORT ERROR', error);
             if (_deviceList) {
                 _deviceList.disconnectDevices();
-                _deviceList.onBeforeUnload();
+                _deviceList.dispose();
             }
 
             _deviceList = null;
@@ -988,9 +988,9 @@ export class Core extends EventEmitter {
         handleMessage(message, isTrustedOrigin);
     }
 
-    onBeforeUnload() {
+    dispose() {
         if (_deviceList) {
-            _deviceList.onBeforeUnload();
+            _deviceList.dispose();
         }
         disposeBackend();
         this.removeAllListeners();
@@ -1084,7 +1084,7 @@ const disableWebUSBTransport = async () => {
 
     try {
         // disconnect previous device list
-        _deviceList.onBeforeUnload();
+        _deviceList.dispose();
         // and init with new settings, without webusb
         await initDeviceList(settings);
     } catch (error) {

--- a/src/js/device/DescriptorStream.js
+++ b/src/js/device/DescriptorStream.js
@@ -156,6 +156,7 @@ export default class DescriptorStream extends EventEmitter {
 
     stop() {
         this.listening = false;
+        this.removeAllListeners();
     }
 
     _reportChanges() {

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -653,7 +653,7 @@ class Device extends EventEmitter {
         return null;
     }
 
-    onBeforeUnload() {
+    dispose() {
         this.removeAllListeners();
         if (this.isUsedHere() && this.activitySessionID) {
             try {

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -654,6 +654,7 @@ class Device extends EventEmitter {
     }
 
     onBeforeUnload() {
+        this.removeAllListeners();
         if (this.isUsedHere() && this.activitySessionID) {
             try {
                 if (this.commands) {

--- a/src/js/device/DeviceList.js
+++ b/src/js/device/DeviceList.js
@@ -280,7 +280,7 @@ export default class DeviceList extends EventEmitter {
         };
     }
 
-    onBeforeUnload() {
+    dispose() {
         this.removeAllListeners();
 
         if (this.stream) {
@@ -294,7 +294,7 @@ export default class DeviceList extends EventEmitter {
             this.fetchController = null;
         }
 
-        this.allDevices().forEach(device => device.onBeforeUnload());
+        this.allDevices().forEach(device => device.dispose());
     }
 
     disconnectDevices() {

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -53,6 +53,7 @@ export const manifest = (data: any) => {
 };
 
 export const dispose = () => {
+    eventEmitter.removeAllListeners();
     iframe.dispose();
     if (_popupManager) {
         _popupManager.close();

--- a/src/js/env/node/index.js
+++ b/src/js/env/node/index.js
@@ -38,7 +38,7 @@ export const manifest = (m: $T.Manifest) => {
 export const dispose = () => {
     eventEmitter.removeAllListeners();
     if (_core) {
-        _core.onBeforeUnload();
+        _core.dispose();
     }
     // TODO: fix top level values during refactor
     // $FlowIssue

--- a/src/js/env/node/index.js
+++ b/src/js/env/node/index.js
@@ -36,10 +36,15 @@ export const manifest = (m: $T.Manifest) => {
 };
 
 export const dispose = () => {
-    // iframe.dispose();
-    // if (_popupManager) {
-    //     _popupManager.close();
-    // }
+    eventEmitter.removeAllListeners();
+    if (_core) {
+        _core.onBeforeUnload();
+    }
+    // TODO: fix top level values during refactor
+    // $FlowIssue
+    _settings = null;
+    // $FlowIssue
+    _core = null;
 };
 
 // handle message received from iframe

--- a/src/js/env/react-native/index.js
+++ b/src/js/env/react-native/index.js
@@ -38,10 +38,15 @@ export const manifest = (data: $T.Manifest) => {
 };
 
 export const dispose = () => {
-    // iframe.dispose();
-    // if (_popupManager) {
-    //     _popupManager.close();
-    // }
+    eventEmitter.removeAllListeners();
+    if (_core) {
+        _core.onBeforeUnload();
+    }
+    // TODO: fix top level values during refactor
+    // $FlowIssue
+    _settings = null;
+    // $FlowIssue
+    _core = null;
 };
 
 // handle message received from iframe

--- a/src/js/env/react-native/index.js
+++ b/src/js/env/react-native/index.js
@@ -40,7 +40,7 @@ export const manifest = (data: $T.Manifest) => {
 export const dispose = () => {
     eventEmitter.removeAllListeners();
     if (_core) {
-        _core.onBeforeUnload();
+        _core.dispose();
     }
     // TODO: fix top level values during refactor
     // $FlowIssue

--- a/src/js/iframe/iframe.js
+++ b/src/js/iframe/iframe.js
@@ -231,6 +231,6 @@ const init = async (payload: any, origin: string) => {
 window.addEventListener('message', handleMessage, false);
 window.addEventListener('unload', () => {
     if (_core) {
-        _core.onBeforeUnload();
+        _core.dispose();
     }
 });

--- a/src/js/popup/PopupManager.js
+++ b/src/js/popup/PopupManager.js
@@ -367,8 +367,4 @@ export default class PopupManager extends EventEmitter {
             this._window.postMessage(message, this.origin);
         }
     }
-
-    onBeforeUnload() {
-        this.close();
-    }
 }

--- a/tests/device/methods.test.js
+++ b/tests/device/methods.test.js
@@ -6,91 +6,104 @@ const { setup, skipTest, initTrezorConnect, Controller, TrezorConnect } = global
 let controller;
 let currentMnemonic;
 
-fixtures.forEach(testCase => {
-    describe(`TrezorConnect.${testCase.method}`, () => {
-        beforeAll(async done => {
-            if (!testCase.setup.mnemonic) done();
-            try {
-                if (!controller) {
-                    controller = new Controller({
-                        url: 'ws://localhost:9001/',
-                        name: testCase.method,
-                    });
-                    controller.on('error', error => {
-                        controller = undefined;
-                        console.log('Controller WS error', error);
-                    });
-                    controller.on('disconnect', () => {
-                        controller = undefined;
-                        console.log('Controller WS disconnected');
-                    });
+describe(`TrezorConnect methods`, () => {
+    // reset controller at the end
+    afterAll(done => {
+        if (controller) {
+            controller.dispose();
+            controller = undefined;
+        }
+        done();
+    });
+
+    fixtures.forEach(testCase => {
+        describe(`TrezorConnect.${testCase.method}`, () => {
+            beforeAll(async done => {
+                if (!testCase.setup.mnemonic) done();
+                try {
+                    if (!controller) {
+                        controller = new Controller({
+                            url: 'ws://localhost:9001/',
+                            name: testCase.method,
+                        });
+                        controller.on('error', error => {
+                            controller = undefined;
+                            console.log('Controller WS error', error);
+                        });
+                        controller.on('disconnect', () => {
+                            controller = undefined;
+                            console.log('Controller WS disconnected');
+                        });
+                    }
+
+                    if (testCase.setup.mnemonic !== currentMnemonic) {
+                        await setup(controller, testCase.setup);
+                        currentMnemonic = testCase.setup.mnemonic;
+                    }
+
+                    await initTrezorConnect(controller);
+
+                    done();
+                } catch (error) {
+                    console.log('Controller WS init error', error);
+                    done(error);
                 }
+            }, 40000);
 
-                if (testCase.setup.mnemonic !== currentMnemonic) {
-                    await setup(controller, testCase.setup);
-                    currentMnemonic = testCase.setup.mnemonic;
-                }
-
-                await initTrezorConnect(controller);
-
+            afterAll(done => {
+                TrezorConnect.dispose();
                 done();
-            } catch (error) {
-                console.log('Controller WS init error', error);
-                done(error);
-            }
-        }, 40000);
+            });
 
-        afterAll(done => {
-            TrezorConnect.dispose();
-            done();
-        });
+            testCase.tests.forEach(t => {
+                // check if test should be skipped on current configuration
+                const testMethod = skipTest(t.skip) ? it.skip : it;
+                testMethod(t.description, async done => {
+                    if (t.customTimeout) {
+                        jest.setTimeout(t.customTimeout);
+                    }
+                    if (!controller) {
+                        done('Controller not found');
+                        return;
+                    }
 
-        testCase.tests.forEach(t => {
-            // check if test should be skipped on current configuration
-            const testMethod = skipTest(t.skip) ? it.skip : it;
-            testMethod(t.description, async done => {
-                if (t.customTimeout) {
-                    jest.setTimeout(t.customTimeout);
-                }
-                if (!controller) {
-                    done('Controller not found');
-                    return;
-                }
+                    // print current test case, `jest` default reporter doesn't log this. see https://github.com/facebook/jest/issues/4471
+                    const log = chalk.black.bgYellow.bold(` ${testCase.method}: `);
+                    process.stderr.write(`\n${log} ${chalk.bold(t.description)}\n`);
 
-                // print current test case, `jest` default reporter doesn't log this. see https://github.com/facebook/jest/issues/4471
-                const log = chalk.black.bgYellow.bold(` ${testCase.method}: `);
-                process.stderr.write(`\n${log} ${chalk.bold(t.description)}\n`);
+                    if (t.mnemonic && t.mnemonic !== currentMnemonic) {
+                        // single test requires different seed, switch it
+                        await setup(controller, { mnemonic: t.mnemonic });
+                        currentMnemonic = t.mnemonic;
+                    } else if (!t.mnemonic && testCase.setup.mnemonic !== currentMnemonic) {
+                        // restore testCase.setup
+                        await setup(controller, testCase.setup);
+                        currentMnemonic = testCase.setup.mnemonic;
+                    }
 
-                if (t.mnemonic && t.mnemonic !== currentMnemonic) {
-                    // single test requires different seed, switch it
-                    await setup(controller, { mnemonic: t.mnemonic });
-                    currentMnemonic = t.mnemonic;
-                } else if (!t.mnemonic && testCase.setup.mnemonic !== currentMnemonic) {
-                    // restore testCase.setup
-                    await setup(controller, testCase.setup);
-                    currentMnemonic = testCase.setup.mnemonic;
-                }
+                    controller.options.name = t.description;
+                    const result = await TrezorConnect[testCase.method](t.params);
+                    let expected = t.result
+                        ? { success: true, payload: t.result }
+                        : { success: false };
 
-                controller.options.name = t.description;
-                const result = await TrezorConnect[testCase.method](t.params);
-                let expected = t.result ? { success: true, payload: t.result } : { success: false };
+                    // find legacy result
+                    if (t.legacyResults) {
+                        t.legacyResults.forEach(r => {
+                            if (skipTest(r.rules)) {
+                                expected = r.payload
+                                    ? { success: true, payload: r.payload }
+                                    : { success: false };
+                            }
+                        });
+                    }
 
-                // find legacy result
-                if (t.legacyResults) {
-                    t.legacyResults.forEach(r => {
-                        if (skipTest(r.rules)) {
-                            expected = r.payload
-                                ? { success: true, payload: r.payload }
-                                : { success: false };
-                        }
-                    });
-                }
-
-                expect(result).toMatchObject(expected);
-                if (t.customTimeout) {
-                    jest.setTimeout(20000);
-                }
-                done();
+                    expect(result).toMatchObject(expected);
+                    if (t.customTimeout) {
+                        jest.setTimeout(20000);
+                    }
+                    done();
+                });
             });
         });
     });

--- a/tests/websocket-client.js
+++ b/tests/websocket-client.js
@@ -140,6 +140,7 @@ class Controller extends EventEmitter {
     }
 
     connect() {
+        if (this.isConnected()) return Promise.resolve();
         // url validation
         let { url } = this.options;
         if (typeof url !== 'string') {


### PR DESCRIPTION
- fixed `TrezorConnect.dispose` and allow tests to ends gracefully. (`--detectOpenHandles --forceExit` are not longer required) fix: #515

- rename `onBeforeUnload` methods to `dispose`