### PR TITLE
fix: missing message for Failure_ActionCancelled

### DIFF
--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -386,6 +386,11 @@ export default class DeviceCommands {
             if (code === 'Failure_FirmwareError' && !message) {
                 message = 'Firmware installation failed';
             }
+            // Failure_ActionCancelled message could be also missing
+            // https://github.com/trezor/connect/issues/865
+            if (code === 'Failure_ActionCancelled' && !message) {
+                message = 'Action cancelled by user';
+            }
             // pass code and message from firmware error
             return Promise.reject(new ERRORS.TrezorError(code, message));
         }

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -211,7 +211,7 @@ export const call = async (params: any): Promise<any> => {
         if (response) {
             if (
                 !response.success &&
-                response.payload.error.code !== 'Device_CallInProgress' &&
+                response.payload.code !== 'Device_CallInProgress' &&
                 _popupManager
             ) {
                 _popupManager.unlock();


### PR DESCRIPTION
Should fix #865 and also [#4101](https://github.com/trezor/trezor-suite/issues/4101) in Suite.