### PR TITLE
feat(cardano): add support for multisig

### DIFF
--- a/.github/workflows/karma.yml
+++ b/.github/workflows/karma.yml
@@ -150,7 +150,7 @@ jobs:
         path: build
     # xvfb is required to run karma 
     - run: sudo apt-get install xvfb
-    - run: xvfb-run --auto-servernum ./tests/run.sh -s 'yarn test:karma:production' -i cardanoGetAddress,cardanoGetPublicKey,cardanoSignTransaction
+    - run: xvfb-run --auto-servernum ./tests/run.sh -s 'yarn test:karma:production' -i cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction
 
   eos:
     needs: check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    - run: ./tests/run.sh -i cardanoGetAddress,cardanoGetPublicKey,cardanoSignTransaction
+    - run: ./tests/run.sh -i cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction
 
   eos:
     needs: check

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,7 +191,7 @@ test stellar:
 test cardano:
   extends: .test
   variables:
-    TESTS_INCLUDED_METHODS: "cardanoGetAddress,cardanoGetPublicKey,cardanoSignTransaction"
+    TESTS_INCLUDED_METHODS: "cardanoGetAddress,cardanoGetNativeScriptHash,cardanoGetPublicKey,cardanoSignTransaction"
 
 test eos:
   extends: .test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 8.2.2 (not released)
 
+### Added
+- Cardano: `getNativeScriptHash` call
+- Cardano: support for 1854 and 1855 key paths
+- Cardano: support for script addresses
+- Cardano: support for token minting and burning
+- Cardano: support for multi-sig transactions using native scripts
+
 ### Changed
 - Updated dependencies.
 - Fixed missing `hex` field in SignMessage and VerifyMessage types.

--- a/docs/methods/cardanoGetAddress.md
+++ b/docs/methods/cardanoGetAddress.md
@@ -26,12 +26,14 @@ TrezorConnect.cardanoGetAddress(params).then(function(result) {
 * `bundle` - `Array` of Objects with single address fields
 
 #### Address Parameters
-###### [flowtype](../../src/js/types/networks/cardano.js#L37-L43)
-* `addressType` - *obligatory* `CardanoAddressType`/`number` - you can use the flow `CARDANO.ADDRESS_TYPE` object or typescript `CardanoAddressType` enum. Supports Base, Pointer, Enterprise, Byron and Reward address types.
+###### [flowtype](../../src/js/types/networks/cardano.js#L37-L45)
+* `addressType` - *obligatory* `CardanoAddressType`/`number` - you can use the flow `CARDANO.ADDRESS_TYPE` object or typescript `CardanoAddressType` enum. Supports all address types.
 * `path` — *obligatory* `string | Array<number>` minimum length is `5`. [read more](path.md)
-* `stakingPath` — *optional* `string | Array<number>` minimum length is `5`. [read more](path.md) Used for base address derivation
+* `stakingPath` — *optional* `string | Array<number>` minimum length is `5`. [read more](path.md) Used for base and reward address derivation
 * `stakingKeyHash` - *optional* `string` hex string of staking key hash. Used for base address derivation (as an alternative to `stakingPath`)
 * `certificatePointer` - *optional* `CardanoCertificatePointer` object. Must contain `number`s `blockIndex`, `txIndex` and `certificateIndex`. ([flowtype](../../src/js/types/networks/cardano.js#L31-L35)) Used for pointer address derivation. [read more about pointer address](https://hydra.iohk.io/build/2006688/download/1/delegation_design_spec.pdf#subsubsection.3.2.2)
+* `paymentScriptHash` - *optional* `string` hex string of payment script hash.
+* `stakingScriptHash` - *optional* `string` hex string of staking script hash.
 
 
 #### Handle button request
@@ -52,7 +54,7 @@ Display byron address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     addressParameters: {
-        addressType: 8,
+        addressType: CardanoAddressType.BYRON,
         path: "m/44'/1815'/0'/0/0",
     },
     protocolMagic: 764824073,
@@ -63,9 +65,45 @@ Display base address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     addressParameters: {
-        addressType: 0,
+        addressType: CardanoAddressType.BASE,
         path: "m/1852'/1815'/0'/0/0",
         stakingPath: "m/1852'/1815'/0'/2/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display base address with script payment part:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.BASE_SCRIPT_KEY,
+        paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+        stakingPath: "m/1852'/1815'/0'/2/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display base address with script staking part:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.BASE_KEY_SCRIPT,
+        path: "m/1852'/1815'/0'/0/0",
+        stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display base address with both payment and staking part being a script:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.BASE_SCRIPT_SCRIPT,
+        paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+        stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
     },
     protocolMagic: 764824073,
     networkId: 1,
@@ -75,8 +113,24 @@ Display pointer address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     addressParameters: {
-        addressType: 4,
+        addressType: CardanoAddressType.POINTER,
         path: "m/1852'/1815'/0'/0/0",
+        certificatePointer: {
+            blockIndex: 1,
+            txIndex: 2,
+            certificateIndex: 3,
+        },
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display pointer script address:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.POINTER_SCRIPT,
+        paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
         certificatePointer: {
             blockIndex: 1,
             txIndex: 2,
@@ -91,8 +145,19 @@ Display enterprise address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     addressParameters: {
-        addressType: 6,
+        addressType: CardanoAddressType.ENTERPRISE,
         path: "m/1852'/1815'/0'/0/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display enterprise script address:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.ENTERPRISE_SCRIPT,
+        paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
     },
     protocolMagic: 764824073,
     networkId: 1,
@@ -102,8 +167,19 @@ Display reward address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     addressParameters: {
-        addressType: 14,
-        path: "m/1852'/1815'/0'/0/0",
+        addressType: CardanoAddressType.REWARD,
+        stakingPath: "m/1852'/1815'/0'/0/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display reward script address:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: CardanoAddressType.REWARD_SCRIPT,
+        stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
     },
     protocolMagic: 764824073,
     networkId: 1,
@@ -183,9 +259,11 @@ Result with only one address
                 blockIndex: number,
                 txIndex: number,
                 certificatePointer: number,
-            }
+            },
+            paymentScriptHash?: string,
+            stakingScriptHash?: string,
         }
-        serializedPath: string,
+        serializedPath?: string,
         serializedStakingPath?: string,
         protocolMagic: number,
         networkId: number,
@@ -208,9 +286,11 @@ Result with bundle of addresses
                     blockIndex: number,
                     txIndex: number,
                     certificatePointer: number,
-                }
+                },
+                paymentScriptHash?: string,
+                stakingScriptHash?: string,
             }
-            serializedPath: string,
+            serializedPath?: string,
             serializedStakingPath?: string,
             protocolMagic: number,
             networkId: number,
@@ -226,9 +306,11 @@ Result with bundle of addresses
                     blockIndex: number,
                     txIndex: number,
                     certificatePointer: number,
-                }
+                },
+                paymentScriptHash?: string,
+                stakingScriptHash?: string,
             }
-            serializedPath: string,
+            serializedPath?: string,
             serializedStakingPath?: string,
             protocolMagic: number,
             networkId: number,
@@ -244,9 +326,11 @@ Result with bundle of addresses
                     blockIndex: number,
                     txIndex: number,
                     certificatePointer: number,
-                }
+                },
+                paymentScriptHash?: string,
+                stakingScriptHash?: string,
             }
-            serializedPath: string,
+            serializedPath?: string,
             serializedStakingPath?: string,
             protocolMagic: number,
             networkId: number,

--- a/docs/methods/cardanoGetNativeScriptHash.md
+++ b/docs/methods/cardanoGetNativeScriptHash.md
@@ -1,0 +1,122 @@
+## Cardano: get native script hash
+Display native script components on Trezor, display the calculated native script hash and return the hash to the caller.
+
+ES6
+```javascript
+const result = await TrezorConnect.cardanoGetNativeScriptHash(params);
+```
+
+CommonJS
+```javascript
+TrezorConnect.cardanoGetNativeScriptHash(params).then(function(result) {
+
+});
+```
+
+### Params
+[****Optional common params****](commonParams.md)
+##### [flowtype](../../src/js/types/networks/cardano.js#L76-L79)
+* `script` — *obligatory* `CardanoNativeScript` see description below.
+* `displayFormat` — *obligatory* `CardanoNativeScriptHashDisplayFormat` enum.
+
+#### CardanoNativeScript
+###### [flowtype](../../src/js/types/networks/cardano.js#L66-74)
+* `type` - *obligatory* `CardanoNativeScriptType`/`number`.
+* `scripts` — *optional* `Array` of nested `CardanoNativeScript`s.
+* `keyHash` — *optional* `string` hex string of key hash. Used for `CardanoScriptType.PUB_KEY`.
+* `keyPath` - *optional* `string | Array<number>` minimum length is `3`. Used for `CardanoScriptType.PUB_KEY`.
+* `requiredSignaturesCount` - *optional* `string` used for `CardanoScriptType.N_OF_K`.
+* `invalidBefore` - *optional* `string` used for `CardanoScriptType.INVALID_BEFORE`.
+* `invalidHereafter` - *optional* `string` used for `CardanoScriptType.INVALID_HEREAFTER`.
+
+
+### Example
+Get native script hash of a simple PUB_KEY script:
+```javascript
+TrezorConnect.cardanoGetNativeScriptHash({
+    script: {
+        type: CardanoNativeScriptType.PUB_KEY,
+        keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+    },
+    displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+});
+```
+Get native script hash of a nested script:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    script: {
+        type: CardanoNativeScriptType.ALL,
+        scripts: [
+            {
+                type: CardanoNativeScriptType.PUB_KEY,
+                keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+            },
+            {
+                type: CardanoNativeScriptType.PUB_KEY,
+                keyPath: "m/1854'/1815'/0'/0/0",
+            },
+            {
+                type: CardanoNativeScriptType.ANY,
+                scripts: [
+                    {
+                        type: CardanoNativeScriptType.PUB_KEY,
+                        keyPath: "m/1854'/1815'/0'/0/0",
+                    },
+                    {
+                        type: CardanoNativeScriptType.PUB_KEY,
+                        keyHash:
+                            '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                    },
+                ],
+            },
+            {
+                type: CardanoNativeScriptType.N_OF_K,
+                requiredSignaturesCount: 2,
+                scripts: [
+                    {
+                        type: CardanoNativeScriptType.PUB_KEY,
+                        keyPath: "m/1854'/1815'/0'/0/0",
+                    },
+                    {
+                        type: CardanoNativeScriptType.PUB_KEY,
+                        keyHash:
+                            '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                    },
+                    {
+                        type: CardanoNativeScriptType.PUB_KEY,
+                        keyHash:
+                            'cecb1d427c4ae436d28cc0f8ae9bb37501a5b77bcc64cd1693e9ae20',
+                    },
+                ],
+            },
+            {
+                type: CardanoNativeScriptType.INVALID_BEFORE,
+                invalidBefore: '100',
+            },
+            {
+                type: CardanoNativeScriptType.INVALID_HEREAFTER,
+                invalidHereafter: '200',
+            },
+        ],
+    },
+    displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+});
+```
+### Result
+```javascript
+{
+    success: true,
+    payload: {
+        scriptHash: 'b12ac304f89f4cd4d23f59a2b90d2b2697f7540b8f470d6aa05851b5',
+    }
+}
+```
+Error
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -15,33 +15,37 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 });
 ```
 
-### Params 
+### Params
 [****Optional common params****](commonParams.md)
-###### [flowtype](../../src/js/types/networks/cardano.js#L60-L179)
+###### [flowtype](../../src/js/types/networks/cardano.js#L87-L211)
 * `signingMode` - *obligatory* [CardanoTxSigningMode](#CardanoTxSigningMode)
-* `inputs` - *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L62)
-* `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L77)
+* `inputs` - *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L87)
+* `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L103)
 * `fee` - *obligatory* `String`
 * `protocolMagic` - *obligatory* `Integer` 764824073 for Mainnet, 42 for Testnet
 * `networkId` - *obligatory* `Integer` 1 for Mainnet, 0 for Testnet
 * `ttl` - *optional* `String`
 * `validityIntervalStart` - *optional* `String`
-* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L124)
-* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L131)
-* `auixiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#143)
+* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L150)
+* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L158)
+* `auxiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#L173)
+* `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L164)
+* `additionalWitnessRequests` - *optional* `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 * `metadata` - *removed* - use `auxiliaryData` instead
 
 ### CardanoTxSigningMode
 
-[Type definition](../../src/js/types/trezor/protobuf.js#L78)
+[Type definition](../../src/js/types/trezor/protobuf.js#L98)
 
 #### `ORDINARY_TRANSACTION`
 
-Represents an ordinary user transaction transferring funds.
+Represents an ordinary user transaction transferring funds, delegating stake or withdrawing rewards. The transaction will be witnessed by keys derived from paths included in the inputs, certificates and withdrawals. Additionaly, if token minting is present, transaction will also be witnessed by keys derived from paths included in `additionalWitnessRequests`.
 
 The transaction
 - *should* have valid `path` property on all `inputs`
 - *must not* contain a pool registration certificate
+- *may* contain only 1852 and 1855 paths
+- *must not* contain 1855 witness requests when transaction is not minting/burning tokens
 
 #### `POOL_REGISTRATION_AS_OWNER`
 Represents pool registration from the perspective of pool owner.
@@ -50,9 +54,22 @@ The transaction
 - *must* have `path` undefined on all `inputs` (i.e., we are not witnessing any UTxO)
 - *must* have single Pool registration certificate
 - *must* have single owner given by path on that certificate
-- *must not* have withdrawals
+- *must not* contain withdrawals
+- *must not* contain token minting
+- *must* contain only staking witness requests
 
 These restrictions are in place due to a possibility of maliciously signing *another* part of the transaction with the pool owner path as we are not displaying device-owned paths on the device screen.
+
+#### `MULTISIG_TRANSACTION`
+Represents a multi-sig transaction using native scripts. The transaction will only be signed by keys derived from paths included in `additionalWitnessRequests`.
+
+The transaction
+- *must* have `path` undefined on all `inputs`
+- *must not* contain output addresses given by parameters
+- *must not* contain a pool registration certificate
+- *must* contain script hash stake credentials in certificates and withdrawals (no paths)
+- *may* contain only 1854 and 1855 witness requests
+- *must not* contain 1855 witness requests when transaction is not minting/burning tokens
 
 ### Stake pool registration certificate specifics
 
@@ -96,7 +113,7 @@ TrezorConnect.cardanoSignTransaction({
             tokenBundle: [
                 {
                     policyId: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
-                    tokens: [
+                    tokenAmounts: [
                         {
                             assetNameBytes: "74652474436f696e",
                             amount: "7878754"
@@ -247,6 +264,80 @@ TrezorConnect.cardanoSignTransaction({
             nonce: "22634813",
         },
     },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+
+#### Multisig transaction
+```javascript
+TrezorConnect.cardanoSignTransaction({
+    signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+    inputs: [
+        {
+            prev_hash: "1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc",
+            prev_index: 0,
+        }
+    ],
+    outputs: [
+        {
+            address: "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
+            amount: "3003112",
+        },
+        {
+            address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+            amount: '2000000',
+            tokenBundle: [
+                {
+                    policyId: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+                    tokens: [
+                        {
+                            assetNameBytes: "74652474436f696e",
+                            amount: "7878754"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    fee: "42",
+    ttl: "10",
+    validityIntervalStart: "20",
+    certificates: [
+        {
+            type: CardanoCertificateType.STAKE_REGISTRATION,
+            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+        },
+        {
+            type: CardanoCertificateType.STAKE_DEREGISTRATION,
+            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+        },
+        {
+            type: CardanoCertificateType.STAKE_DELEGATION,
+            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            pool: 'f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973',
+        },
+    ],
+    withdrawals: [
+        {
+            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            amount: '1000',
+        }
+    ],
+    auxiliaryData: {
+        hash: "ea4c91860dd5ec5449f8f985d227946ff39086b17f10b5afb93d12ee87050b6a"
+    },
+    mint: [
+        {
+            policyId: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+            tokenAmounts: [
+                {
+                    assetNameBytes: "74652474436f696e",
+                    mintAmount: "7878754"
+                }
+            ]
+        }
+    ],
     protocolMagic: 764824073,
     networkId: 1,
 });

--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -12,6 +12,7 @@ const RULE_PATCH = {
     'CardanoTxCertificate.path': 'optional',
     'CardanoTxInputType.address_n': 'optional',
     'CardanoTxWithdrawal.path': 'optional',
+    'CardanoNativeScript.scripts': 'optional',
     'CardanoNativeScript.key_path': 'optional',
     'Success.message': 'required', // didn't find use case where it's not sent
     'SignedIdentity.address': 'required',
@@ -124,6 +125,8 @@ const TYPE_PATCH = {
     'CardanoToken.mint_amount': 'string | number',
     'CardanoTxOutputType.amount': 'string | number',
     'CardanoTxOutput.amount': 'string | number',
+    'CardanoNativeScript.invalid_before': 'string | number',
+    'CardanoNativeScript.invalid_hereafter': 'string | number',
     'EosAsset.amount': 'string',
     'EosAsset.symbol': 'string',
     'EosPermissionLevel.actor': 'string',

--- a/scripts/protobuf-patches.js
+++ b/scripts/protobuf-patches.js
@@ -11,6 +11,8 @@ const RULE_PATCH = {
     'CardanoTxCertificateType.path': 'optional',
     'CardanoTxCertificate.path': 'optional',
     'CardanoTxInputType.address_n': 'optional',
+    'CardanoTxWithdrawal.path': 'optional',
+    'CardanoNativeScript.key_path': 'optional',
     'Success.message': 'required', // didn't find use case where it's not sent
     'SignedIdentity.address': 'required',
     'EosAuthorizationKey.key': 'required', // its valid to be undefined according to implementation/tests
@@ -119,6 +121,7 @@ const TYPE_PATCH = {
     'CardanoSignTxInit.validity_interval_start': 'string | number',
     'CardanoTokenType.amount': 'string | number',
     'CardanoToken.amount': 'string | number',
+    'CardanoToken.mint_amount': 'string | number',
     'CardanoTxOutputType.amount': 'string | number',
     'CardanoTxOutput.amount': 'string | number',
     'EosAsset.amount': 'string',

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -129,6 +129,13 @@
         },
         {
             "methods": [
+                "cardanoGetNativeScriptHash"
+            ],
+            "min": ["0", "2.4.3"],
+            "comment": ["Cardano GetNativeScriptHash call added in 2.4.3"]
+        },
+        {
+            "methods": [
                 "tezosSignTransaction"
             ],
             "min": ["0", "2.1.8"],

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -11261,7 +11261,7 @@
                     "id": 1
                 },
                 {
-                    "name": "SCRIPT_TRANSACTION",
+                    "name": "MULTISIG_TRANSACTION",
                     "id": 2
                 }
             ],

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -2228,12 +2228,10 @@
                     "id": 1
                 },
                 {
-                    "rule": "optional",
-                    "options": {
-                        "default": false
-                    },
-                    "type": "bool",
-                    "name": "show_display",
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoNativeScriptHashDisplayFormat",
+                    "name": "display_format",
                     "id": 2
                 }
             ],
@@ -11175,6 +11173,24 @@
                 {
                     "name": "INVALID_HEREAFTER",
                     "id": 5
+                }
+            ],
+            "options": {}
+        },
+        {
+            "name": "CardanoNativeScriptHashDisplayFormat",
+            "values": [
+                {
+                    "name": "HIDE",
+                    "id": 0
+                },
+                {
+                    "name": "BECH32",
+                    "id": 1
+                },
+                {
+                    "name": "POLICY_ID",
+                    "id": 2
                 }
             ],
             "options": {}

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -2160,6 +2160,105 @@
             "oneofs": {}
         },
         {
+            "name": "CardanoNativeScript",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoNativeScriptType",
+                    "name": "type",
+                    "id": 1
+                },
+                {
+                    "rule": "repeated",
+                    "options": {},
+                    "type": "CardanoNativeScript",
+                    "name": "scripts",
+                    "id": 2
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "key_hash",
+                    "id": 3
+                },
+                {
+                    "rule": "repeated",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "key_path",
+                    "id": 4
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "required_signatures_count",
+                    "id": 5
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint64",
+                    "name": "invalid_before",
+                    "id": 6
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint64",
+                    "name": "invalid_hereafter",
+                    "id": 7
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "CardanoGetNativeScriptHash",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoNativeScript",
+                    "name": "script",
+                    "id": 1
+                },
+                {
+                    "rule": "optional",
+                    "options": {
+                        "default": false
+                    },
+                    "type": "bool",
+                    "name": "show_display",
+                    "id": 2
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "CardanoNativeScriptHash",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_hash",
+                    "id": 1
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
             "name": "CardanoAddressParametersType",
             "fields": [
                 {
@@ -2196,6 +2295,20 @@
                     "type": "CardanoBlockchainPointerType",
                     "name": "certificate_pointer",
                     "id": 5
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_payment_hash",
+                    "id": 6
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_staking_hash",
+                    "id": 7
                 }
             ],
             "enums": [],
@@ -2390,6 +2503,13 @@
                     "type": "uint32",
                     "name": "witness_requests_count",
                     "id": 12
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "minting_asset_groups_count",
+                    "id": 13
                 }
             ],
             "enums": [],
@@ -2491,11 +2611,18 @@
                     "id": 1
                 },
                 {
-                    "rule": "required",
+                    "rule": "optional",
                     "options": {},
                     "type": "uint64",
                     "name": "amount",
                     "id": 2
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "sint64",
+                    "name": "mint_amount",
+                    "id": 3
                 }
             ],
             "enums": [],
@@ -2720,6 +2847,13 @@
                     "type": "CardanoPoolParametersType",
                     "name": "pool_parameters",
                     "id": 4
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_hash",
+                    "id": 5
                 }
             ],
             "enums": [],
@@ -2743,6 +2877,13 @@
                     "type": "uint64",
                     "name": "amount",
                     "id": 2
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_hash",
+                    "id": 3
                 }
             ],
             "enums": [],
@@ -2803,6 +2944,22 @@
                     "type": "bytes",
                     "name": "hash",
                     "id": 2
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "CardanoTxMint",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "asset_groups_count",
+                    "id": 1
                 }
             ],
             "enums": [],
@@ -10993,6 +11150,36 @@
             "options": {}
         },
         {
+            "name": "CardanoNativeScriptType",
+            "values": [
+                {
+                    "name": "PUB_KEY",
+                    "id": 0
+                },
+                {
+                    "name": "ALL",
+                    "id": 1
+                },
+                {
+                    "name": "ANY",
+                    "id": 2
+                },
+                {
+                    "name": "N_OF_K",
+                    "id": 3
+                },
+                {
+                    "name": "INVALID_BEFORE",
+                    "id": 4
+                },
+                {
+                    "name": "INVALID_HEREAFTER",
+                    "id": 5
+                }
+            ],
+            "options": {}
+        },
+        {
             "name": "CardanoCertificateType",
             "values": [
                 {
@@ -11056,6 +11243,10 @@
                 {
                     "name": "POOL_REGISTRATION_AS_OWNER",
                     "id": 1
+                },
+                {
+                    "name": "SCRIPT_TRANSACTION",
+                    "id": 2
                 }
             ],
             "options": {}
@@ -11700,6 +11891,18 @@
                 {
                     "name": "MessageType_CardanoPoolRelayParameters",
                     "id": 329
+                },
+                {
+                    "name": "MessageType_CardanoGetNativeScriptHash",
+                    "id": 330
+                },
+                {
+                    "name": "MessageType_CardanoNativeScriptHash",
+                    "id": 331
+                },
+                {
+                    "name": "MessageType_CardanoTxMint",
+                    "id": 332
                 },
                 {
                     "name": "MessageType_RippleGetAddress",

--- a/src/js/core/methods/CardanoGetNativeScriptHash.js
+++ b/src/js/core/methods/CardanoGetNativeScriptHash.js
@@ -1,0 +1,99 @@
+/* @flow */
+
+import AbstractMethod from './AbstractMethod';
+import { getFirmwareRange, validateParams } from './helpers/paramsValidator';
+import { getMiscNetwork } from '../../data/CoinInfo';
+import { validatePath } from '../../utils/pathUtils';
+
+import type { CoreMessage } from '../../types';
+import type { CardanoNativeScript } from '../../types/networks/cardano';
+import type {
+    CardanoGetNativeScriptHash as CardanoGetNativeScriptHashProto,
+    CardanoNativeScript as CardanoNativeScriptProto,
+} from '../../types/trezor/protobuf';
+
+type Params = CardanoGetNativeScriptHashProto;
+
+export default class CardanoGetNativeScriptHash extends AbstractMethod {
+    params: Params;
+
+    constructor(message: CoreMessage) {
+        super(message);
+
+        this.requiredPermissions = ['read'];
+        this.firmwareRange = getFirmwareRange(
+            this.name,
+            getMiscNetwork('Cardano'),
+            this.firmwareRange,
+        );
+        this.info = 'Get Cardano native script hash';
+
+        const { payload } = message;
+
+        validateParams(payload, [
+            { name: 'script', type: 'object', obligatory: true },
+            { name: 'displayFormat', type: 'number', obligatory: true },
+        ]);
+
+        this.validateScript(payload.script);
+
+        this.params = {
+            script: this.scriptToProto(payload.script),
+            display_format: payload.displayFormat,
+        };
+    }
+
+    validateScript(script: CardanoNativeScript) {
+        validateParams(script, [
+            { name: 'type', type: 'number', obligatory: true },
+            { name: 'scripts', type: 'array', allowEmpty: true },
+            { name: 'keyHash', type: 'string' },
+            { name: 'requiredSignaturesCount', type: 'number' },
+            { name: 'invalidBefore', type: 'amount' },
+            { name: 'invalidHereafter', type: 'amount' },
+        ]);
+
+        if (script.keyPath) {
+            validatePath(script.keyPath, 3);
+        }
+
+        if (script.scripts) {
+            script.scripts.forEach(nestedScript => {
+                this.validateScript(nestedScript);
+            });
+        }
+    }
+
+    scriptToProto(script: CardanoNativeScript): CardanoNativeScriptProto {
+        let scripts = [];
+        if (script.scripts) {
+            scripts = script.scripts.map(nestedScript => this.scriptToProto(nestedScript));
+        }
+        let keyPath = [];
+        if (script.keyPath) {
+            keyPath = validatePath(script.keyPath, 3);
+        }
+        return {
+            type: script.type,
+            scripts,
+            key_hash: script.keyHash,
+            key_path: keyPath,
+            required_signatures_count: script.requiredSignaturesCount,
+            invalid_before: script.invalidBefore,
+            invalid_hereafter: script.invalidHereafter,
+        };
+    }
+
+    async run() {
+        const { message } = await this.device
+            .getCommands()
+            .typedCall('CardanoGetNativeScriptHash', 'CardanoNativeScriptHash', {
+                script: this.params.script,
+                display_format: this.params.display_format,
+            });
+
+        return {
+            scriptHash: message.script_hash,
+        };
+    }
+}

--- a/src/js/core/methods/helpers/cardanoAddressParameters.js
+++ b/src/js/core/methods/helpers/cardanoAddressParameters.js
@@ -8,11 +8,14 @@ import type { CardanoAddressParameters } from '../../../types/networks/cardano';
 export const validateAddressParameters = (addressParameters: CardanoAddressParameters) => {
     validateParams(addressParameters, [
         { name: 'addressType', type: 'number', obligatory: true },
-        { name: 'path', obligatory: true },
         { name: 'stakingKeyHash', type: 'string' },
+        { name: 'paymentScriptHash', type: 'string' },
+        { name: 'stakingScriptHash', type: 'string' },
     ]);
 
-    validatePath(addressParameters.path);
+    if (addressParameters.path) {
+        validatePath(addressParameters.path);
+    }
     if (addressParameters.stakingPath) {
         validatePath(addressParameters.stakingPath);
     }
@@ -29,7 +32,10 @@ export const validateAddressParameters = (addressParameters: CardanoAddressParam
 export const addressParametersToProto = (
     addressParameters: CardanoAddressParameters,
 ): CardanoAddressParametersType => {
-    const path = validatePath(addressParameters.path, 3);
+    let path = [];
+    if (addressParameters.path) {
+        path = validatePath(addressParameters.path, 3);
+    }
 
     let stakingPath = [];
     if (addressParameters.stakingPath) {
@@ -51,6 +57,8 @@ export const addressParametersToProto = (
         address_n_staking: stakingPath,
         staking_key_hash: addressParameters.stakingKeyHash,
         certificate_pointer: certificatePointer,
+        script_payment_hash: addressParameters.paymentScriptHash,
+        script_staking_hash: addressParameters.stakingScriptHash,
     };
 };
 

--- a/src/js/core/methods/helpers/cardanoCertificate.js
+++ b/src/js/core/methods/helpers/cardanoCertificate.js
@@ -183,7 +183,7 @@ export const transformCertificate = (
     const paramsToValidate = [{ name: 'type', type: 'number', obligatory: true }];
 
     if (certificate.type !== CardanoCertificateType.STAKE_POOL_REGISTRATION) {
-        paramsToValidate.push({ name: 'path', obligatory: true });
+        paramsToValidate.push({ name: 'scriptHash', type: 'string' });
     }
 
     if (certificate.type === CardanoCertificateType.STAKE_DELEGATION) {
@@ -204,6 +204,7 @@ export const transformCertificate = (
         certificate: {
             type: certificate.type,
             path: certificate.path ? validatePath(certificate.path, 5) : undefined,
+            script_hash: certificate.scriptHash,
             pool: certificate.pool,
             pool_parameters: poolParameters,
         },

--- a/src/js/core/methods/helpers/cardanoOutputs.js
+++ b/src/js/core/methods/helpers/cardanoOutputs.js
@@ -1,54 +1,15 @@
 /* @flow */
 import { validateParams } from './paramsValidator';
 
-import type {
-    CardanoToken as CardanoTokenProto,
-    CardanoTxOutput,
-} from '../../../types/trezor/protobuf';
-import type { CardanoAssetGroup, CardanoToken } from '../../../types/networks/cardano';
+import type { CardanoTxOutput } from '../../../types/trezor/protobuf';
 import { addressParametersToProto, validateAddressParameters } from './cardanoAddressParameters';
-
-type AssetGroupWithTokens = {
-    policyId: string,
-    tokens: CardanoTokenProto[],
-};
+import type { AssetGroupWithTokens } from './cardanoTokenBundle';
+import { tokenBundleToProto, validateTokenBundle } from './cardanoTokenBundle';
 
 export type OutputWithTokens = {
     output: CardanoTxOutput,
     tokenBundle?: AssetGroupWithTokens[],
 };
-
-const validateTokens = (tokenAmounts: CardanoToken[]) => {
-    tokenAmounts.forEach(tokenAmount => {
-        validateParams(tokenAmount, [
-            { name: 'assetNameBytes', type: 'string', obligatory: true },
-            { name: 'amount', type: 'amount', obligatory: true },
-        ]);
-    });
-};
-
-const validateTokenBundle = (tokenBundle: CardanoAssetGroup[]) => {
-    tokenBundle.forEach(tokenGroup => {
-        validateParams(tokenGroup, [
-            { name: 'policyId', type: 'string', obligatory: true },
-            { name: 'tokenAmounts', type: 'array', obligatory: true },
-        ]);
-
-        validateTokens(tokenGroup.tokenAmounts);
-    });
-};
-
-const tokenAmountsToProto = (tokenAmounts: CardanoToken[]): CardanoTokenProto[] =>
-    tokenAmounts.map(tokenAmount => ({
-        asset_name_bytes: tokenAmount.assetNameBytes,
-        amount: tokenAmount.amount,
-    }));
-
-const tokenBundleToProto = (tokenBundle: CardanoAssetGroup[]): AssetGroupWithTokens[] =>
-    tokenBundle.map(tokenGroup => ({
-        policyId: tokenGroup.policyId,
-        tokens: tokenAmountsToProto(tokenGroup.tokenAmounts),
-    }));
 
 export const transformOutput = (output: any) => {
     validateParams(output, [

--- a/src/js/core/methods/helpers/cardanoTokenBundle.js
+++ b/src/js/core/methods/helpers/cardanoTokenBundle.js
@@ -1,0 +1,44 @@
+/* @flow */
+import { validateParams } from './paramsValidator';
+
+import type { CardanoToken as CardanoTokenProto } from '../../../types/trezor/protobuf';
+import type { CardanoAssetGroup, CardanoToken } from '../../../types/networks/cardano';
+
+export type AssetGroupWithTokens = {
+    policyId: string,
+    tokens: CardanoTokenProto[],
+};
+
+const validateTokens = (tokenAmounts: CardanoToken[]) => {
+    tokenAmounts.forEach(tokenAmount => {
+        validateParams(tokenAmount, [
+            { name: 'assetNameBytes', type: 'string', obligatory: true },
+            { name: 'amount', type: 'amount' },
+            { name: 'mintAmount', type: 'amount' },
+        ]);
+    });
+};
+
+export const validateTokenBundle = (tokenBundle: CardanoAssetGroup[]) => {
+    tokenBundle.forEach(tokenGroup => {
+        validateParams(tokenGroup, [
+            { name: 'policyId', type: 'string', obligatory: true },
+            { name: 'tokenAmounts', type: 'array', obligatory: true },
+        ]);
+
+        validateTokens(tokenGroup.tokenAmounts);
+    });
+};
+
+const tokenAmountsToProto = (tokenAmounts: CardanoToken[]): CardanoTokenProto[] =>
+    tokenAmounts.map(tokenAmount => ({
+        asset_name_bytes: tokenAmount.assetNameBytes,
+        amount: tokenAmount.amount,
+        mint_amount: tokenAmount.mintAmount,
+    }));
+
+export const tokenBundleToProto = (tokenBundle: CardanoAssetGroup[]): AssetGroupWithTokens[] =>
+    tokenBundle.map(tokenGroup => ({
+        policyId: tokenGroup.policyId,
+        tokens: tokenAmountsToProto(tokenGroup.tokenAmounts),
+    }));

--- a/src/js/core/methods/helpers/cardanoWitnesses.js
+++ b/src/js/core/methods/helpers/cardanoWitnesses.js
@@ -1,13 +1,18 @@
 /* @flow */
 import type { CertificateWithPoolOwnersAndRelays } from './cardanoCertificate';
 import type { InputWithPath, Path } from '../CardanoSignTransaction';
-import { Enum_CardanoCertificateType as CardanoCertificateType } from '../../../types/trezor/protobuf';
-import type { CardanoTxWithdrawal } from '../../../types/trezor/protobuf';
+import {
+    Enum_CardanoCertificateType as CardanoCertificateType,
+    Enum_CardanoTxSigningMode as CardanoTxSigningModeEnum,
+} from '../../../types/trezor/protobuf';
+import type { CardanoTxSigningMode, CardanoTxWithdrawal } from '../../../types/trezor/protobuf';
 
 export const gatherWitnessPaths = (
     inputsWithPath: InputWithPath[],
     certificatesWithPoolOwnersAndRelays: CertificateWithPoolOwnersAndRelays[],
     withdrawals: CardanoTxWithdrawal[],
+    additionalWitnessRequests: Path[],
+    signingMode: CardanoTxSigningMode,
 ): Path[] => {
     const witnessPaths = new Map<string, Path>();
     function _insert(path: Path) {
@@ -15,26 +20,36 @@ export const gatherWitnessPaths = (
         witnessPaths.set(pathKey, path);
     }
 
-    inputsWithPath.forEach(({ path }) => {
-        if (path) _insert(path);
-    });
+    if (signingMode !== CardanoTxSigningModeEnum.MULTISIG_TRANSACTION) {
+        inputsWithPath.forEach(({ path }) => {
+            if (path) _insert(path);
+        });
 
-    certificatesWithPoolOwnersAndRelays.forEach(({ certificate, poolOwners }) => {
-        if (
-            certificate.path &&
-            (certificate.type === CardanoCertificateType.STAKE_DELEGATION ||
-                certificate.type === CardanoCertificateType.STAKE_DEREGISTRATION)
-        ) {
-            _insert(certificate.path);
-        }
-        poolOwners.forEach(poolOwner => {
-            if (poolOwner.staking_key_path) {
-                _insert(poolOwner.staking_key_path);
+        certificatesWithPoolOwnersAndRelays.forEach(({ certificate, poolOwners }) => {
+            if (
+                certificate.path &&
+                (certificate.type === CardanoCertificateType.STAKE_DELEGATION ||
+                    certificate.type === CardanoCertificateType.STAKE_DEREGISTRATION)
+            ) {
+                _insert(certificate.path);
+            }
+            poolOwners.forEach(poolOwner => {
+                if (poolOwner.staking_key_path) {
+                    _insert(poolOwner.staking_key_path);
+                }
+            });
+        });
+
+        withdrawals.forEach(({ path }) => {
+            if (path) {
+                _insert(path);
             }
         });
-    });
+    }
 
-    withdrawals.forEach(({ path }) => _insert(path));
+    additionalWitnessRequests.forEach(path => {
+        _insert(path);
+    });
 
     return Array.from(witnessPaths.values());
 };

--- a/src/js/core/methods/index.js
+++ b/src/js/core/methods/index.js
@@ -17,6 +17,7 @@ import blockchainSubscribeFiatRates from './blockchain/BlockchainSubscribeFiatRa
 import blockchainUnsubscribe from './blockchain/BlockchainUnsubscribe';
 import blockchainUnsubscribeFiatRates from './blockchain/BlockchainUnsubscribeFiatRates';
 import cardanoGetAddress from './CardanoGetAddress';
+import cardanoGetNativeScriptHash from './CardanoGetNativeScriptHash';
 import cardanoGetPublicKey from './CardanoGetPublicKey';
 import cardanoSignTransaction from './CardanoSignTransaction';
 import cipherKeyValue from './CipherKeyValue';
@@ -80,6 +81,7 @@ const METHODS = {
     blockchainUnsubscribe,
     blockchainUnsubscribeFiatRates,
     cardanoGetAddress,
+    cardanoGetNativeScriptHash,
     cardanoGetPublicKey,
     cardanoSignTransaction,
     cipherKeyValue,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -73,6 +73,8 @@ const TrezorConnect: API = {
         return call({ method: 'cardanoGetAddress', ...params, useEventListener });
     },
 
+    cardanoGetNativeScriptHash: params => call({ method: 'cardanoGetNativeScriptHash', ...params }),
+
     cardanoGetPublicKey: params => call({ method: 'cardanoGetPublicKey', ...params }),
 
     cardanoSignTransaction: params => call({ method: 'cardanoSignTransaction', ...params }),

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -1,11 +1,19 @@
 /* @flow */
 import TrezorConnect from '../../index';
+import {
+    CardanoAddressType,
+    CardanoCertificateType,
+    CardanoNativeScriptHashDisplayFormat,
+    CardanoNativeScriptType,
+    CardanoPoolRelayType,
+    CardanoTxSigningMode,
+} from '../networks/cardano';
 
 export const cardanoGetAddress = async () => {
     // regular
     const singleAddress = await TrezorConnect.cardanoGetAddress({
         addressParameters: {
-            addressType: 0,
+            addressType: CardanoAddressType.BASE,
             path: 'm/44',
             stakingPath: 'm/44',
             stakingKeyHash: 'aaff00..',
@@ -48,7 +56,7 @@ export const cardanoGetAddress = async () => {
         bundle: [
             {
                 addressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.BASE,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -102,7 +110,7 @@ export const cardanoGetAddress = async () => {
         keepSession: false,
         skipFinalReload: false,
         addressParameters: {
-            addressType: 0,
+            addressType: CardanoAddressType.BASE,
             path: 'm/44',
             stakingPath: 'm/44',
             stakingKeyHash: 'aaff00..',
@@ -123,7 +131,7 @@ export const cardanoGetAddress = async () => {
     // $FlowExpectedError: payload is Address
     const e1 = await TrezorConnect.cardanoGetAddress({
         addressParameters: {
-            addressType: 0,
+            addressType: CardanoAddressType.BASE,
             path: 'm/44',
             stakingPath: 'm/44',
         },
@@ -139,7 +147,7 @@ export const cardanoGetAddress = async () => {
         bundle: [
             {
                 addressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.BASE,
                     path: 'm/44',
                     stakingPath: 'm/44',
                 },
@@ -164,10 +172,10 @@ export const cardanoGetAddress = async () => {
 export const cardanoGetNativeScriptHash = async () => {
     const result = await TrezorConnect.cardanoGetNativeScriptHash({
         script: {
-            type: 0,
+            type: CardanoNativeScriptType.PUB_KEY,
             scripts: [
                 {
-                    type: 0,
+                    type: CardanoNativeScriptType.PUB_KEY,
                     scripts: [],
                     keyHash: '00aaff...',
                     keyPath: 'm/44',
@@ -182,7 +190,7 @@ export const cardanoGetNativeScriptHash = async () => {
             invalidBefore: '0',
             invalidHereafter: '0',
         },
-        displayFormat: 0,
+        displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
     });
 
     (result.success: boolean);
@@ -255,7 +263,7 @@ export const cardanoSignTransaction = async () => {
             },
             {
                 addressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.BASE,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -276,7 +284,7 @@ export const cardanoSignTransaction = async () => {
         ],
         certificates: [
             {
-                type: 0,
+                type: CardanoCertificateType.STAKE_REGISTRATION,
                 path: 'm/44',
                 pool: 'aaff00..',
                 poolParameters: {
@@ -300,7 +308,7 @@ export const cardanoSignTransaction = async () => {
                     ],
                     relays: [
                         {
-                            type: 0,
+                            type: CardanoPoolRelayType.SINGLE_HOST_IP,
                             ipv4Address: '192.168.0.1',
                             ipv6Address: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
                             port: 1234,
@@ -328,7 +336,7 @@ export const cardanoSignTransaction = async () => {
                 votingPublicKey: 'aaff00..',
                 stakingPath: 'm/44',
                 rewardAddressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.REWARD,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -347,7 +355,7 @@ export const cardanoSignTransaction = async () => {
         validityIntervalStart: '20',
         protocolMagic: 0,
         networkId: 0,
-        signingMode: 0,
+        signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
     });
 
     if (sign.success) {

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -312,9 +312,16 @@ export const cardanoSignTransaction = async () => {
                         hash: 'aaff00..',
                     },
                 },
+                scriptHash: 'aaff00..',
             },
         ],
-        withdrawals: [{ path: 'm/44', amount: '3003112' }],
+        withdrawals: [{ path: 'm/44', amount: '3003112', scriptHash: 'aaff00..' }],
+        mint: [
+            {
+                policyId: 'aaff00..',
+                tokenAmounts: [{ assetNameBytes: 'aaff00..', mintAmount: '-3003112' }],
+            },
+        ],
         auxiliaryData: {
             hash: 'aaff00..',
             catalystRegistrationParameters: {
@@ -334,6 +341,7 @@ export const cardanoSignTransaction = async () => {
                 nonce: '0',
             },
         },
+        additionalWitnessRequests: ['m/44'],
         fee: '42',
         ttl: '10',
         validityIntervalStart: '20',

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -14,6 +14,8 @@ export const cardanoGetAddress = async () => {
                 txIndex: 1,
                 certificateIndex: 2,
             },
+            paymentScriptHash: 'aaff00..',
+            stakingScriptHash: 'aaff00..',
         },
         protocolMagic: 0,
         networkId: 0,
@@ -28,7 +30,7 @@ export const cardanoGetAddress = async () => {
         (payload.serializedStakingPath: string);
         const { addressParameters } = payload;
         (addressParameters.addressType: number);
-        (addressParameters.path: string | number[]);
+        (addressParameters.path: ?string | ?(number[]));
         (addressParameters.stakingPath: ?string | ?(number[]));
         (addressParameters.stakingKeyHash: ?string);
         const { certificatePointer } = addressParameters;
@@ -37,6 +39,8 @@ export const cardanoGetAddress = async () => {
             (certificatePointer.txIndex: ?number);
             (certificatePointer.certificateIndex: ?number);
         }
+        (addressParameters.paymentScriptHash: ?string);
+        (addressParameters.stakingScriptHash: ?string);
     }
 
     // bundle
@@ -53,6 +57,8 @@ export const cardanoGetAddress = async () => {
                         txIndex: 1,
                         certificateIndex: 2,
                     },
+                    paymentScriptHash: 'aaff00..',
+                    stakingScriptHash: 'aaff00..',
                 },
                 protocolMagic: 0,
                 networkId: 0,
@@ -69,14 +75,16 @@ export const cardanoGetAddress = async () => {
             (item.serializedStakingPath: string);
             const { addressParameters } = item;
             (addressParameters.addressType: number);
-            (addressParameters.path: string | number[]);
-            (addressParameters.stakingPath: ?string | number[]);
+            (addressParameters.path: ?string | ?(number[]));
+            (addressParameters.stakingPath: ?string | ?(number[]));
             const { certificatePointer } = addressParameters;
             if (certificatePointer) {
                 (certificatePointer.blockIndex: ?number);
                 (certificatePointer.txIndex: ?number);
                 (certificatePointer.certificateIndex: ?number);
             }
+            (addressParameters.paymentScriptHash: ?string);
+            (addressParameters.stakingScriptHash: ?string);
         });
     } else {
         (bundleAddress.payload.error: string);
@@ -103,6 +111,8 @@ export const cardanoGetAddress = async () => {
                 txIndex: 1,
                 certificateIndex: 2,
             },
+            paymentScriptHash: 'aaff00..',
+            stakingScriptHash: 'aaff00..',
         },
         address: 'a',
         protocolMagic: 0,

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -161,6 +161,38 @@ export const cardanoGetAddress = async () => {
     TrezorConnect.cardanoGetAddress({ bundle: 1 });
 };
 
+export const cardanoGetNativeScriptHash = async () => {
+    const result = await TrezorConnect.cardanoGetNativeScriptHash({
+        script: {
+            type: 0,
+            scripts: [
+                {
+                    type: 0,
+                    scripts: [],
+                    keyHash: '00aaff...',
+                    keyPath: 'm/44',
+                    requiredSignaturesCount: 0,
+                    invalidBefore: '0',
+                    invalidHereafter: '0',
+                },
+            ],
+            keyHash: '00aaff...',
+            keyPath: 'm/44',
+            requiredSignaturesCount: 0,
+            invalidBefore: '0',
+            invalidHereafter: '0',
+        },
+        displayFormat: 0,
+    });
+
+    (result.success: boolean);
+    if (result.success) {
+        (result.payload.scriptHash: string);
+    } else {
+        (result.payload.error: string);
+    }
+};
+
 export const cardanoGetPublicKey = async () => {
     // regular
     const singlePK = await TrezorConnect.cardanoGetPublicKey({ path: 'm/44' });

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -238,6 +238,10 @@ export type API = {
 
     // Cardano (ADA)
     cardanoGetAddress: Bundled<Cardano.CardanoGetAddress, Cardano.CardanoAddress>,
+    cardanoGetNativeScriptHash: Method<
+        Cardano.CardanoGetNativeScriptHash,
+        Cardano.CardanoNativeScriptHash,
+    >,
     cardanoGetPublicKey: Bundled<Cardano.CardanoGetPublicKey, Cardano.CardanoPublicKey>,
     cardanoSignTransaction: Method<Cardano.CardanoSignTransaction, Cardano.CardanoSignedTxData>,
 

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -92,13 +92,15 @@ export type CardanoInput = {
 
 export type CardanoToken = {
     assetNameBytes: string,
-    amount: string,
+    amount?: string,
+    mintAmount?: string,
 };
 
 export type CardanoAssetGroup = {
     policyId: string,
     tokenAmounts: CardanoToken[],
 };
+
 export type CardanoOutput =
     | {
           addressParameters: CardanoAddressParameters,
@@ -151,12 +153,16 @@ export type CardanoCertificate = {
     path?: string | number[],
     pool?: string,
     poolParameters?: CardanoPoolParameters,
+    scriptHash?: string,
 };
 
 export type CardanoWithdrawal = {
-    path: string | number[],
+    path?: string | number[],
     amount: string,
+    scriptHash?: string,
 };
+
+export type CardanoMint = CardanoAssetGroup[];
 
 export type CardanoCatalystRegistrationParameters = {
     votingPublicKey: string,
@@ -178,9 +184,11 @@ export type CardanoSignTransaction = {
     certificates?: CardanoCertificate[],
     withdrawals?: CardanoWithdrawal[],
     validityIntervalStart?: string,
+    auxiliaryData?: CardanoAuxiliaryData,
+    mint?: CardanoMint,
+    additionalWitnessRequests?: (string | number[])[],
     protocolMagic: number,
     networkId: number,
-    auxiliaryData?: CardanoAuxiliaryData,
     signingMode: CardanoTxSigningMode,
 };
 

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -4,9 +4,11 @@
 import type {
     HDNodeType,
     CardanoAddressType,
-    CardanoTxAuxiliaryDataSupplementType,
     CardanoCertificateType,
+    CardanoNativeScriptType,
+    CardanoNativeScriptHashDisplayFormat,
     CardanoPoolRelayType,
+    CardanoTxAuxiliaryDataSupplementType,
     CardanoTxSigningMode,
     CardanoTxWitnessType,
 } from '../trezor/protobuf';
@@ -57,6 +59,27 @@ export type CardanoAddress = {
     serializedPath: string,
     serializedStakingPath: string,
     address: string,
+};
+
+// GetNativeScriptHash
+
+export type CardanoNativeScript = {
+    type: CardanoNativeScriptType,
+    scripts?: CardanoNativeScript[],
+    keyHash?: string,
+    keyPath?: string | number[],
+    requiredSignaturesCount?: number,
+    invalidBefore?: string,
+    invalidHereafter?: string,
+};
+
+export type CardanoGetNativeScriptHash = {
+    script: CardanoNativeScript,
+    displayFormat: CardanoNativeScriptHashDisplayFormat,
+};
+
+export type CardanoNativeScriptHash = {
+    scriptHash: string,
 };
 
 // Sign transaction
@@ -183,6 +206,8 @@ export type CardanoSignedTxData = {
 export {
     Enum_CardanoAddressType as CardanoAddressType,
     Enum_CardanoCertificateType as CardanoCertificateType,
+    Enum_CardanoNativeScriptType as CardanoNativeScriptType,
+    Enum_CardanoNativeScriptHashDisplayFormat as CardanoNativeScriptHashDisplayFormat,
     Enum_CardanoPoolRelayType as CardanoPoolRelayType,
     Enum_CardanoTxSigningMode as CardanoTxSigningMode,
     Enum_CardanoTxWitnessType as CardanoTxWitnessType,

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -34,10 +34,12 @@ export type CardanoCertificatePointer = {
 
 export type CardanoAddressParameters = {
     addressType: CardanoAddressType,
-    path: string | number[],
+    path?: string | number[],
     stakingPath?: string | number[],
     stakingKeyHash?: string,
     certificatePointer?: CardanoCertificatePointer,
+    paymentScriptHash?: string,
+    stakingScriptHash?: string,
 };
 
 export type CardanoGetAddress = {

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -58,6 +58,15 @@ export const Enum_CardanoNativeScriptType = Object.freeze({
 });
 export type CardanoNativeScriptType = $Values<typeof Enum_CardanoNativeScriptType>;
 
+export const Enum_CardanoNativeScriptHashDisplayFormat = Object.freeze({
+    HIDE: 0,
+    BECH32: 1,
+    POLICY_ID: 2,
+});
+export type CardanoNativeScriptHashDisplayFormat = $Values<
+    typeof Enum_CardanoNativeScriptHashDisplayFormat,
+>;
+
 export const Enum_CardanoCertificateType = Object.freeze({
     STAKE_REGISTRATION: 0,
     STAKE_DEREGISTRATION: 1,
@@ -615,18 +624,18 @@ export type CardanoBlockchainPointerType = {
 // CardanoNativeScript
 export type CardanoNativeScript = {
     type: CardanoNativeScriptType,
-    scripts: CardanoNativeScript[],
+    scripts?: CardanoNativeScript[],
     key_hash?: string,
     key_path?: number[],
     required_signatures_count?: number,
-    invalid_before?: number,
-    invalid_hereafter?: number,
+    invalid_before?: string | number,
+    invalid_hereafter?: string | number,
 };
 
 // CardanoGetNativeScriptHash
 export type CardanoGetNativeScriptHash = {
     script: CardanoNativeScript,
-    show_display?: boolean,
+    display_format: CardanoNativeScriptHashDisplayFormat,
 };
 
 // CardanoNativeScriptHash

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -93,7 +93,7 @@ export type CardanoTxAuxiliaryDataSupplementType = $Values<
 export const Enum_CardanoTxSigningMode = Object.freeze({
     ORDINARY_TRANSACTION: 0,
     POOL_REGISTRATION_AS_OWNER: 1,
-    SCRIPT_TRANSACTION: 2,
+    MULTISIG_TRANSACTION: 2,
 });
 export type CardanoTxSigningMode = $Values<typeof Enum_CardanoTxSigningMode>;
 
@@ -771,7 +771,7 @@ export type CardanoTxCertificate = {
 
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
-    path: number[],
+    path?: number[],
     amount: number,
     script_hash?: string,
 };

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -48,6 +48,16 @@ export const Enum_CardanoAddressType = Object.freeze({
 });
 export type CardanoAddressType = $Values<typeof Enum_CardanoAddressType>;
 
+export const Enum_CardanoNativeScriptType = Object.freeze({
+    PUB_KEY: 0,
+    ALL: 1,
+    ANY: 2,
+    N_OF_K: 3,
+    INVALID_BEFORE: 4,
+    INVALID_HEREAFTER: 5,
+});
+export type CardanoNativeScriptType = $Values<typeof Enum_CardanoNativeScriptType>;
+
 export const Enum_CardanoCertificateType = Object.freeze({
     STAKE_REGISTRATION: 0,
     STAKE_DEREGISTRATION: 1,
@@ -74,6 +84,7 @@ export type CardanoTxAuxiliaryDataSupplementType = $Values<
 export const Enum_CardanoTxSigningMode = Object.freeze({
     ORDINARY_TRANSACTION: 0,
     POOL_REGISTRATION_AS_OWNER: 1,
+    SCRIPT_TRANSACTION: 2,
 });
 export type CardanoTxSigningMode = $Values<typeof Enum_CardanoTxSigningMode>;
 
@@ -601,6 +612,28 @@ export type CardanoBlockchainPointerType = {
     certificate_index: number,
 };
 
+// CardanoNativeScript
+export type CardanoNativeScript = {
+    type: CardanoNativeScriptType,
+    scripts: CardanoNativeScript[],
+    key_hash?: string,
+    key_path?: number[],
+    required_signatures_count?: number,
+    invalid_before?: number,
+    invalid_hereafter?: number,
+};
+
+// CardanoGetNativeScriptHash
+export type CardanoGetNativeScriptHash = {
+    script: CardanoNativeScript,
+    show_display?: boolean,
+};
+
+// CardanoNativeScriptHash
+export type CardanoNativeScriptHash = {
+    script_hash: string,
+};
+
 // CardanoAddressParametersType
 export type CardanoAddressParametersType = {
     address_type: CardanoAddressType,
@@ -608,6 +641,8 @@ export type CardanoAddressParametersType = {
     address_n_staking: number[],
     staking_key_hash?: string,
     certificate_pointer?: CardanoBlockchainPointerType,
+    script_payment_hash?: string,
+    script_staking_hash?: string,
 };
 
 // CardanoGetAddress
@@ -649,6 +684,7 @@ export type CardanoSignTxInit = {
     has_auxiliary_data: boolean,
     validity_interval_start?: string | number,
     witness_requests_count: number,
+    minting_asset_groups_count: number,
 };
 
 // CardanoTxInput
@@ -674,7 +710,8 @@ export type CardanoAssetGroup = {
 // CardanoToken
 export type CardanoToken = {
     asset_name_bytes: string,
-    amount: string | number,
+    amount?: string | number,
+    mint_amount?: string | number,
 };
 
 // CardanoPoolOwner
@@ -720,12 +757,14 @@ export type CardanoTxCertificate = {
     path?: number[],
     pool?: string,
     pool_parameters?: CardanoPoolParametersType,
+    script_hash?: string,
 };
 
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
     path: number[],
     amount: number,
+    script_hash?: string,
 };
 
 // CardanoCatalystRegistrationParametersType
@@ -740,6 +779,11 @@ export type CardanoCatalystRegistrationParametersType = {
 export type CardanoTxAuxiliaryData = {
     catalyst_registration_parameters?: CardanoCatalystRegistrationParametersType,
     hash?: string,
+};
+
+// CardanoTxMint
+export type CardanoTxMint = {
+    asset_groups_count: number,
 };
 
 // CardanoTxItemAck
@@ -2145,6 +2189,9 @@ export type MessageType = {
     FirmwareUpload: $Exact<FirmwareUpload>,
     SelfTest: SelfTest,
     CardanoBlockchainPointerType: $Exact<CardanoBlockchainPointerType>,
+    CardanoNativeScript: $Exact<CardanoNativeScript>,
+    CardanoGetNativeScriptHash: $Exact<CardanoGetNativeScriptHash>,
+    CardanoNativeScriptHash: $Exact<CardanoNativeScriptHash>,
     CardanoAddressParametersType: $Exact<CardanoAddressParametersType>,
     CardanoGetAddress: $Exact<CardanoGetAddress>,
     CardanoAddress: $Exact<CardanoAddress>,
@@ -2163,6 +2210,7 @@ export type MessageType = {
     CardanoTxWithdrawal: $Exact<CardanoTxWithdrawal>,
     CardanoCatalystRegistrationParametersType: $Exact<CardanoCatalystRegistrationParametersType>,
     CardanoTxAuxiliaryData: CardanoTxAuxiliaryData,
+    CardanoTxMint: $Exact<CardanoTxMint>,
     CardanoTxItemAck: CardanoTxItemAck,
     CardanoTxAuxiliaryDataSupplement: $Exact<CardanoTxAuxiliaryDataSupplement>,
     CardanoTxWitnessRequest: CardanoTxWitnessRequest,

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -277,9 +277,16 @@ export const cardanoSignTransaction = async () => {
                         hash: 'aaff00..',
                     },
                 },
+                scriptHash: 'aaff00..',
             },
         ],
-        withdrawals: [{ path: 'm/44', amount: '3003112' }],
+        withdrawals: [{ path: 'm/44', amount: '3003112', scriptHash: 'aaff00..' }],
+        mint: [
+            {
+                policyId: 'aaff00..',
+                tokenAmounts: [{ assetNameBytes: 'aaff00..', mintAmount: '-3003112' }],
+            },
+        ],
         auxiliaryData: {
             hash: 'aaff00..',
             catalystRegistrationParameters: {
@@ -299,6 +306,7 @@ export const cardanoSignTransaction = async () => {
                 nonce: '0',
             },
         },
+        additionalWitnessRequests: ['m/44'],
         fee: '42',
         ttl: '10',
         validityIntervalStart: '20',

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -1,11 +1,11 @@
-import { CardanoTxSigningMode } from 'types/trezor/protobuf';
+import { CardanoAddressType, CardanoCertificateType, CardanoNativeScriptHashDisplayFormat, CardanoNativeScriptType, CardanoPoolRelayType, CardanoTxSigningMode } from 'types/trezor/protobuf';
 import TrezorConnect from '../index';
 
 export const cardanoGetAddress = async () => {
     // regular
     const singleAddress = await TrezorConnect.cardanoGetAddress({
         addressParameters: {
-            addressType: 0,
+            addressType: CardanoAddressType.BASE,
             path: 'm/44',
             stakingPath: 'm/44',
             stakingKeyHash: 'aaff00..',
@@ -51,7 +51,7 @@ export const cardanoGetAddress = async () => {
         bundle: [
             {
                 addressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.BASE,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -107,7 +107,7 @@ export const cardanoGetAddress = async () => {
         keepSession: false,
         skipFinalReload: false,
         addressParameters: {
-            addressType: 0,
+            addressType: CardanoAddressType.BASE,
             path: 'm/44',
             stakingPath: 'm/44',
             stakingKeyHash: 'aaff00..',
@@ -139,10 +139,10 @@ export const cardanoGetAddress = async () => {
 export const cardanoGetNativeScriptHash = async () => {
     const result = await TrezorConnect.cardanoGetNativeScriptHash({
         script: {
-            type: 0,
+            type: CardanoNativeScriptType.PUB_KEY,
             scripts: [
                 {
-                    type: 0,
+                    type: CardanoNativeScriptType.PUB_KEY,
                     scripts: [],
                     keyHash: '00aaff...',
                     keyPath: 'm/44',
@@ -157,7 +157,7 @@ export const cardanoGetNativeScriptHash = async () => {
             invalidBefore: '0',
             invalidHereafter: '0',
         },
-        displayFormat: 0,
+        displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
     });
 
     if (result.success) {
@@ -220,7 +220,7 @@ export const cardanoSignTransaction = async () => {
             },
             {
                 addressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.BASE,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -241,7 +241,7 @@ export const cardanoSignTransaction = async () => {
         ],
         certificates: [
             {
-                type: 0,
+                type: CardanoCertificateType.STAKE_REGISTRATION,
                 path: 'm/44',
                 pool: 'aaff00..',
                 poolParameters: {
@@ -265,7 +265,7 @@ export const cardanoSignTransaction = async () => {
                     ],
                     relays: [
                         {
-                            type: 0,
+                            type: CardanoPoolRelayType.SINGLE_HOST_IP,
                             ipv4Address: '192.168.0.1',
                             ipv6Address: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
                             port: 1234,
@@ -293,7 +293,7 @@ export const cardanoSignTransaction = async () => {
                 votingPublicKey: 'aaff00..',
                 stakingPath: 'm/44',
                 rewardAddressParameters: {
-                    addressType: 0,
+                    addressType: CardanoAddressType.REWARD,
                     path: 'm/44',
                     stakingPath: 'm/44',
                     stakingKeyHash: 'aaff00..',
@@ -312,7 +312,7 @@ export const cardanoSignTransaction = async () => {
         validityIntervalStart: '20',
         protocolMagic: 0,
         networkId: 0,
-        signingMode: 0,
+        signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
     });
 
     if (sign.success) {

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -136,6 +136,37 @@ export const cardanoGetAddress = async () => {
     TrezorConnect.cardanoGetAddress({ bundle: 1 });
 };
 
+export const cardanoGetNativeScriptHash = async () => {
+    const result = await TrezorConnect.cardanoGetNativeScriptHash({
+        script: {
+            type: 0,
+            scripts: [
+                {
+                    type: 0,
+                    scripts: [],
+                    keyHash: '00aaff...',
+                    keyPath: 'm/44',
+                    requiredSignaturesCount: 0,
+                    invalidBefore: '0',
+                    invalidHereafter: '0',
+                },
+            ],
+            keyHash: '00aaff...',
+            keyPath: 'm/44',
+            requiredSignaturesCount: 0,
+            invalidBefore: '0',
+            invalidHereafter: '0',
+        },
+        displayFormat: 0,
+    });
+
+    if (result.success) {
+        result.payload.scriptHash;
+    } else {
+        result.payload.error;
+    }
+};
+
 export const cardanoGetPublicKey = async () => {
     // regular
     const singlePK = await TrezorConnect.cardanoGetPublicKey({ path: 'm/44' });

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -14,6 +14,8 @@ export const cardanoGetAddress = async () => {
                 txIndex: 1,
                 certificateIndex: 2,
             },
+            paymentScriptHash: 'aaff00..',
+            stakingScriptHash: 'aaff00..',
         },
         protocolMagic: 0,
         networkId: 0,
@@ -36,6 +38,8 @@ export const cardanoGetAddress = async () => {
             certificatePointer.txIndex;
             certificatePointer.certificateIndex;
         }
+        addressParameters.paymentScriptHash;
+        addressParameters.stakingScriptHash;
         // @ts-ignore
         payload.forEach(item => {
             item.address;
@@ -56,6 +60,8 @@ export const cardanoGetAddress = async () => {
                         txIndex: 1,
                         certificateIndex: 2,
                     },
+                    paymentScriptHash: 'aaff00..',
+                    stakingScriptHash: 'aaff00..',
                 },
                 protocolMagic: 0,
                 networkId: 0,
@@ -80,6 +86,8 @@ export const cardanoGetAddress = async () => {
                 certificatePointer.txIndex;
                 certificatePointer.certificateIndex;
             }
+            addressParameters.paymentScriptHash;
+            addressParameters.stakingScriptHash;
         });
         // @ts-ignore
         bundleAddress.payload.address;
@@ -108,6 +116,8 @@ export const cardanoGetAddress = async () => {
                 txIndex: 1,
                 certificateIndex: 2,
             },
+            paymentScriptHash: 'aaff00..',
+            stakingScriptHash: 'aaff00..',
         },
         address: 'a',
         protocolMagic: 0,

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -194,6 +194,9 @@ export namespace TrezorConnect {
     function cardanoGetAddress(
         params: P.CommonParams & P.Bundle<Cardano.CardanoGetAddress>,
     ): P.BundledResponse<Cardano.CardanoAddress>;
+    function cardanoGetNativeScriptHash(
+        params: P.CommonParams & Cardano.CardanoGetNativeScriptHash,
+    ): P.Response<Cardano.CardanoNativeScriptHash>;
     function cardanoGetPublicKey(
         params: P.CommonParams & Cardano.CardanoGetPublicKey,
     ): P.Response<Cardano.CardanoPublicKey>;

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -91,7 +91,8 @@ export interface CardanoInput {
 
 export type CardanoToken = {
     assetNameBytes: string;
-    amount: string;
+    amount?: string;
+    mintAmount?: string;
 }
 
 export type CardanoAssetGroup = {
@@ -148,15 +149,19 @@ export type CardanoPoolParameters = {
 
 export type CardanoCertificate = {
     type: CardanoCertificateType;
-    path: string | number[];
+    path?: string | number[];
     pool?: string;
     poolParameters?: CardanoPoolParameters;
+    scriptHash?: string;
 }
 
 export type CardanoWithdrawal = {
-    path: string | number[];
+    path?: string | number[];
     amount: string;
+    scriptHash?: string;
 }
+
+export type CardanoMint = CardanoAssetGroup[]
 
 export type CardanoCatalystRegistrationParameters = {
     votingPublicKey: string;
@@ -178,9 +183,11 @@ export interface CardanoSignTransaction {
     certificates?: CardanoCertificate[];
     withdrawals?: CardanoWithdrawal[];
     validityIntervalStart?: string;
+    auxiliaryData?: CardanoAuxiliaryData;
+    mint?: CardanoMint;
+    additionalWitnessRequests?: (string | number[])[];
     protocolMagic: number;
     networkId: number;
-    auxiliaryData?: CardanoAuxiliaryData;
     signingMode: CardanoTxSigningMode;
 }
 

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -34,10 +34,12 @@ export interface CardanoCertificatePointer {
 
 export interface CardanoAddressParameters {
     addressType: CardanoAddressType;
-    path: string | number[];
+    path?: string | number[];
     stakingPath?: string | number[];
     stakingKeyHash?: string;
     certificatePointer?: CardanoCertificatePointer;
+    paymentScriptHash?: string;
+    stakingScriptHash?: string;
 }
 
 export interface CardanoGetAddress {

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -1,13 +1,14 @@
-
 // Cardano method parameters types
-import { 
+import {
     HDNodeType,
     CardanoAddressType,
-    CardanoTxAuxiliaryDataSupplementType,
     CardanoCertificateType,
+    CardanoNativeScriptType,
+    CardanoNativeScriptHashDisplayFormat,
     CardanoPoolRelayType,
+    CardanoTxAuxiliaryDataSupplementType,
+    CardanoTxSigningMode,
     CardanoTxWitnessType,
-    CardanoTxSigningMode
 } from '../trezor/protobuf';
 
 // GetPublicKey
@@ -57,6 +58,27 @@ export interface CardanoAddress {
     serializedPath: string;
     serializedStakingPath: string;
     address: string;
+}
+
+// GetNativeScriptHash
+
+export interface CardanoNativeScript {
+    type: CardanoNativeScriptType;
+    scripts?: CardanoNativeScript[];
+    keyHash?: string;
+    keyPath?: string | number[];
+    requiredSignaturesCount?: number;
+    invalidBefore?: string;
+    invalidHereafter?: string;
+}
+
+export interface CardanoGetNativeScriptHash {
+    script: CardanoNativeScript;
+    displayFormat: CardanoNativeScriptHashDisplayFormat;
+}
+
+export interface CardanoNativeScriptHash {
+    scriptHash: string;
 }
 
 // Sign transaction
@@ -184,6 +206,8 @@ export interface CardanoSignedTxData {
 export {
     CardanoAddressType,
     CardanoCertificateType,
+    CardanoNativeScriptType,
+    CardanoNativeScriptHashDisplayFormat,
     CardanoPoolRelayType,
     CardanoTxSigningMode,
     CardanoTxWitnessType,

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -80,7 +80,7 @@ export enum CardanoTxAuxiliaryDataSupplementType {
 export enum CardanoTxSigningMode {
     ORDINARY_TRANSACTION = 0,
     POOL_REGISTRATION_AS_OWNER = 1,
-    SCRIPT_TRANSACTION = 2,
+    MULTISIG_TRANSACTION = 2,
 }
 
 export enum CardanoTxWitnessType {
@@ -744,7 +744,7 @@ export type CardanoTxCertificate = {
 
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
-    path: number[];
+    path?: number[];
     amount: number;
     script_hash?: string;
 };
@@ -810,7 +810,7 @@ export type CardanoTxInputType = {
 
 export type CardanoTokenType = {
     asset_name_bytes: string;
-    amount?: string | number;
+    amount: string | number;
 };
 
 export type CardanoAssetGroupType = {

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -53,6 +53,12 @@ export enum CardanoNativeScriptType {
     INVALID_HEREAFTER = 5,
 }
 
+export enum CardanoNativeScriptHashDisplayFormat {
+    HIDE = 0,
+    BECH32 = 1,
+    POLICY_ID = 2,
+}
+
 export enum CardanoCertificateType {
     STAKE_REGISTRATION = 0,
     STAKE_DEREGISTRATION = 1,
@@ -591,18 +597,18 @@ export type CardanoBlockchainPointerType = {
 // CardanoNativeScript
 export type CardanoNativeScript = {
     type: CardanoNativeScriptType;
-    scripts: CardanoNativeScript[];
+    scripts?: CardanoNativeScript[];
     key_hash?: string;
     key_path?: number[];
     required_signatures_count?: number;
-    invalid_before?: number;
-    invalid_hereafter?: number;
+    invalid_before?: string | number;
+    invalid_hereafter?: string | number;
 };
 
 // CardanoGetNativeScriptHash
 export type CardanoGetNativeScriptHash = {
     script: CardanoNativeScript;
-    show_display?: boolean;
+    display_format: CardanoNativeScriptHashDisplayFormat;
 };
 
 // CardanoNativeScriptHash

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -44,6 +44,15 @@ export enum CardanoAddressType {
     REWARD_SCRIPT = 15,
 }
 
+export enum CardanoNativeScriptType {
+    PUB_KEY = 0,
+    ALL = 1,
+    ANY = 2,
+    N_OF_K = 3,
+    INVALID_BEFORE = 4,
+    INVALID_HEREAFTER = 5,
+}
+
 export enum CardanoCertificateType {
     STAKE_REGISTRATION = 0,
     STAKE_DEREGISTRATION = 1,
@@ -65,6 +74,7 @@ export enum CardanoTxAuxiliaryDataSupplementType {
 export enum CardanoTxSigningMode {
     ORDINARY_TRANSACTION = 0,
     POOL_REGISTRATION_AS_OWNER = 1,
+    SCRIPT_TRANSACTION = 2,
 }
 
 export enum CardanoTxWitnessType {
@@ -578,6 +588,28 @@ export type CardanoBlockchainPointerType = {
     certificate_index: number;
 };
 
+// CardanoNativeScript
+export type CardanoNativeScript = {
+    type: CardanoNativeScriptType;
+    scripts: CardanoNativeScript[];
+    key_hash?: string;
+    key_path?: number[];
+    required_signatures_count?: number;
+    invalid_before?: number;
+    invalid_hereafter?: number;
+};
+
+// CardanoGetNativeScriptHash
+export type CardanoGetNativeScriptHash = {
+    script: CardanoNativeScript;
+    show_display?: boolean;
+};
+
+// CardanoNativeScriptHash
+export type CardanoNativeScriptHash = {
+    script_hash: string;
+};
+
 // CardanoAddressParametersType
 export type CardanoAddressParametersType = {
     address_type: CardanoAddressType;
@@ -585,6 +617,8 @@ export type CardanoAddressParametersType = {
     address_n_staking: number[];
     staking_key_hash?: string;
     certificate_pointer?: CardanoBlockchainPointerType;
+    script_payment_hash?: string;
+    script_staking_hash?: string;
 };
 
 // CardanoGetAddress
@@ -626,6 +660,7 @@ export type CardanoSignTxInit = {
     has_auxiliary_data: boolean;
     validity_interval_start?: string | number;
     witness_requests_count: number;
+    minting_asset_groups_count: number;
 };
 
 // CardanoTxInput
@@ -651,7 +686,8 @@ export type CardanoAssetGroup = {
 // CardanoToken
 export type CardanoToken = {
     asset_name_bytes: string;
-    amount: string | number;
+    amount?: string | number;
+    mint_amount?: string | number;
 };
 
 // CardanoPoolOwner
@@ -697,12 +733,14 @@ export type CardanoTxCertificate = {
     path?: number[];
     pool?: string;
     pool_parameters?: CardanoPoolParametersType;
+    script_hash?: string;
 };
 
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
     path: number[];
     amount: number;
+    script_hash?: string;
 };
 
 // CardanoCatalystRegistrationParametersType
@@ -717,6 +755,11 @@ export type CardanoCatalystRegistrationParametersType = {
 export type CardanoTxAuxiliaryData = {
     catalyst_registration_parameters?: CardanoCatalystRegistrationParametersType;
     hash?: string;
+};
+
+// CardanoTxMint
+export type CardanoTxMint = {
+    asset_groups_count: number;
 };
 
 // CardanoTxItemAck
@@ -761,7 +804,7 @@ export type CardanoTxInputType = {
 
 export type CardanoTokenType = {
     asset_name_bytes: string;
-    amount: string | number;
+    amount?: string | number;
 };
 
 export type CardanoAssetGroupType = {

--- a/tests/__fixtures__/cardanoGetAddress.js
+++ b/tests/__fixtures__/cardanoGetAddress.js
@@ -152,7 +152,7 @@ export default {
             },
         },
         {
-            description: "Base Hash Mainnet - m/1852'/1815'/4'/0/0",
+            description: "Base Staking Key Hash Mainnet - m/1852'/1815'/4'/0/0",
             params: {
                 addressParameters: {
                     addressType: CardanoAddressType.BASE,
@@ -168,7 +168,7 @@ export default {
             },
         },
         {
-            description: "Base Hash Testnet - m/1852'/1815'/4'/0/0",
+            description: "Base Staking Key Hash Testnet - m/1852'/1815'/4'/0/0",
             params: {
                 addressParameters: {
                     addressType: CardanoAddressType.BASE,
@@ -182,6 +182,138 @@ export default {
                 address:
                     'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf',
             },
+        },
+        {
+            description: 'Base Script Key Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_SCRIPT_KEY,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    stakingPath: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address:
+                    'addr1zyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsf42dkl',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Base Script Key Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_SCRIPT_KEY,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    stakingPath: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address:
+                    'addr_test1zqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms2rhd6q',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Base Key Script Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_KEY_SCRIPT,
+                    path: "m/1852'/1815'/0'/0/0",
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address:
+                    'addr1yxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5s8vnrtt',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Base Key Script Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_KEY_SCRIPT,
+                    path: "m/1852'/1815'/0'/0/0",
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address:
+                    'addr_test1yzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5sy6wr85',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Base Script Script Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_SCRIPT_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address:
+                    'addr1xyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5s3gftll',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Base Script Script Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.BASE_SCRIPT_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address:
+                    'addr_test1xqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5d004u0fv0r3a4ld7f8yg8rmxnk5dsxf542ghcc42ngw5sj75tnq',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: "Enterprise Mainnet - m/1852'/1815'/0'/0/0",
@@ -210,6 +342,46 @@ export default {
             result: {
                 address: 'addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47',
             },
+        },
+        {
+            description: 'Enterprise Script Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.ENTERPRISE_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address: 'addr1wyx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsqee7sp',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Enterprise Script Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.ENTERPRISE_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address: 'addr_test1wqx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3lsm3dzly',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: "Pointer Mainnet - m/1852'/1815'/0'/0/0",
@@ -250,11 +422,61 @@ export default {
             },
         },
         {
+            description: 'Pointer Script Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.POINTER_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    certificatePointer: {
+                        blockIndex: 24157,
+                        txIndex: 177,
+                        certificateIndex: 42,
+                    },
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address: 'addr12yx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5ph3wczvf2zmd4yp',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Pointer Script Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.POINTER_SCRIPT,
+                    paymentScriptHash: '0d5acbf6a1dfb0c8724e60df314987315ccbf78bb6c0f9b6f3d568fe',
+                    certificatePointer: {
+                        blockIndex: 24157,
+                        txIndex: 177,
+                        certificateIndex: 42,
+                    },
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address: 'addr_test12qx44jlk580mpjrjfesd7v2fsuc4ejlh3wmvp7dk702k3l5ph3wczvf2d4sugn',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
             description: "Reward Mainnet - m/1852'/1815'/0'/2/0",
             params: {
                 addressParameters: {
                     addressType: CardanoAddressType.REWARD,
-                    path: "m/1852'/1815'/0'/2/0",
+                    stakingPath: "m/1852'/1815'/0'/2/0",
                 },
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
@@ -268,7 +490,7 @@ export default {
             params: {
                 addressParameters: {
                     addressType: CardanoAddressType.REWARD,
-                    path: "m/1852'/1815'/0'/2/0",
+                    stakingPath: "m/1852'/1815'/0'/2/0",
                 },
                 protocolMagic: PROTOCOL_MAGICS.testnet,
                 networkId: NETWORK_IDS.testnet,
@@ -276,6 +498,73 @@ export default {
             result: {
                 address: 'stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq',
             },
+        },
+        {
+            description: 'Reward Script Mainnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.REWARD_SCRIPT,
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address: 'stake17xxhh6785k83c76lklynjyr3anfm2xcry624ytuv24f582gt5mad4',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Reward Script Testnet',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.REWARD_SCRIPT,
+                    stakingScriptHash: '8d7bebc7a58f1c7b5fb7c9391071ecd3b51b032695522f8c555343a9',
+                },
+                protocolMagic: PROTOCOL_MAGICS.testnet,
+                networkId: NETWORK_IDS.testnet,
+            },
+            result: {
+                address: 'stake_test17zxhh6785k83c76lklynjyr3anfm2xcry624ytuv24f582gv73lfg',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Reward Mainnet - path sent as path instead of stakingPath',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.REWARD,
+                    path: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: {
+                address: 'stake1uyfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yacalmqha',
+            },
+        },
+        {
+            description: 'Reward Mainnet - both path and stakingPath are set',
+            params: {
+                addressParameters: {
+                    addressType: CardanoAddressType.REWARD,
+                    path: "m/1852'/1815'/0'/2/0",
+                    stakingPath: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+            },
+            result: false,
         },
     ],
 };

--- a/tests/__fixtures__/cardanoGetNativeScriptHash.js
+++ b/tests/__fixtures__/cardanoGetNativeScriptHash.js
@@ -1,0 +1,383 @@
+import {
+    Enum_CardanoNativeScriptHashDisplayFormat as CardanoNativeScriptHashDisplayFormat,
+    Enum_CardanoNativeScriptType as CardanoNativeScriptType,
+} from '../../src/js/types/trezor/protobuf';
+
+export default {
+    method: 'cardanoGetNativeScriptHash',
+    setup: {
+        mnemonic: 'mnemonic_all',
+    },
+    tests: [
+        {
+            description: 'PUB_KEY script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.PUB_KEY,
+                    keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'PUB_KEY script containing a path',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.PUB_KEY,
+                    keyPath: "m/1854'/1815'/0'/0/0",
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'ALL script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'af5c2ce476a6ede1c879f7b1909d6a0b96cb2081391712d4a355cef6',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'ALL script containing a path',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyPath: "m/1854'/1815'/0'/0/0",
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'af5c2ce476a6ede1c879f7b1909d6a0b96cb2081391712d4a355cef6',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'ALL script containing a 1855 path',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyPath: "m/1855'/1815'/0'",
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'fbf6672eb655c29b0f148fa1429be57c2174b067a7b3e3942e967fe8',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'ANY script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ANY,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'd6428ec36719146b7b5fb3a2d5322ce702d32762b8c7eeeb797a20db',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'ANY script containing a path',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ANY,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyPath: "m/1854'/1815'/0'/0/0",
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'd6428ec36719146b7b5fb3a2d5322ce702d32762b8c7eeeb797a20db',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'N_OF_K script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.N_OF_K,
+                    requiredSignaturesCount: 2,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'cecb1d427c4ae436d28cc0f8ae9bb37501a5b77bcc64cd1693e9ae20',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: '2b2b17fd18e18acae4601d4818a1dee00a917ff72e772fa8482e36c9',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'N_OF_K script containing a path',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.N_OF_K,
+                    requiredSignaturesCount: 2,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyPath: "m/1854'/1815'/0'/0/0",
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'cecb1d427c4ae436d28cc0f8ae9bb37501a5b77bcc64cd1693e9ae20',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: '2b2b17fd18e18acae4601d4818a1dee00a917ff72e772fa8482e36c9',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'INVALID_BEFORE script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.INVALID_BEFORE,
+                            invalidBefore: '100',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'c6262ef9bb2b1291c058d93b46dabf458e2d135f803f60713f84b0b7',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'INVALID_HEREAFTER script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.INVALID_HEREAFTER,
+                            invalidHereafter: '200',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: 'b12ac304f89f4cd4d23f59a2b90d2b2697f7540b8f470d6aa05851b5',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'Nested script',
+            params: {
+                script: {
+                    type: CardanoNativeScriptType.ALL,
+                    scripts: [
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                        },
+                        {
+                            type: CardanoNativeScriptType.PUB_KEY,
+                            keyPath: "m/1854'/1815'/0'/0/0",
+                        },
+                        {
+                            type: CardanoNativeScriptType.ANY,
+                            scripts: [
+                                {
+                                    type: CardanoNativeScriptType.PUB_KEY,
+                                    keyPath: "m/1854'/1815'/0'/0/0",
+                                },
+                                {
+                                    type: CardanoNativeScriptType.PUB_KEY,
+                                    keyHash:
+                                        '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                                },
+                            ],
+                        },
+                        {
+                            type: CardanoNativeScriptType.N_OF_K,
+                            requiredSignaturesCount: 2,
+                            scripts: [
+                                {
+                                    type: CardanoNativeScriptType.PUB_KEY,
+                                    keyPath: "m/1854'/1815'/0'/0/0",
+                                },
+                                {
+                                    type: CardanoNativeScriptType.PUB_KEY,
+                                    keyHash:
+                                        '0241f2d196f52a92fbd2183d03b370c30b6960cfdeae364ffabac889',
+                                },
+                                {
+                                    type: CardanoNativeScriptType.PUB_KEY,
+                                    keyHash:
+                                        'cecb1d427c4ae436d28cc0f8ae9bb37501a5b77bcc64cd1693e9ae20',
+                                },
+                            ],
+                        },
+                        {
+                            type: CardanoNativeScriptType.INVALID_BEFORE,
+                            invalidBefore: '100',
+                        },
+                        {
+                            type: CardanoNativeScriptType.INVALID_HEREAFTER,
+                            invalidHereafter: '200',
+                        },
+                    ],
+                },
+                displayFormat: CardanoNativeScriptHashDisplayFormat.HIDE,
+            },
+            result: {
+                scriptHash: '4a6b4288459bf34668c0b281f922691460caf0c7c09caee3a726c27a',
+            },
+            legacyResults: [
+                {
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+    ],
+};

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -127,6 +127,22 @@ const SAMPLE_OUTPUTS = {
             },
         ],
     },
+    output_common_with_ledger: {
+        address:
+            'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+        amount: '2000000',
+        tokenBundle: [
+            {
+                policyId: '0d63e8d2c5a00cbcffbdf9112487c443466e1ea7d8c834df5ac5c425',
+                tokenAmounts: [
+                    {
+                        assetNameBytes: '74657374436f696e',
+                        amount: '7878754',
+                    },
+                ],
+            },
+        ],
+    },
 };
 
 const SAMPLE_CERTIFICATES = {
@@ -134,13 +150,26 @@ const SAMPLE_CERTIFICATES = {
         type: CardanoCertificateType.STAKE_REGISTRATION,
         path: "m/1852'/1815'/0'/2/0",
     },
+    stake_registration_script: {
+        type: CardanoCertificateType.STAKE_REGISTRATION,
+        scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+    },
     stake_deregistration: {
         type: CardanoCertificateType.STAKE_DEREGISTRATION,
         path: "m/1852'/1815'/0'/2/0",
     },
+    stake_deregistration_script: {
+        type: CardanoCertificateType.STAKE_DEREGISTRATION,
+        scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+    },
     stake_delegation: {
         type: CardanoCertificateType.STAKE_DELEGATION,
         path: "m/1852'/1815'/0'/2/0",
+        pool: 'f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973',
+    },
+    stake_delegation_script: {
+        type: CardanoCertificateType.STAKE_DELEGATION,
+        scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
         pool: 'f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973',
     },
     stake_pool_registration: {
@@ -224,6 +253,57 @@ const SAMPLE_CERTIFICATES = {
 const SAMPLE_WITHDRAWAL = {
     path: "m/1852'/1815'/0'/2/0",
     amount: '1000',
+};
+
+const SAMPLE_WITHDRAWAL_SCRIPT = {
+    scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+    amount: '1000',
+};
+
+const SAMPLE_MINTS = {
+    basic: [
+        {
+            policyId: '95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39',
+            tokenAmounts: [
+                {
+                    assetNameBytes: '74652474436f696e',
+                    mintAmount: '7878754',
+                },
+                {
+                    assetNameBytes: '75652474436f696e',
+                    mintAmount: '-7878754',
+                },
+            ],
+        },
+        {
+            policyId: '96a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39',
+            tokenAmounts: [
+                {
+                    assetNameBytes: '74652474436f696e',
+                    mintAmount: '7878754',
+                },
+                {
+                    assetNameBytes: '75652474436f696e',
+                    mintAmount: '-1234',
+                },
+            ],
+        },
+    ],
+    common_with_ledger: [
+        {
+            policyId: '0d63e8d2c5a00cbcffbdf9112487c443466e1ea7d8c834df5ac5c425',
+            tokenAmounts: [
+                {
+                    assetNameBytes: '74657374436f696e',
+                    mintAmount: '7878754',
+                },
+                {
+                    assetNameBytes: '75657374436f696e',
+                    mintAmount: '-7878754',
+                },
+            ],
+        },
+    ],
 };
 
 const FEE = '42';
@@ -898,6 +978,307 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
+        },
+        {
+            description: 'ordinaryTransactionWithTokenMinting',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.token_output],
+                fee: FEE,
+                ttl: TTL,
+                validityIntervalStart: VALIDITY_INTERVAL_START,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+                mint: SAMPLE_MINTS.basic,
+                additionalWitnessRequests: ["m/1855'/1815'/0'"],
+            },
+            result: {
+                hash: '042c1d3a6eab693d2ea6b186a88aed038159e7eb581da80464bca7339fb9afe0',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'ff10637250efa74970675169585720dd5b663c49ecf523ac6214e11a74858f80ec6ef4c86ea66666ec7102fe78c92bcc4e76d50a7bff1fd9660757e94863ba09',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b75258e4f61eb7b313d8554c2fe10673cf214ca2d762bfd53ec3b7846e2ee872',
+                        signature:
+                            'd42665ef7855bfe6898b440476ec8967f8ce786a30865a27e0c091b912b8fd87cad2f7d2f1adeb0e2a7201f2ca020a41f48fb982cb3b7f278dab848192d42e0d',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support token minting
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+        {
+            description: 'multisigTransactionWithTokenMinting',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.token_output],
+                fee: FEE,
+                ttl: TTL,
+                validityIntervalStart: VALIDITY_INTERVAL_START,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                mint: SAMPLE_MINTS.basic,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1855'/1815'/0'"],
+            },
+            result: {
+                hash: '042c1d3a6eab693d2ea6b186a88aed038159e7eb581da80464bca7339fb9afe0',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            'ef08436c998df4fd4aade2ce240d92d8851783b688a949c167aa070e885ffb592943767ddae0b826265a307405cf9865b6f66fbfa2e5a39797950104b7b13d0d',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b75258e4f61eb7b313d8554c2fe10673cf214ca2d762bfd53ec3b7846e2ee872',
+                        signature:
+                            'd42665ef7855bfe6898b440476ec8967f8ce786a30865a27e0c091b912b8fd87cad2f7d2f1adeb0e2a7201f2ca020a41f48fb982cb3b7f278dab848192d42e0d',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'multisigWithStakeRegistration',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_registration_script],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0"],
+            },
+            result: {
+                hash: 'ed9fc2755091fa72b58e9dd06db05cce87c0c6f3962f587d5fc348fe478f0752',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            'dccfcce8a2a17673c0e465a60a334eabbe326127d3dd04b727702ea486ed7c231259353c0890cfcb8209169eda7a139aeec42c77ce87231b0b9c250efb64450e',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'multisigWithStakeRegistrationAndStakeDelegation',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [
+                    SAMPLE_CERTIFICATES.stake_registration_script,
+                    SAMPLE_CERTIFICATES.stake_delegation_script,
+                ],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '26fb07b23368898665829283985ffe6c4cb2ec13758e83f467b78e5061f9619b',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            'c3fc7aae0a78b3b888f68775da3b9ba1e5478f2003e8c1f0b558172acd23205f2652e7e021f5041a4a1a785fad4f711ca80a9b39afd2939644d4da47d86f7b05',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            '982247b7a3a3625eaae74d4710f0d9a9b4bae6f0e201c31544f056ad3d7e5940e477cedf3f83fa0e37152e5f97585d910296e95395677dee047e204864187f09',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'multisigWithStakeDeregistration',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: 'c4e70484c964eca910219047542632ac9a9ac81f11f5d5afd8bb1b0ef4366d69',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '059fa17fb8e8302083d110ec4587d6ce80b3bc15baa75e0a2d449df190ce462d0e6ebc67d96f74fa6ce0b149714d1ef24f40c24846fef9d58405c6e2287e540b',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            'dc51848d3257f8f6783d6a53736ba638bc62c7098e5ec6d4d2b313520c78c689942f6e2542ba2b6b9749b7a57d4c8658c84fbc5b1e2847159eb0c256298bcd01',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'multisigWithStakeDeregistrationAndWithdrawal',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
+                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: 'e02d252c5cad2a4d8f163069cd7f0822c7876d16af9ad8ac2d461655812b2d1b',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '882994b27b1886a2f7ae3b42e08f3ce2c9c5b7d82e467135e0069f396a18f89696e882dbeadce0b3af8a10edbfb55057e6909e8232ac0107cc4fbf647493720b',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            'cc119eb4e7f27d5c316a5d1301850a2f3e4d08c267d5422cae8e4f00178a55d053a2288ed0a55fc8ec05bd8c1cd5fee5a713da85d489a2a02ac273866e36ae06',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'multisigWithMostElementsFilledAndSharedWithLedger',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.output_common_with_ledger],
+                fee: FEE,
+                ttl: TTL,
+                validityIntervalStart: VALIDITY_INTERVAL_START,
+                certificates: [
+                    SAMPLE_CERTIFICATES.stake_registration_script,
+                    SAMPLE_CERTIFICATES.stake_deregistration_script,
+                    SAMPLE_CERTIFICATES.stake_delegation_script,
+                ],
+                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                auxiliaryData: {
+                    hash: '58ec01578fcdfdc376f09631a7b2adc608eaf57e3720484c7ff37c13cff90fdf',
+                },
+                mint: SAMPLE_MINTS.common_with_ledger,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '2be64c04ea3f5bac3c224ec47a4157ade91fc6ab4fd6b83ce3d57b2e9186720b',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '38a56a46b21caef91742ffafdec202ed96809c3070c9bfd51db5c750d77edbfb8514d9cd2255ab5a857dd8a63706ae0ca29e390fba6af7a906b186aed117b809',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            '0c9071c421fe207ac1d9102643eac8ddf5ff29238782956b5706b9f1f084dfc5c087b4ceda6d079f8bb6438d3b556d3ac97565a87a8ec33f11856408b0480400',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support multisig
+                    rules: ['<2.4.3'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: 'signTtlIs0',

--- a/tests/__fixtures__/index.js
+++ b/tests/__fixtures__/index.js
@@ -11,6 +11,7 @@ import binanceSignTransaction from './binanceSignTransaction';
 // import resetDevice from './resetDevice';
 import cardanoGetAddress from './cardanoGetAddress';
 import cardanoGetPublicKey from './cardanoGetPublicKey';
+import cardanoGetNativeScriptHash from './cardanoGetNativeScriptHash';
 import cardanoSignTransaction from './cardanoSignTransaction';
 import composeTransaction from './composeTransaction';
 import eosGetPublicKey from './eosGetPublicKey';
@@ -60,6 +61,7 @@ let fixtures = [
     // todo: missing fixtures: BinanceGetPublicKey.js
     binanceSignTransaction,
     cardanoGetAddress,
+    cardanoGetNativeScriptHash,
     cardanoGetPublicKey,
     cardanoSignTransaction,
     // todo: missing fixtures: ChangePin.js


### PR DESCRIPTION
This PR adds support for Cardano native scripts and token minting. Relevant firmware PR [here](https://github.com/trezor/trezor-firmware/pull/1772).

There should be no breaking changes. New features:
- `cardanoGetNativeScriptHash` call ([docs](../blob/276ad461774e78ad8d46d6c9138c2e2cae682b4b/docs/methods/cardanoGetNativeScriptHash.md))
- multi-sig transactions ([docs](https://github.com/trezor/trezor-firmware/blob/master/core/src/apps/cardano/README.md#multi-sig-transaction))
  - [Script credentials](../blob/276ad461774e78ad8d46d6c9138c2e2cae682b4b/src/js/types/networks/cardano.js#L37-L45) must be used in certificates and withdrawals when signing a multi-sig transaction (using the `MULTISIG_TRANSACTION` signing mode). Ordinary (1852') witness requests are not allowed. All the multisig witness requests (1854') should be provided in the [`additionalWitnessRequests` field](../blob/276ad461774e78ad8d46d6c9138c2e2cae682b4b/src/js/types/networks/cardano.js#L188) in the `cardanoSignTransaction` call and they are all shown to the user. Multisig transaction cannot contain a pool registration certificate.
- token minting and burning ([docs](https://github.com/trezor/trezor-firmware/blob/master/core/src/apps/cardano/README.md#token-mintingburning))
  - There is a new optional [`mint` field](../blob/276ad461774e78ad8d46d6c9138c2e2cae682b4b/src/js/types/networks/cardano.js#L187) in the `cardanoSignTransaction` call. Keys derived from a minting path (1855') are used to create token minting/burning policies. Corresponding witness requests should be provided in the [`additionalWitnessRequests` field](../blob/276ad461774e78ad8d46d6c9138c2e2cae682b4b/src/js/types/networks/cardano.js#L188) in the `cardanoSignTransaction` call and they are all shown to the user.