### PR TITLE
feat(ci): add job for deploying connect to connect.trezor.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,8 +88,6 @@ publish release to npm:
 publish beta release to npm:
   image: node:14
   stage: deploy
-  except:
-    - v8
   when: manual
   before_script:
     - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}">.npmrc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@ build:
     paths:
       - build
 
-# Deploy
-deploy review:
+# Deploy to testing environment
+deploy test:
   stage: deploy
   variables:
     GIT_STRATEGY: none
@@ -46,6 +46,22 @@ deploy review:
     - rsync --delete -va build/ "${DEPLOY_BASE_DIR}/${CI_BUILD_REF_NAME}/"
   only:
     - branches
+  tags:
+    - deploy
+
+# Deploy release to connect.trezor.io
+deploy production:
+  stage: deploy
+  only:
+    refs:
+      - v8
+  when: manual
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - nix-shell --run "make clean"
+    - nix-shell --run "make build"
+    - nix-shell --run "make sync-8"
   tags:
     - deploy
 


### PR DESCRIPTION
This pr will allow us to connect directly to connect.trezor.io right from your GitLab ci with a manual action. This job will only run on the v8 branch. It is still a work in progress as we need to add some prerequisites to the GitLab CI environment, but otherwise, it should be good to go.