### PR TITLE
feat(ci): improve commit message check on pr to v8

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -11,9 +11,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - run: |
-            LAST_COMMIT=$(git log -1 --pretty=%B)
-            VERSION=$(jq -r .version package.json)
-            [[ "$LAST_COMMIT" == "version $VERSION" ]]; if [ $? -eq 0 ]; then echo "Last commit message contains version";   exit 0; else echo "Last commit message DOES NOT contain version" >&2;   exit 1; fi
+            ./scripts/ci-check_release_commit_messages.sh
 
     version_bump_check:
       name: Check connect version bump

--- a/scripts/ci-check_release_commit_messages.sh
+++ b/scripts/ci-check_release_commit_messages.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+fail=0
+
+git fetch origin develop
+
+# list all commits between HEAD and develop
+for commit in $(git rev-list origin/develop..)
+do
+    message=$(git log -n1 --format=%B $commit)
+    echo "Checking $commit"
+    version=$(jq -r .version package.json)
+    echo "Checking connect version"
+
+    # The commit message must contain either
+
+    # 1. Version substring
+    if [[ $message == "version $version" ]]; then
+      continue
+    fi
+
+    # 2. "cherry-picked from [some commit in develop]"
+    if [[ $message =~ "(cherry picked from commit" ]]; then
+      # remove last ")" and extract commit hash
+      develop_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
+      # check if develop really contains this commit hash
+      if [[ $(git branch -a --contains $develop_commit | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
+        continue
+      fi
+    fi
+
+    # 3. [RELEASE ONLY] substring
+    if [[ $message =~ "[RELEASE ONLY]" ]]; then
+      continue
+    fi
+
+    fail=1
+    echo "FAILURE! Neither 'version x.x.x' nor 'cherry picked from..'  nor '[RELEASE ONLY]' substring found in this commit message."
+done
+
+echo "ALL OK"
+exit $fail

--- a/scripts/ci-check_release_commit_messages.sh
+++ b/scripts/ci-check_release_commit_messages.sh
@@ -5,20 +5,20 @@ fail=0
 git fetch origin develop
 
 # list all commits between HEAD and develop
-for commit in $(git rev-list origin/develop..)
-do
-    COMMIT_ID=$(git log --pretty=format:'%H' -n 1 $commit)
-    echo "Checking $commit"
+commit=$(git rev-list origin/develop..)
 
-    # 1. Checking if the commit is in develop"
+commit_id=$(git log --pretty=format:'%H' -n 1 $commit)
+echo "Checking $commit"
 
-    if [[ $(git merge-base --is-ancestor $COMMIT_ID HEAD | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
-      continue
-    fi
+# 1. Checking if the commit is in develop"
 
-    fail=1
-    echo "Last commit is not in develop!"
-done
+if [[ $(git merge-base --is-ancestor $commit_id HEAD | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
+  continue
+fi
+
+fail=1
+echo "Last commit is not in develop!"
+
 
 echo "ALL OK"
 exit $fail


### PR DESCRIPTION
Hi, this pull request introduces better commit message checking for pull requests to the `v8` branch. Now the check will let you merge if it contains one of 3 types of commits 
~~1. version x.x.x. (same as `package.json` version)~~
~~2. cherry-picked commits from develop with `git cherry-pick <develop hash> -x `(for message cherry-picked from ...)~~
~~3. with suffix `[RELEASE ONLY]`~~
The script will now only check if the last commit is indeed present in the `develop` branch if not it fails.

We can modify it more but I think it's what you wanted to add @szymonlesisz 