### PR TITLE
feat(ci): automate production and beta releases to npm registry

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,27 @@
+name: "connect version check"
+on:
+  pull_request:
+    branches:
+      - v8
+jobs:
+    version_commit_check:
+      name: Check connect version commit message
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - run: |
+            LAST_COMMIT=$(git log -1 --pretty=%B)
+            VERSION=$(jq -r .version package.json)
+            [[ "$LAST_COMMIT" == "version $VERSION" ]]; if [ $? -eq 0 ]; then echo "Last commit message contains version";   exit 0; else echo "Last commit message DOES NOT contain version" >&2;   exit 1; fi
+
+    version_bump_check:
+      name: Check connect version bump
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-node@v2
+        - run: |
+            yarn install
+            REMOTE_VERSION=$(npm show trezor-connect version)
+            LOCAL_VERSION=$(jq -r .version package.json)
+            node scripts/ci-compare-version.js $LOCAL_VERSION $REMOTE_VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ publish release to npm:
       - v8
   when: manual
   before_script:
-    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'>.npmrc
+    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}">.npmrc
   script:
     - yarn build:npm && cd ./npm
     - npm publish
@@ -76,7 +76,7 @@ publish beta release to npm:
     - v8
   when: manual
   before_script:
-    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'>.npmrc
+    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}">.npmrc
   script:
     - yarn build:npm-extended && cd ./npm-extended
     - npm publish --tag beta

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,38 @@ deploy review:
   tags:
     - deploy
 
+# Publish release to npm registry
+
+publish release to npm:
+  image: node:14
+  stage: deploy
+  only:
+    refs:
+      - v8
+  when: manual
+  before_script:
+    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'>.npmrc
+  script:
+    - yarn build:npm && cd ./npm
+    - npm publish
+    - cd ../
+    - yarn build:npm-extended && cd ./npm-extended
+    - npm publish --tag extended
+
+# Publish beta release to npm registry
+
+publish beta release to npm:
+  image: node:14
+  stage: deploy
+  except:
+    - v8
+  when: manual
+  before_script:
+    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'>.npmrc
+  script:
+    - yarn build:npm-extended && cd ./npm-extended
+    - npm publish --tag beta
+
 # Test
 .test:
   stage: test

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "bchaddrjs": "^0.5.2",
         "bignumber.js": "^9.0.1",
         "bowser": "^2.11.0",
+        "compare-versions": "^3.6.0",
         "copy-webpack-plugin": "^6.3.2",
         "css-loader": "4.3.0",
         "es6-promise": "^4.2.2",

--- a/scripts/ci-compare-version.js
+++ b/scripts/ci-compare-version.js
@@ -1,0 +1,9 @@
+const compareVersions = require('compare-versions');
+
+if (compareVersions.compare(process.argv[2], process.argv[3], '>')) {
+    process.exit(0);
+}
+console.log(
+    'trezor-connect package.json version is the same or lower than the npm registry version.',
+);
+process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3798,6 +3798,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
This pr will allow us to publish releases to the npm registry with a simple button press. We will have 2 jobs one for production running only on v8 branch and beta one for all other branches with an option to upload beta tag packages.