### PR TITLE
fix: add missing hex param to sign/verify types

### DIFF
--- a/src/js/types/networks/bitcoin.js
+++ b/src/js/types/networks/bitcoin.js
@@ -129,6 +129,7 @@ export type SignMessage = {
     path: string | number[],
     coin: string,
     message: string,
+    hex?: boolean,
 };
 
 export type VerifyMessage = {
@@ -136,6 +137,7 @@ export type VerifyMessage = {
     signature: string,
     message: string,
     coin: string,
+    hex?: boolean,
 };
 
 export type { TxInputType, TxOutputType } from '../trezor/protobuf';

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -125,6 +125,7 @@ export interface SignMessage {
     path: string | number[];
     coin: string;
     message: string;
+    hex?: boolean;
 }
 
 export interface VerifyMessage {
@@ -132,6 +133,7 @@ export interface VerifyMessage {
     signature: string;
     message: string;
     coin: string;
+    hex?: boolean;
 }
 
 export { TxInputType, TxOutputType } from '../trezor/protobuf';


### PR DESCRIPTION
Added missing hex param to Bitcoin's signMessage and verifyMessage methods.