### PR TITLE
feat(stellar): strong typing in stellar protobuf

### DIFF
--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -9370,12 +9370,12 @@
             "oneofs": {}
         },
         {
-            "name": "StellarAssetType",
+            "name": "StellarAsset",
             "fields": [
                 {
                     "rule": "required",
                     "options": {},
-                    "type": "uint32",
+                    "type": "StellarAssetType",
                     "name": "type",
                     "id": 1
                 },
@@ -9449,51 +9449,51 @@
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "network_passphrase",
                     "id": 3
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "source_account",
                     "id": 4
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "fee",
                     "id": 5
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint64",
                     "name": "sequence_number",
                     "id": 6
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "timebounds_start",
                     "id": 8
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "timebounds_end",
                     "id": 9
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "uint32",
+                    "type": "StellarMemoType",
                     "name": "memo_type",
                     "id": 10
                 },
@@ -9519,14 +9519,41 @@
                     "id": 13
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "num_operations",
                     "id": 14
                 }
             ],
-            "enums": [],
+            "enums": [
+                {
+                    "name": "StellarMemoType",
+                    "values": [
+                        {
+                            "name": "NONE",
+                            "id": 0
+                        },
+                        {
+                            "name": "TEXT",
+                            "id": 1
+                        },
+                        {
+                            "name": "ID",
+                            "id": 2
+                        },
+                        {
+                            "name": "HASH",
+                            "id": 3
+                        },
+                        {
+                            "name": "RETURN",
+                            "id": 4
+                        }
+                    ],
+                    "options": {}
+                }
+            ],
             "messages": [],
             "options": {},
             "oneofs": {}
@@ -9550,21 +9577,21 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "destination_account",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "asset",
                     "id": 3
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "amount",
@@ -9587,14 +9614,14 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "new_account",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "starting_balance",
@@ -9617,35 +9644,35 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "send_asset",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "send_max",
                     "id": 3
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "destination_account",
                     "id": 4
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "destination_asset",
                     "id": 5
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "destination_amount",
@@ -9654,7 +9681,7 @@
                 {
                     "rule": "repeated",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "paths",
                     "id": 7
                 }
@@ -9675,42 +9702,42 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "selling_asset",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "buying_asset",
                     "id": 3
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "amount",
                     "id": 4
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "price_n",
                     "id": 5
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "price_d",
                     "id": 6
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint64",
                     "name": "offer_id",
@@ -9733,35 +9760,35 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "selling_asset",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "buying_asset",
                     "id": 3
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "sint64",
                     "name": "amount",
                     "id": 4
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "price_n",
                     "id": 5
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint32",
                     "name": "price_d",
@@ -9842,7 +9869,7 @@
                 {
                     "rule": "optional",
                     "options": {},
-                    "type": "uint32",
+                    "type": "StellarSignerType",
                     "name": "signer_type",
                     "id": 10
                 },
@@ -9861,7 +9888,26 @@
                     "id": 12
                 }
             ],
-            "enums": [],
+            "enums": [
+                {
+                    "name": "StellarSignerType",
+                    "values": [
+                        {
+                            "name": "ACCOUNT",
+                            "id": 0
+                        },
+                        {
+                            "name": "PRE_AUTH",
+                            "id": 1
+                        },
+                        {
+                            "name": "HASH",
+                            "id": 2
+                        }
+                    ],
+                    "options": {}
+                }
+            ],
             "messages": [],
             "options": {},
             "oneofs": {}
@@ -9877,14 +9923,14 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "StellarAssetType",
+                    "type": "StellarAsset",
                     "name": "asset",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint64",
                     "name": "limit",
@@ -9907,16 +9953,16 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "trusted_account",
                     "id": 2
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "uint32",
+                    "type": "StellarAssetType",
                     "name": "asset_type",
                     "id": 3
                 },
@@ -9928,9 +9974,9 @@
                     "id": 4
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
-                    "type": "uint32",
+                    "type": "bool",
                     "name": "is_authorized",
                     "id": 5
                 }
@@ -9951,7 +9997,7 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "destination_account",
@@ -9974,7 +10020,7 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "string",
                     "name": "key",
@@ -10004,7 +10050,7 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
+                    "rule": "required",
                     "options": {},
                     "type": "uint64",
                     "name": "bump_to",
@@ -11907,6 +11953,24 @@
             "options": {
                 "(has_bitcoin_only_values)": true
             }
+        },
+        {
+            "name": "StellarAssetType",
+            "values": [
+                {
+                    "name": "NATIVE",
+                    "id": 0
+                },
+                {
+                    "name": "ALPHANUM4",
+                    "id": 1
+                },
+                {
+                    "name": "ALPHANUM12",
+                    "id": 2
+                }
+            ],
+            "options": {}
         }
     ],
     "imports": [],

--- a/src/js/core/methods/helpers/stellarSignTx.js
+++ b/src/js/core/methods/helpers/stellarSignTx.js
@@ -115,7 +115,7 @@ const transformOperation = (op: StellarOperation): ?StellarOperationMessage => {
                 buying_asset: op.buying,
                 selling_asset: op.selling,
                 amount: op.amount,
-                offer_id: op.offerId,
+                offer_id: op.offerId || 0,
                 price_n: op.price.n,
                 price_d: op.price.d,
             };
@@ -159,7 +159,7 @@ const transformOperation = (op: StellarOperation): ?StellarOperationMessage => {
                 trusted_account: op.trustor,
                 asset_type: op.assetType,
                 asset_code: op.assetCode,
-                is_authorized: op.authorize ? 1 : 0,
+                is_authorized: !!op.authorize,
             };
 
         case 'accountMerge':

--- a/src/js/core/methods/helpers/stellarSignTx.js
+++ b/src/js/core/methods/helpers/stellarSignTx.js
@@ -1,5 +1,5 @@
 /* @flow */
-
+import { ERRORS } from '../../../constants';
 import { validateParams } from './paramsValidator';
 import type {
     StellarTransaction,
@@ -31,10 +31,15 @@ const processTxRequest = async (
 const transformSignMessage = (tx: StellarTransaction): StellarSignTx => {
     const options: StellarSignTx = {};
     // timebounds_start and timebounds_end are the only fields which needs to be converted to number
-    if (tx.timebounds) {
-        options.timebounds_start = tx.timebounds.minTime;
-        options.timebounds_end = tx.timebounds.maxTime;
+    if (!tx.timebounds) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            'transformSignMessage: Unspecified timebounds are not supported',
+        );
     }
+
+    options.timebounds_start = tx.timebounds.minTime;
+    options.timebounds_end = tx.timebounds.maxTime;
 
     if (tx.memo) {
         options.memo_type = tx.memo.type;

--- a/src/js/types/networks/stellar.js
+++ b/src/js/types/networks/stellar.js
@@ -17,9 +17,11 @@ import type {
     StellarBumpSequenceOp,
 } from '../trezor/protobuf';
 
+export type StellarAssetType = 0 | 1 | 2;
+
 export type StellarAsset = {
-    type: 0 | 1 | 2, // 0: native, 1: credit_alphanum4, 2: credit_alphanum12
-    code: string,
+    type: StellarAssetType,
+    code?: string,
     issuer?: string,
 };
 
@@ -34,7 +36,7 @@ export type StellarPaymentOperation = {
     type: 'payment', // Proto: "StellarPaymentOp"
     source?: string, // Proto: "source_account"
     destination: string, // Proto: "destination_account"
-    asset?: StellarAsset | typeof undefined, // Proto: ok
+    asset: StellarAsset, // Proto: ok
     amount: string, // Proto: ok
 };
 
@@ -90,7 +92,7 @@ export type StellarChangeTrustOperation = {
     type: 'changeTrust', // Proto: "StellarChangeTrustOp"
     source?: string, // Proto: "source_account"
     line: StellarAsset, // Proto: ok
-    limit?: string, // Proto: ok
+    limit: string, // Proto: ok
 };
 
 export type StellarAllowTrustOperation = {
@@ -98,7 +100,7 @@ export type StellarAllowTrustOperation = {
     source?: string, // Proto: "source_account"
     trustor: string, // Proto: "trusted_account"
     assetCode: string, // Proto: "asset_code"
-    assetType: number, // Proto: "asset_type" // TODO not found in stellar-sdk
+    assetType: StellarAssetType, // Proto: "asset_type"
     authorize?: boolean | typeof undefined, // Proto: "is_authorized" > parse to number
 };
 

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -97,6 +97,13 @@ export const Enum_SafetyCheckLevel = Object.freeze({
 });
 export type SafetyCheckLevel = $Keys<typeof Enum_SafetyCheckLevel>;
 
+export const Enum_StellarAssetType = Object.freeze({
+    NATIVE: 0,
+    ALPHANUM4: 1,
+    ALPHANUM12: 2,
+});
+export type StellarAssetType = $Values<typeof Enum_StellarAssetType>;
+
 // BinanceGetAddress
 export type BinanceGetAddress = {
     address_n: number[],
@@ -1796,10 +1803,10 @@ export type RippleSignedTx = {
     serialized_tx: string,
 };
 
-// StellarAssetType
-export type StellarAssetType = {
-    type: 0 | 1 | 2,
-    code: string,
+// StellarAsset
+export type StellarAsset = {
+    type: StellarAssetType,
+    code?: string,
     issuer?: string,
 };
 
@@ -1814,20 +1821,29 @@ export type StellarAddress = {
     address: string,
 };
 
+export const Enum_StellarMemoType = Object.freeze({
+    NONE: 0,
+    TEXT: 1,
+    ID: 2,
+    HASH: 3,
+    RETURN: 4,
+});
+export type StellarMemoType = $Values<typeof Enum_StellarMemoType>;
+
 // StellarSignTx
 export type StellarSignTx = {
     address_n: number[],
-    network_passphrase?: string,
-    source_account?: string,
-    fee?: number,
-    sequence_number?: string | number,
-    timebounds_start?: number,
-    timebounds_end?: number,
-    memo_type?: number,
+    network_passphrase: string,
+    source_account: string,
+    fee: number,
+    sequence_number: string | number,
+    timebounds_start: number,
+    timebounds_end: number,
+    memo_type: StellarMemoType,
     memo_text?: string,
     memo_id?: string,
     memo_hash?: Buffer | string,
-    num_operations?: number,
+    num_operations: number,
 };
 
 // StellarTxOpRequest
@@ -1836,49 +1852,56 @@ export type StellarTxOpRequest = {};
 // StellarPaymentOp
 export type StellarPaymentOp = {
     source_account?: string,
-    destination_account?: string,
-    asset?: StellarAssetType,
-    amount?: string | number,
+    destination_account: string,
+    asset: StellarAsset,
+    amount: string | number,
 };
 
 // StellarCreateAccountOp
 export type StellarCreateAccountOp = {
     source_account?: string,
-    new_account?: string,
-    starting_balance?: string | number,
+    new_account: string,
+    starting_balance: string | number,
 };
 
 // StellarPathPaymentOp
 export type StellarPathPaymentOp = {
     source_account?: string,
-    send_asset?: StellarAssetType,
-    send_max?: string | number,
-    destination_account?: string,
-    destination_asset?: StellarAssetType,
-    destination_amount?: string | number,
-    paths?: StellarAssetType[],
+    send_asset: StellarAsset,
+    send_max: string | number,
+    destination_account: string,
+    destination_asset: StellarAsset,
+    destination_amount: string | number,
+    paths?: StellarAsset[],
 };
 
 // StellarManageOfferOp
 export type StellarManageOfferOp = {
     source_account?: string,
-    selling_asset?: StellarAssetType,
-    buying_asset?: StellarAssetType,
-    amount?: string | number,
-    price_n?: number,
-    price_d?: number,
-    offer_id?: string | number,
+    selling_asset: StellarAsset,
+    buying_asset: StellarAsset,
+    amount: string | number,
+    price_n: number,
+    price_d: number,
+    offer_id: string | number,
 };
 
 // StellarCreatePassiveOfferOp
 export type StellarCreatePassiveOfferOp = {
     source_account?: string,
-    selling_asset?: StellarAssetType,
-    buying_asset?: StellarAssetType,
-    amount?: string | number,
-    price_n?: number,
-    price_d?: number,
+    selling_asset: StellarAsset,
+    buying_asset: StellarAsset,
+    amount: string | number,
+    price_n: number,
+    price_d: number,
 };
+
+export const Enum_StellarSignerType = Object.freeze({
+    ACCOUNT: 0,
+    PRE_AUTH: 1,
+    HASH: 2,
+});
+export type StellarSignerType = $Values<typeof Enum_StellarSignerType>;
 
 // StellarSetOptionsOp
 export type StellarSetOptionsOp = {
@@ -1891,7 +1914,7 @@ export type StellarSetOptionsOp = {
     medium_threshold?: string | number,
     high_threshold?: string | number,
     home_domain?: string,
-    signer_type?: number,
+    signer_type?: StellarSignerType,
     signer_key?: Buffer | string,
     signer_weight?: number,
 };
@@ -1899,36 +1922,36 @@ export type StellarSetOptionsOp = {
 // StellarChangeTrustOp
 export type StellarChangeTrustOp = {
     source_account?: string,
-    asset?: StellarAssetType,
-    limit?: string | number,
+    asset: StellarAsset,
+    limit: string | number,
 };
 
 // StellarAllowTrustOp
 export type StellarAllowTrustOp = {
     source_account?: string,
-    trusted_account?: string,
-    asset_type?: number,
+    trusted_account: string,
+    asset_type: StellarAssetType,
     asset_code?: string,
-    is_authorized?: number,
+    is_authorized: boolean,
 };
 
 // StellarAccountMergeOp
 export type StellarAccountMergeOp = {
     source_account?: string,
-    destination_account?: string,
+    destination_account: string,
 };
 
 // StellarManageDataOp
 export type StellarManageDataOp = {
     source_account?: string,
-    key?: string,
+    key: string,
     value?: Buffer | string,
 };
 
 // StellarBumpSequenceOp
 export type StellarBumpSequenceOp = {
     source_account?: string,
-    bump_to?: string | number,
+    bump_to: string | number,
 };
 
 // StellarSignedTx
@@ -2282,22 +2305,22 @@ export type MessageType = {
     RipplePayment: $Exact<RipplePayment>,
     RippleSignTx: RippleSignTx,
     RippleSignedTx: $Exact<RippleSignedTx>,
-    StellarAssetType: $Exact<StellarAssetType>,
+    StellarAsset: $Exact<StellarAsset>,
     StellarGetAddress: StellarGetAddress,
     StellarAddress: $Exact<StellarAddress>,
-    StellarSignTx: StellarSignTx,
+    StellarSignTx: $Exact<StellarSignTx>,
     StellarTxOpRequest: StellarTxOpRequest,
-    StellarPaymentOp: StellarPaymentOp,
-    StellarCreateAccountOp: StellarCreateAccountOp,
-    StellarPathPaymentOp: StellarPathPaymentOp,
-    StellarManageOfferOp: StellarManageOfferOp,
-    StellarCreatePassiveOfferOp: StellarCreatePassiveOfferOp,
+    StellarPaymentOp: $Exact<StellarPaymentOp>,
+    StellarCreateAccountOp: $Exact<StellarCreateAccountOp>,
+    StellarPathPaymentOp: $Exact<StellarPathPaymentOp>,
+    StellarManageOfferOp: $Exact<StellarManageOfferOp>,
+    StellarCreatePassiveOfferOp: $Exact<StellarCreatePassiveOfferOp>,
     StellarSetOptionsOp: StellarSetOptionsOp,
-    StellarChangeTrustOp: StellarChangeTrustOp,
-    StellarAllowTrustOp: StellarAllowTrustOp,
-    StellarAccountMergeOp: StellarAccountMergeOp,
-    StellarManageDataOp: StellarManageDataOp,
-    StellarBumpSequenceOp: StellarBumpSequenceOp,
+    StellarChangeTrustOp: $Exact<StellarChangeTrustOp>,
+    StellarAllowTrustOp: $Exact<StellarAllowTrustOp>,
+    StellarAccountMergeOp: $Exact<StellarAccountMergeOp>,
+    StellarManageDataOp: $Exact<StellarManageDataOp>,
+    StellarBumpSequenceOp: $Exact<StellarBumpSequenceOp>,
     StellarSignedTx: $Exact<StellarSignedTx>,
     TezosGetAddress: TezosGetAddress,
     TezosAddress: $Exact<TezosAddress>,

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -86,6 +86,12 @@ export enum Enum_SafetyCheckLevel {
 }
 export type SafetyCheckLevel = keyof typeof Enum_SafetyCheckLevel;
 
+export enum StellarAssetType {
+    NATIVE = 0,
+    ALPHANUM4 = 1,
+    ALPHANUM12 = 2,
+}
+
 // BinanceGetAddress
 export type BinanceGetAddress = {
     address_n: number[];
@@ -1766,10 +1772,10 @@ export type RippleSignedTx = {
     serialized_tx: string;
 };
 
-// StellarAssetType
-export type StellarAssetType = {
-    type: 0 | 1 | 2;
-    code: string;
+// StellarAsset
+export type StellarAsset = {
+    type: StellarAssetType;
+    code?: string;
     issuer?: string;
 };
 
@@ -1784,20 +1790,28 @@ export type StellarAddress = {
     address: string;
 };
 
+export enum StellarMemoType {
+    NONE = 0,
+    TEXT = 1,
+    ID = 2,
+    HASH = 3,
+    RETURN = 4,
+}
+
 // StellarSignTx
 export type StellarSignTx = {
     address_n: number[];
-    network_passphrase?: string;
-    source_account?: string;
-    fee?: number;
-    sequence_number?: string | number;
-    timebounds_start?: number;
-    timebounds_end?: number;
-    memo_type?: number;
+    network_passphrase: string;
+    source_account: string;
+    fee: number;
+    sequence_number: string | number;
+    timebounds_start: number;
+    timebounds_end: number;
+    memo_type: StellarMemoType;
     memo_text?: string;
     memo_id?: string;
     memo_hash?: Buffer | string;
-    num_operations?: number;
+    num_operations: number;
 };
 
 // StellarTxOpRequest
@@ -1806,49 +1820,55 @@ export type StellarTxOpRequest = {};
 // StellarPaymentOp
 export type StellarPaymentOp = {
     source_account?: string;
-    destination_account?: string;
-    asset?: StellarAssetType;
-    amount?: string | number;
+    destination_account: string;
+    asset: StellarAsset;
+    amount: string | number;
 };
 
 // StellarCreateAccountOp
 export type StellarCreateAccountOp = {
     source_account?: string;
-    new_account?: string;
-    starting_balance?: string | number;
+    new_account: string;
+    starting_balance: string | number;
 };
 
 // StellarPathPaymentOp
 export type StellarPathPaymentOp = {
     source_account?: string;
-    send_asset?: StellarAssetType;
-    send_max?: string | number;
-    destination_account?: string;
-    destination_asset?: StellarAssetType;
-    destination_amount?: string | number;
-    paths?: StellarAssetType[];
+    send_asset: StellarAsset;
+    send_max: string | number;
+    destination_account: string;
+    destination_asset: StellarAsset;
+    destination_amount: string | number;
+    paths?: StellarAsset[];
 };
 
 // StellarManageOfferOp
 export type StellarManageOfferOp = {
     source_account?: string;
-    selling_asset?: StellarAssetType;
-    buying_asset?: StellarAssetType;
-    amount?: string | number;
-    price_n?: number;
-    price_d?: number;
-    offer_id?: string | number;
+    selling_asset: StellarAsset;
+    buying_asset: StellarAsset;
+    amount: string | number;
+    price_n: number;
+    price_d: number;
+    offer_id: string | number;
 };
 
 // StellarCreatePassiveOfferOp
 export type StellarCreatePassiveOfferOp = {
     source_account?: string;
-    selling_asset?: StellarAssetType;
-    buying_asset?: StellarAssetType;
-    amount?: string | number;
-    price_n?: number;
-    price_d?: number;
+    selling_asset: StellarAsset;
+    buying_asset: StellarAsset;
+    amount: string | number;
+    price_n: number;
+    price_d: number;
 };
+
+export enum StellarSignerType {
+    ACCOUNT = 0,
+    PRE_AUTH = 1,
+    HASH = 2,
+}
 
 // StellarSetOptionsOp
 export type StellarSetOptionsOp = {
@@ -1861,7 +1881,7 @@ export type StellarSetOptionsOp = {
     medium_threshold?: string | number;
     high_threshold?: string | number;
     home_domain?: string;
-    signer_type?: number;
+    signer_type?: StellarSignerType;
     signer_key?: Buffer | string;
     signer_weight?: number;
 };
@@ -1869,36 +1889,36 @@ export type StellarSetOptionsOp = {
 // StellarChangeTrustOp
 export type StellarChangeTrustOp = {
     source_account?: string;
-    asset?: StellarAssetType;
-    limit?: string | number;
+    asset: StellarAsset;
+    limit: string | number;
 };
 
 // StellarAllowTrustOp
 export type StellarAllowTrustOp = {
     source_account?: string;
-    trusted_account?: string;
-    asset_type?: number;
+    trusted_account: string;
+    asset_type: StellarAssetType;
     asset_code?: string;
-    is_authorized?: number;
+    is_authorized: boolean;
 };
 
 // StellarAccountMergeOp
 export type StellarAccountMergeOp = {
     source_account?: string;
-    destination_account?: string;
+    destination_account: string;
 };
 
 // StellarManageDataOp
 export type StellarManageDataOp = {
     source_account?: string;
-    key?: string;
+    key: string;
     value?: Buffer | string;
 };
 
 // StellarBumpSequenceOp
 export type StellarBumpSequenceOp = {
     source_account?: string;
-    bump_to?: string | number;
+    bump_to: string | number;
 };
 
 // StellarSignedTx


### PR DESCRIPTION
companion PR for https://github.com/trezor/trezor-firmware/pull/1755

to recap:
* `StellarAssetType` is renamed to `StellarAsset`, and the name `StellarAssetType` is reused for an enum.
  * this causes no issue in Connect whatsoever, far as I was able to determine
* many fields are now required. These seem to mostly match what Connect already assumed, with some minor tweaks.
* some fields are now enums
* `timebounds` are now required, and it's an error to not specify them
  * this should be OK from Stellar point of view, as omitting timebounds is _strongly discouraged_. Stellar Account Viewer always specifies timebounds.

I was unable to get the typechecker to pass, so I could use some hints. At this point `flow` doesn't say anything more specific than "exact not matching inexact blabla"