### PR TITLE
fix: TrezorConnect.firmwareUpdate method

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@babel/preset-env": "^7.12.10",
         "@babel/preset-flow": "^7.12.1",
         "@trezor/blockchain-link": "^1.0.17",
-        "@trezor/rollout": "1.1.0",
+        "@trezor/rollout": "^1.2.0",
         "@trezor/utxo-lib": "^0.1.2",
         "babel-collect-imports": "https://github.com/szymonlesisz/babel-collect-imports",
         "babel-eslint": "^10.1.0",
@@ -112,7 +112,7 @@
     },
     "extendedDependencies": {
         "@trezor/blockchain-link": "^1.0.17",
-        "@trezor/rollout": "1.1.0",
+        "@trezor/rollout": "^1.2.0",
         "@trezor/utxo-lib": "^0.1.2",
         "bchaddrjs": "^0.5.2",
         "bignumber.js": "^9.0.1",

--- a/src/js/core/methods/FirmwareUpdate.js
+++ b/src/js/core/methods/FirmwareUpdate.js
@@ -10,7 +10,7 @@ import { getReleases } from '../../data/FirmwareInfo';
 import type { CoreMessage } from '../../types';
 
 type Params = {
-    binary?: Buffer,
+    binary?: ArrayBuffer,
     version?: number[],
     btcOnly?: boolean,
     baseUrl?: string,
@@ -35,7 +35,7 @@ export default class FirmwareUpdate extends AbstractMethod {
             { name: 'version', type: 'array' },
             { name: 'btcOnly', type: 'boolean' },
             { name: 'baseUrl', type: 'string' },
-            { name: 'binary', type: 'buffer' },
+            { name: 'binary', type: 'array-buffer' },
             { name: 'intermediary', type: 'boolean' },
         ]);
 
@@ -76,7 +76,7 @@ export default class FirmwareUpdate extends AbstractMethod {
     async run() {
         const { device } = this;
 
-        let binary;
+        let binary: ArrayBuffer;
         try {
             if (this.params.binary) {
                 binary = modifyFirmware({

--- a/src/js/core/methods/FirmwareUpdate.js
+++ b/src/js/core/methods/FirmwareUpdate.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { getBinary } from '@trezor/rollout';
+import { getBinary, modifyFirmware } from '@trezor/rollout';
 import AbstractMethod from './AbstractMethod';
 import { UI, ERRORS } from '../../constants';
 import { uploadFirmware } from './helpers/uploadFirmware';
@@ -79,7 +79,10 @@ export default class FirmwareUpdate extends AbstractMethod {
         let binary;
         try {
             if (this.params.binary) {
-                binary = this.params.binary;
+                binary = modifyFirmware({
+                    fw: this.params.binary,
+                    features: device.features,
+                });
             } else {
                 const firmware = await getBinary({
                     // features and releases are used for sanity checking inside @trezor/rollout

--- a/src/js/core/methods/helpers/__tests__/paramsValidator.test.js
+++ b/src/js/core/methods/helpers/__tests__/paramsValidator.test.js
@@ -1,0 +1,57 @@
+import { validateParams } from '../paramsValidator';
+
+const fixtures = [
+    {
+        description: 'array',
+        type: 'array',
+        value: [],
+        success: true,
+        allowEmpty: true,
+    },
+    {
+        description: 'array invalid (empty)',
+        type: 'array',
+        value: [],
+    },
+    {
+        description: 'array-buffer',
+        type: 'array-buffer',
+        value: new ArrayBuffer(0),
+        success: true,
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: Buffer.from('foo'),
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: [],
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: 'foo',
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: 0,
+    },
+];
+describe('helpers/paramsValidator', () => {
+    fixtures.forEach(f => {
+        it(f.description, () => {
+            if (!f.success) {
+                expect(() =>
+                    validateParams({ param: f.value }, [{ name: 'param', ...f }]),
+                ).toThrow();
+            } else {
+                expect(() =>
+                    validateParams({ param: f.value }, [{ name: 'param', ...f }]),
+                ).not.toThrow();
+            }
+        });
+    });
+});

--- a/src/js/core/methods/helpers/paramsValidator.js
+++ b/src/js/core/methods/helpers/paramsValidator.js
@@ -10,7 +10,7 @@ import type { CoinInfo, FirmwareRange } from '../../../types';
 
 type Param = {
     name: string,
-    type?: 'string' | 'number' | 'array' | 'buffer' | 'boolean' | 'amount' | 'object',
+    type?: 'string' | 'number' | 'array' | 'array-buffer' | 'boolean' | 'amount' | 'object',
     obligatory?: boolean,
     allowEmpty?: boolean,
 };
@@ -47,14 +47,10 @@ export const validateParams = (values: any, fields: Param[]) => {
                             `Parameter "${field.name}" has invalid value "${value}". Integer representation expected.`,
                         );
                     }
-                } else if (field.type === 'buffer') {
-                    if (
-                        typeof value === 'undefined' ||
-                        (typeof value.constructor.isBuffer === 'function' &&
-                            value.constructor.isBuffer(value))
-                    ) {
+                } else if (field.type === 'array-buffer') {
+                    if (!(value instanceof ArrayBuffer)) {
                         throw invalidParameter(
-                            `Parameter "${field.name}" has invalid type. "buffer" expected.`,
+                            `Parameter "${field.name}" has invalid type. "ArrayBuffer" expected.`,
                         );
                     }
                     // eslint-disable-next-line valid-typeof

--- a/src/js/types/__tests__/management.js
+++ b/src/js/types/__tests__/management.js
@@ -33,12 +33,18 @@ export const management = () => {
     });
 
     TrezorConnect.firmwareUpdate({
-        binary: Buffer.from('abcd'),
+        binary: new ArrayBuffer(0),
     });
 
     TrezorConnect.firmwareUpdate({
         version: [2, 2, 0],
         btcOnly: false,
+    });
+
+    // $FlowExpectedError: cannot use both
+    TrezorConnect.firmwareUpdate({
+        binary: new ArrayBuffer(0),
+        version: [2, 2, 0],
     });
 
     TrezorConnect.recoveryDevice({

--- a/src/js/types/trezor/management.js
+++ b/src/js/types/trezor/management.js
@@ -31,17 +31,13 @@ export type ChangePin = {
 };
 
 export type FirmwareUpdateBinary = {
-    binary?: Buffer,
+    binary: ArrayBuffer,
 };
 export type FirmwareUpdate = {
-    version?: number[],
+    version: number[],
     btcOnly?: boolean,
     baseUrl?: string,
-};
-
-export type FirmwareRequest = {
-    length: number,
-    offset: number,
+    intermediary?: boolean,
 };
 
 export type RecoveryDevice = {

--- a/src/ts/types/__tests__/management.ts
+++ b/src/ts/types/__tests__/management.ts
@@ -33,7 +33,18 @@ export const management = async () => {
     });
 
     TrezorConnect.firmwareUpdate({
-        binary: Buffer.from('abcd'),
+        binary: new ArrayBuffer(0),
+    });
+
+    TrezorConnect.firmwareUpdate({
+        version: [2, 2, 0],
+        btcOnly: false,
+    });
+
+    // @ts-expect-error: cannot use both
+    TrezorConnect.firmwareUpdate({
+        binary: new ArrayBuffer(0),
+        version: [2, 2, 0],
     });
 
     TrezorConnect.recoveryDevice({

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -344,9 +344,8 @@ export namespace TrezorConnect {
     /**
      * Sends FirmwareErase message followed by FirmwareUpdate message
      */
-    function firmwareUpdate(
-        params: P.CommonParams & (Mgmnt.FirmwareUpdate | Mgmnt.FirmwareUpdateBinary),
-    ): P.Response<P.DefaultMessage>;
+    function firmwareUpdate(params: P.CommonParams & Mgmnt.FirmwareUpdate): P.Response<P.DefaultMessage>;
+    function firmwareUpdate(params: P.CommonParams & Mgmnt.FirmwareUpdateBinary): P.Response<P.DefaultMessage>;
 
     /**
      * Asks device to initiate seed backup procedure

--- a/src/ts/types/trezor/management.d.ts
+++ b/src/ts/types/trezor/management.d.ts
@@ -29,18 +29,14 @@ export interface ChangePin {
 }
 
 export interface FirmwareUpdateBinary {
-    binary: Buffer;
+    binary: ArrayBuffer;
 }
 
 export interface FirmwareUpdate {
     version: number[];
-    btcOnly: boolean;
+    btcOnly?: boolean;
     baseUrl?: string;
-}
-
-export interface FirmwareRequest {
-    length: number;
-    offset: number;
+    intermediary?: boolean;
 }
 
 export interface RecoveryDevice {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,10 +1799,10 @@
     tiny-worker "^2.3.0"
     ws "^7.4.0"
 
-"@trezor/rollout@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@trezor/rollout/-/rollout-1.1.0.tgz#861bd034b2c869593f7b85ad0db925f10258ac2c"
-  integrity sha512-KecQrCSrWiO5HX2gVQLvtZEpk46JvtwXq7qi40g3q+YfHhRGNrlojcHumIOjhCl55+J7F3XRjXz3aXwWfSEyaQ==
+"@trezor/rollout@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@trezor/rollout/-/rollout-1.2.0.tgz#827316debc5cf2e8af2210900eb49540ea2753d1"
+  integrity sha512-R8/M8PsGQUndHlyETZ5+mPOveaJSTlEgmAovY7Ifm3quvk8nV5ByWL1LUJ8IYUgir209EWDWSKWfa5RWoon8IA==
   dependencies:
     cross-fetch "^3.0.6"
     runtypes "^5.0.1"


### PR DESCRIPTION
- uploaded binary modified in the same way as when downloaded by version
- Rollout version 1.2.0 needed