### PR TITLE
fix: cardano tx witness request message as obj

### DIFF
--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -296,7 +296,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             const { message } = await typedCall(
                 'CardanoTxWitnessRequest',
                 'CardanoTxWitnessResponse',
-                path,
+                { path },
             );
             witnesses.push({
                 type: CardanoTxWitnessType[message.type],


### PR DESCRIPTION
I think that

Protobuf 
```
   {
            "name": "CardanoTxWitnessRequest",
            "fields": [
                {
                    "rule": "repeated",
                    "options": {},
                    "type": "uint32",
                    "name": "path",
                    "id": 1
                }
            ],
            "enums": [],
            "messages": [],
            "options": {},
            "oneofs": {}
        },
```

should be sent as 

```
{
 path: [...]
}
```

not as 

```
[...]
```

This message is under tests, so as long as tests pass I think it is safe to merge.