### PR TITLE
feat(ci): beta version check on pr to v8

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -5,15 +5,13 @@ on:
     branches: [v8]
 
 jobs:
-    version_commit_check:
-      name: Check connect version commit message
+    version_beta_check:
+      name: Check if connect version is beta
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v2
         - run: |
-            LAST_COMMIT=$(git log -1 --pretty=%B)
-            VERSION=$(jq -r .version package.json)
-            [[ "$LAST_COMMIT" == "version $VERSION" ]]; if [ $? -eq 0 ]; then echo "Last commit message contains version";   exit 0; else echo "Last commit message DOES NOT contain version" >&2;   exit 1; fi
+            bash ./scripts/ci-check-beta-version.sh
 
     version_bump_check:
       name: Check connect version bump

--- a/scripts/ci-check-beta-version.sh
+++ b/scripts/ci-check-beta-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+VERSION=$(jq -r .version package.json)
+
+[[ "$VERSION" != *"beta"* ]]
+
+if [ $? -eq 0 ]; then
+    echo "Not a beta version, all good."
+    exit 0
+
+else
+    echo "FAIL! package.json contains beta version!" >&2
+
+    exit 1
+fi


### PR DESCRIPTION
A script that will check if a beta suffix is present in connect version on the pull request to v8 branch. Also edits the GitHub workflow to use this script.

Tested the script over on the forked connect repo and it's working as expected. https://github.com/vdovhanych/connect/runs/3609535853?check_suite_focus=true