### PR TITLE
chore(ci): small changes to job separations on v8 branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,8 @@ build:
 # Deploy to testing environment
 deploy test:
   stage: deploy
+  except:
+    - v8
   variables:
     GIT_STRATEGY: none
   when: manual
@@ -63,7 +65,7 @@ rollback production copy:
     refs:
       - v8
   when: manual
-  needs: ["build"]
+  needs: ["verify"]
   variables:
     GIT_STRATEGY: none
   before_script: []
@@ -96,7 +98,7 @@ publish release to npm:
     refs:
       - v8
   when: manual
-  needs: []
+  needs: ["verify"]
   before_script:
     - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
   script:
@@ -111,6 +113,8 @@ publish release to npm:
 
 publish beta release to npm:
   stage: deploy
+  except:
+    - v8
   when: manual
   needs: ["verify"]
   before_script:


### PR DESCRIPTION
Small changes in the giltab-ci file. Beta jobs will no longer be available on v8 pipeline, and I also change what stage the jobs need to run. Specifically, the release to npm will need to verify to finish before it's available.