### PR TITLE
Fix/unavailable capabilites

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@
 webpack
 src
 build
+__tests__
+__fixtures__
 _old
 .babelrc
 .flowconfig

--- a/scripts/build-npm-extended.js
+++ b/scripts/build-npm-extended.js
@@ -9,7 +9,7 @@ const LIB = path.resolve(__dirname, '../npm-extended/lib');
 const DATA_SRC = path.resolve(__dirname, '../src/data');
 const DATA = path.resolve(__dirname, '../npm-extended/data');
 
-const ignored = ['__tests__', '_old', 'icons', 'udev'];
+const ignored = ['__tests__', '__fixtures__', '_old', 'icons', 'udev'];
 const shouldIgnore = src => ignored.find(i => src.indexOf(i) >= 0);
 
 // copy all js files any make a copy with .flow extension

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -31,7 +31,7 @@ internal.forEach(file => {
     fs.copySync(file, `${libFile}.flow`);
 });
 
-const ignored = ['__tests__', '_old', 'icons', 'udev'];
+const ignored = ['__tests__', '__fixtures__', '_old', 'icons', 'udev'];
 const shouldIgnore = src => ignored.find(i => src.indexOf(i) >= 0);
 
 // copy typescript

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -106,12 +106,12 @@
     "supportedFirmware": [
         {
             "coin": ["xrp", "txrp"],
-            "excludedMethods": ["getAccountInfo"],
+            "methods": ["getAccountInfo"],
             "min": ["0", "2.1.0"],
             "comment": ["Since firmware 2.1.0 there is a new protobuf field 'destination_tag' in RippleSignTx"]
         },
         {
-            "excludedMethods": [
+            "methods": [
                 "rippleGetAddress",
                 "rippleSignTransaction"
             ],
@@ -119,7 +119,7 @@
             "comment": ["Since firmware 2.1.0 there is a new protobuf field 'destination_tag' in RippleSignTx"]
         },
         {
-            "excludedMethods": [
+            "methods": [
                 "cardanoGetAddress",
                 "cardanoGetPublicKey",
                 "cardanoSignTransaction"
@@ -128,19 +128,19 @@
             "comment": ["Shelley fork support since firmware 2.3.2"]
         },
         {
-            "excludedMethods": [
+            "methods": [
                 "tezosSignTransaction"
             ],
             "min": ["0", "2.1.8"],
             "comment": ["Since 2.1.8 there are new protobuf fields in tezos transaction (Babylon fork)"]
         },
         {
-            "excludedMethods": ["replaceTransaction"],
+            "methods": ["replaceTransaction"],
             "min": ["1.9.4", "2.3.5"],
             "comment": ["new sign tx process since 1.9.4/2.3.5"]
         },
         {
-            "excludedMethods": ["decreaseOutput"],
+            "methods": ["decreaseOutput"],
             "min": ["1.10.0", "2.4.0"],
             "comment": ["allow reduce output in RBF transaction since /2.4.0"]
         }

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -135,12 +135,12 @@
             "comment": ["Since 2.1.8 there are new protobuf fields in tezos transaction (Babylon fork)"]
         },
         {
-            "methods": ["replaceTransaction"],
+            "capabilities": ["replaceTransaction"],
             "min": ["1.9.4", "2.3.5"],
             "comment": ["new sign tx process since 1.9.4/2.3.5"]
         },
         {
-            "methods": ["decreaseOutput"],
+            "capabilities": ["decreaseOutput"],
             "min": ["1.10.0", "2.4.0"],
             "comment": ["allow reduce output in RBF transaction since /2.4.0"]
         }

--- a/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
+++ b/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
@@ -159,6 +159,24 @@ export const getFirmwareRange = [
         result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
     },
     {
+        description: 'range from config.json (by capabilities)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, no data
+                { min: ['1.11.0', '2.5.0'] },
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                // this one is ignored because of coin (not btc)
+                { coin: ['ltc'], methods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
+                // this one is ignored, different excludedMethod
+                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { capabilities: ['decreaseOutput'], min: ['1.10.0', '2.4.0'] },
+            ],
+        },
+        params: ['decreaseOutput', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
         description: 'range from config.json is lower than coinInfo',
         config: {
             supportedFirmware: [{ methods: ['signTransaction'], min: ['1.6.2', '2.1.0'] }],

--- a/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
+++ b/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
@@ -1,0 +1,211 @@
+export const validateParams = [
+    {
+        description: 'array',
+        type: 'array',
+        value: [],
+        success: true,
+        allowEmpty: true,
+    },
+    {
+        description: 'array invalid (empty)',
+        type: 'array',
+        value: [],
+    },
+    {
+        description: 'array-buffer',
+        type: 'array-buffer',
+        value: new ArrayBuffer(0),
+        success: true,
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: Buffer.from('foo'),
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: [],
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: 'foo',
+    },
+    {
+        description: 'array-buffer invalid',
+        type: 'array-buffer',
+        value: 0,
+    },
+];
+
+const DEFAULT_RANGE = {
+    '1': { min: '1.0.0', max: '0' },
+    '2': { min: '2.0.0', max: '0' },
+};
+
+const DEFAULT_COIN_INFO = {
+    support: { trezor1: '1.6.2', trezor2: '2.1.0' },
+    shortcut: 'btc',
+    type: 'bitcoin',
+};
+
+const EMPTY_CONFIG = {
+    supportedFirmware: [],
+};
+
+export const getFirmwareRange = [
+    {
+        description: 'default range. coinInfo and config.json data not found',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', null, DEFAULT_RANGE],
+        result: DEFAULT_RANGE,
+    },
+    {
+        description: 'range from coinInfo',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.6.2', max: '0' }, '2': { min: '2.1.0', max: '0' } },
+    },
+    {
+        description: 'coinInfo without support',
+        config: EMPTY_CONFIG,
+        params: ['signTransaction', { shortcut: 'btc', type: 'bitcoin' }, DEFAULT_RANGE],
+        result: { '1': { min: '0', max: '0' }, '2': { min: '0', max: '0' } },
+    },
+    {
+        description: 'coinInfo without T1 support',
+        config: EMPTY_CONFIG,
+        params: [
+            'signTransaction',
+            { support: { trezor1: null, trezor2: '2.1.0' }, shortcut: 'btc', type: 'bitcoin' },
+            DEFAULT_RANGE,
+        ],
+        result: { '1': { min: '0', max: '0' }, '2': { min: '2.1.0', max: '0' } },
+    },
+    {
+        description: 'coinInfo without T2 support',
+        config: EMPTY_CONFIG,
+        params: [
+            'signTransaction',
+            { support: { trezor1: '1.6.2', trezor2: null }, shortcut: 'btc', type: 'bitcoin' },
+            DEFAULT_RANGE,
+        ],
+        result: { '1': { min: '1.6.2', max: '0' }, '2': { min: '0', max: '0' } },
+    },
+    {
+        description: 'coinInfo support is lower than default',
+        config: EMPTY_CONFIG,
+        params: [
+            'signTransaction',
+            DEFAULT_COIN_INFO,
+            { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+        ],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json (by coinType)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                { coinType: 'bitcoin', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coinType: 'bitcoin', min: ['1.10.0', '2.4.0'] },
+                { coin: 'btc', min: ['1.11.0', '2.5.0'] },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json (by coin as string)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                { coin: 'btc', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: 'btc', min: ['1.10.0', '2.4.0'] },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json (by coin as array)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['btc'], min: ['1.10.0', '2.4.0'] },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json (by excludedMethods)',
+        config: {
+            supportedFirmware: [
+                // this one is ignored, no data
+                { min: ['1.11.0', '2.5.0'] },
+                // this one is ignored, different excludedMethod
+                { coin: ['btc'], excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                // this one is ignored because of coin (not btc)
+                { coin: ['ltc'], excludedMethods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
+                // this one is ignored, different excludedMethod
+                { coinType: 'bitcoin', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { excludedMethods: ['signTransaction'], min: ['1.10.0', '2.4.0'] },
+            ],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json is lower than coinInfo',
+        config: {
+            supportedFirmware: [{ excludedMethods: ['signTransaction'], min: ['1.6.2', '2.1.0'] }],
+        },
+        params: [
+            'signTransaction',
+            { support: { trezor1: '1.10.0', trezor2: '2.4.0' }, shortcut: 'btc', type: 'bitcoin' },
+            DEFAULT_RANGE,
+        ],
+        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+    },
+    {
+        description: 'range from config.json using max',
+        config: {
+            supportedFirmware: [{ excludedMethods: ['signTransaction'], max: ['1.10.0', '2.4.0'] }],
+        },
+        params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
+        result: { '1': { min: '1.6.2', max: '1.10.0' }, '2': { min: '2.1.0', max: '2.4.0' } },
+    },
+    {
+        description: 'range from config.json using max (values lower than default)',
+        config: {
+            supportedFirmware: [{ excludedMethods: ['signTransaction'], max: ['1.0.1', '2.0.1'] }],
+        },
+        params: [
+            'signTransaction',
+            DEFAULT_COIN_INFO,
+            {
+                '1': { min: '1.0.0', max: '1.10.0' },
+                '2': { min: '1.0.0', max: '2.10.0' },
+            },
+        ],
+        result: { '1': { min: '1.6.2', max: '1.10.0' }, '2': { min: '2.1.0', max: '2.10.0' } },
+    },
+    // real config.json data
+    {
+        description: 'xrp + getAccountInfo: coinInfo range IS replaced by config.json range',
+        params: [
+            'getAccountInfo',
+            { support: { trezor1: '1.0.1', trezor2: '2.0.1' }, shortcut: 'xrp', type: 'ripple' },
+            DEFAULT_RANGE,
+        ],
+        result: { '1': { min: '0', max: '0' }, '2': { min: '2.1.0', max: '0' } },
+    },
+    {
+        description: 'btc + getAccountInfo: coinInfo range IS NOT replaced by config.json range',
+        params: ['getAccountInfo', null, DEFAULT_RANGE],
+        result: DEFAULT_RANGE,
+    },
+];

--- a/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
+++ b/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
@@ -108,7 +108,7 @@ export const getFirmwareRange = [
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
                 { coinType: 'bitcoin', min: ['1.10.0', '2.4.0'] },
                 { coin: 'btc', min: ['1.11.0', '2.5.0'] },
             ],
@@ -121,7 +121,7 @@ export const getFirmwareRange = [
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coin: 'btc', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: 'btc', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
                 { coin: 'btc', min: ['1.10.0', '2.4.0'] },
             ],
         },
@@ -133,7 +133,7 @@ export const getFirmwareRange = [
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coin: ['btc'], excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
                 { coin: ['btc'], min: ['1.10.0', '2.4.0'] },
             ],
         },
@@ -141,18 +141,18 @@ export const getFirmwareRange = [
         result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
     },
     {
-        description: 'range from config.json (by excludedMethods)',
+        description: 'range from config.json (by methods)',
         config: {
             supportedFirmware: [
                 // this one is ignored, no data
                 { min: ['1.11.0', '2.5.0'] },
                 // this one is ignored, different excludedMethod
-                { coin: ['btc'], excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
                 // this one is ignored because of coin (not btc)
-                { coin: ['ltc'], excludedMethods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['ltc'], methods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', excludedMethods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { excludedMethods: ['signTransaction'], min: ['1.10.0', '2.4.0'] },
+                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { methods: ['signTransaction'], min: ['1.10.0', '2.4.0'] },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
@@ -161,7 +161,7 @@ export const getFirmwareRange = [
     {
         description: 'range from config.json is lower than coinInfo',
         config: {
-            supportedFirmware: [{ excludedMethods: ['signTransaction'], min: ['1.6.2', '2.1.0'] }],
+            supportedFirmware: [{ methods: ['signTransaction'], min: ['1.6.2', '2.1.0'] }],
         },
         params: [
             'signTransaction',
@@ -173,7 +173,7 @@ export const getFirmwareRange = [
     {
         description: 'range from config.json using max',
         config: {
-            supportedFirmware: [{ excludedMethods: ['signTransaction'], max: ['1.10.0', '2.4.0'] }],
+            supportedFirmware: [{ methods: ['signTransaction'], max: ['1.10.0', '2.4.0'] }],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
         result: { '1': { min: '1.6.2', max: '1.10.0' }, '2': { min: '2.1.0', max: '2.4.0' } },
@@ -181,7 +181,7 @@ export const getFirmwareRange = [
     {
         description: 'range from config.json using max (values lower than default)',
         config: {
-            supportedFirmware: [{ excludedMethods: ['signTransaction'], max: ['1.0.1', '2.0.1'] }],
+            supportedFirmware: [{ methods: ['signTransaction'], max: ['1.0.1', '2.0.1'] }],
         },
         params: [
             'signTransaction',

--- a/src/js/core/methods/helpers/__tests__/paramsValidator.test.js
+++ b/src/js/core/methods/helpers/__tests__/paramsValidator.test.js
@@ -1,57 +1,36 @@
-import { validateParams } from '../paramsValidator';
+import DataManager from '../../../../data/DataManager';
+import configJSON from '../../../../../data/config.json';
+import { validateParams, getFirmwareRange } from '../paramsValidator';
+import * as fixtures from '../__fixtures__/paramsValidator';
 
-const fixtures = [
-    {
-        description: 'array',
-        type: 'array',
-        value: [],
-        success: true,
-        allowEmpty: true,
-    },
-    {
-        description: 'array invalid (empty)',
-        type: 'array',
-        value: [],
-    },
-    {
-        description: 'array-buffer',
-        type: 'array-buffer',
-        value: new ArrayBuffer(0),
-        success: true,
-    },
-    {
-        description: 'array-buffer invalid',
-        type: 'array-buffer',
-        value: Buffer.from('foo'),
-    },
-    {
-        description: 'array-buffer invalid',
-        type: 'array-buffer',
-        value: [],
-    },
-    {
-        description: 'array-buffer invalid',
-        type: 'array-buffer',
-        value: 'foo',
-    },
-    {
-        description: 'array-buffer invalid',
-        type: 'array-buffer',
-        value: 0,
-    },
-];
 describe('helpers/paramsValidator', () => {
-    fixtures.forEach(f => {
-        it(f.description, () => {
-            if (!f.success) {
-                expect(() =>
-                    validateParams({ param: f.value }, [{ name: 'param', ...f }]),
-                ).toThrow();
-            } else {
-                expect(() =>
-                    validateParams({ param: f.value }, [{ name: 'param', ...f }]),
-                ).not.toThrow();
-            }
+    describe('validateParams', () => {
+        fixtures.validateParams.forEach(f => {
+            it(f.description, () => {
+                if (!f.success) {
+                    expect(() =>
+                        validateParams({ param: f.value }, [{ name: 'param', ...f }]),
+                    ).toThrow();
+                } else {
+                    expect(() =>
+                        validateParams({ param: f.value }, [{ name: 'param', ...f }]),
+                    ).not.toThrow();
+                }
+            });
+        });
+    });
+
+    describe('getFirmwareRange', () => {
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+        fixtures.getFirmwareRange.forEach(f => {
+            it(f.description, () => {
+                jest.spyOn(DataManager, 'getConfig').mockImplementation(
+                    () => f.config || configJSON,
+                );
+                expect(getFirmwareRange(...f.params)).toEqual(f.result);
+            });
         });
     });
 });

--- a/src/js/core/methods/helpers/paramsValidator.js
+++ b/src/js/core/methods/helpers/paramsValidator.js
@@ -105,6 +105,10 @@ export const getFirmwareRange = (
             if (rule.methods) {
                 return rule.methods.includes(method);
             }
+            // check if rule applies to capability
+            if (rule.capabilities) {
+                return rule.capabilities.includes(method);
+            }
             // rule doesn't have specified methods
             // it may be a global rule for coin or coinType
             return true;
@@ -119,7 +123,7 @@ export const getFirmwareRange = (
                 return (typeof c.coin === 'string' ? [c.coin] : c.coin).includes(shortcut);
             }
             // rule for method
-            return c.methods;
+            return c.methods || c.capabilities;
         });
 
     if (range) {

--- a/src/js/core/methods/helpers/paramsValidator.js
+++ b/src/js/core/methods/helpers/paramsValidator.js
@@ -102,10 +102,10 @@ export const getFirmwareRange = (
     const range = supportedFirmware
         .filter(rule => {
             // check if rule applies to requested method
-            if (rule.excludedMethods) {
-                return rule.excludedMethods.includes(method);
+            if (rule.methods) {
+                return rule.methods.includes(method);
             }
-            // rule doesn't have specified excludedMethods
+            // rule doesn't have specified methods
             // it may be a global rule for coin or coinType
             return true;
         })
@@ -119,7 +119,7 @@ export const getFirmwareRange = (
                 return (typeof c.coin === 'string' ? [c.coin] : c.coin).includes(shortcut);
             }
             // rule for method
-            return c.excludedMethods;
+            return c.methods;
         });
 
     if (range) {

--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -58,7 +58,7 @@ export type Config = {
     supportedFirmware: Array<{|
         coinType?: string,
         coin?: string | string[],
-        excludedMethods?: string[],
+        methods?: string[],
         min?: string[],
         max?: string[],
     |}>,

--- a/src/js/data/DataManager.js
+++ b/src/js/data/DataManager.js
@@ -59,6 +59,7 @@ export type Config = {
         coinType?: string,
         coin?: string | string[],
         methods?: string[],
+        capabilities?: string[],
         min?: string[],
         max?: string[],
     |}>,

--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -10,7 +10,7 @@ import type {
     Features,
     Deferred,
     FirmwareRelease,
-    UnavailableCapability,
+    UnavailableCapabilities,
 } from '../types';
 
 import { UI, DEVICE, ERRORS, NETWORK } from '../constants';
@@ -99,7 +99,7 @@ class Device extends EventEmitter {
 
     externalState: string[] = [];
 
-    unavailableCapabilities: { [key: string]: UnavailableCapability } = {};
+    unavailableCapabilities: UnavailableCapabilities = {};
 
     networkTypeState: string[] = [];
 

--- a/src/js/types/trezor/device.js
+++ b/src/js/types/trezor/device.js
@@ -16,8 +16,12 @@ export type UnavailableCapability =
     | 'no-capability'
     | 'no-support'
     | 'update-required'
-    | 'trezor-connect-outdated'
-    | string[];
+    | 'trezor-connect-outdated';
+
+// NOTE: unavailableCapabilities is an object with information what is NOT supported by this device.
+// in ideal/expected setup this object should be empty but given setup might have exceptions.
+// key = coin shortcut lowercase (ex: btc, eth, xrp) OR field declared in coins.json "supportedFirmware.capability"
+export type UnavailableCapabilities = { [key: string]: UnavailableCapability };
 
 export type FirmwareRange = {
     '1': {
@@ -64,7 +68,7 @@ export type KnownDevice = {|
     mode: DeviceMode,
     state: ?string,
     features: Features,
-    unavailableCapabilities: { [key: string]: UnavailableCapability },
+    unavailableCapabilities: UnavailableCapabilities,
 |};
 
 export type UnknownDevice = {|

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -136,47 +136,27 @@ describe('utils/deviceFeaturesUtils', () => {
             decreaseOutput: 'update-required',
         });
 
-        // excluded single method without specified coins
+        // added new capability
         expect(
             getUnavailableCapabilities(feat2, coins, [
                 {
                     min: ['0', '2.99.99'],
-                    methods: ['getAccountInfo'],
+                    capabilities: ['newCapabilityOrFeature'],
                 },
             ]),
         ).toEqual({
-            getAccountInfo: 'update-required',
+            newCapabilityOrFeature: 'update-required',
         });
 
-        // excluded single method with specified coins
         expect(
             getUnavailableCapabilities(feat2, coins, [
                 {
-                    min: ['0', '2.99.99'],
-                    coin: ['xrp', 'txrp'],
-                    methods: ['getAccountInfo'],
+                    min: ['0', '0'],
+                    capabilities: ['newCapabilityOrFeature'],
                 },
             ]),
         ).toEqual({
-            getAccountInfo: ['xrp', 'txrp'],
-        });
-
-        // disable multiple methods for outdated trezor-connect
-        expect(
-            getUnavailableCapabilities(feat2, coins, [
-                {
-                    max: ['0', '2.1.0'],
-                    coin: ['xrp', 'txrp'],
-                    methods: ['rippleGetAddress'],
-                },
-                {
-                    max: ['0', '2.1.0'],
-                    methods: ['tezosSignTransaction'],
-                },
-            ]),
-        ).toEqual({
-            rippleGetAddress: ['xrp', 'txrp'],
-            tezosSignTransaction: 'trezor-connect-outdated',
+            newCapabilityOrFeature: 'no-support',
         });
 
         // without capabilities

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -106,16 +106,16 @@ describe('utils/deviceFeaturesUtils', () => {
 
         // default Capabilities T1
         expect(getUnavailableCapabilities(feat1, coins, support)).toEqual({
-            ada: 'no-capability',
-            bnb: 'no-capability',
-            eos: 'no-capability',
+            ada: 'no-support',
+            bnb: 'no-support',
+            eos: 'no-support',
             ppc: 'update-required',
             sys: 'update-required',
             tppc: 'update-required',
-            txrp: 'no-capability',
+            txrp: 'no-support',
             uno: 'update-required',
-            xrp: 'no-capability',
-            xtz: 'no-capability',
+            xrp: 'no-support',
+            xtz: 'no-support',
             xvg: 'update-required',
             zcr: 'update-required',
             replaceTransaction: 'update-required',

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -141,7 +141,7 @@ describe('utils/deviceFeaturesUtils', () => {
             getUnavailableCapabilities(feat2, coins, [
                 {
                     min: ['0', '2.99.99'],
-                    excludedMethods: ['getAccountInfo'],
+                    methods: ['getAccountInfo'],
                 },
             ]),
         ).toEqual({
@@ -154,7 +154,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 {
                     min: ['0', '2.99.99'],
                     coin: ['xrp', 'txrp'],
-                    excludedMethods: ['getAccountInfo'],
+                    methods: ['getAccountInfo'],
                 },
             ]),
         ).toEqual({
@@ -167,11 +167,11 @@ describe('utils/deviceFeaturesUtils', () => {
                 {
                     max: ['0', '2.1.0'],
                     coin: ['xrp', 'txrp'],
-                    excludedMethods: ['rippleGetAddress'],
+                    methods: ['rippleGetAddress'],
                 },
                 {
                     max: ['0', '2.1.0'],
-                    excludedMethods: ['tezosSignTransaction'],
+                    methods: ['tezosSignTransaction'],
                 },
             ]),
         ).toEqual({

--- a/src/js/utils/deviceFeaturesUtils.js
+++ b/src/js/utils/deviceFeaturesUtils.js
@@ -99,13 +99,13 @@ export const getUnavailableCapabilities = (
 
     // 4. check if firmware version is in range of excluded methods in "config.supportedFirmware"
     support.forEach(s => {
-        if (s.min && s.excludedMethods && versionCompare(s.min[fw[0] - 1], fw) > 0) {
-            s.excludedMethods.forEach(m => {
+        if (s.min && s.methods && versionCompare(s.min[fw[0] - 1], fw) > 0) {
+            s.methods.forEach(m => {
                 list[m] = s.coin || 'update-required';
             });
         }
-        if (s.max && s.excludedMethods && versionCompare(s.max[fw[0] - 1], fw) < 0) {
-            s.excludedMethods.forEach(m => {
+        if (s.max && s.methods && versionCompare(s.max[fw[0] - 1], fw) < 0) {
+            s.methods.forEach(m => {
                 list[m] = s.coin || 'trezor-connect-outdated';
             });
         }

--- a/src/ts/types/trezor/device.d.ts
+++ b/src/ts/types/trezor/device.d.ts
@@ -16,8 +16,12 @@ export type UnavailableCapability =
     | 'no-capability'
     | 'no-support'
     | 'update-required'
-    | 'trezor-connect-outdated'
-    | string[];
+    | 'trezor-connect-outdated';
+
+// NOTE: unavailableCapabilities is an object with information what is NOT supported by this device.
+// in ideal/expected setup this object should be empty but given setup might have exceptions.
+// key = coin shortcut lowercase (ex: btc, eth, xrp) OR field declared in coins.json "supportedFirmware.capability"
+export type UnavailableCapabilities = { [key: string]: UnavailableCapability };
 
 export interface FirmwareRange {
     '1': {
@@ -44,7 +48,7 @@ export type KnownDevice = {
     mode: DeviceMode;
     state?: string;
     features: Features;
-    unavailableCapabilities: { [key: string]: UnavailableCapability };
+    unavailableCapabilities: UnavailableCapabilities;
 };
 
 export type UnknownDevice = {


### PR DESCRIPTION
Motivation:
`config.json` fields and `device.unavailableCapabilities` were inconsistent

Problems:
- invalid detection - 'no-capability' (from device.features) was set before 'no-support' (from coins.json)
- there was no possibility to disable support (using "0" value) from config.json
- `device.unavailableCapabilities` returns literal string (reason) OR array of strings (not anymore)
- `config.json` supportedFirmware rules confusing field names (excludedMethods mixed with defined capability/feature)
- there was no tests for `getFirmwareRange` utility