### PR TITLE
FIX:  On webextension example

### DIFF
--- a/examples/webextension/background/index.js
+++ b/examples/webextension/background/index.js
@@ -4,7 +4,7 @@ When the button's clicked:
 - show a notification with response (if succeed)
 */
 
-const { TrezorConnect } = global;
+const { TrezorConnect } = window;
 
 TrezorConnect.manifest({
     email: 'email@developer.com',


### PR DESCRIPTION
TrezorConnect is declared in window object, retrieving it from global will result in error.