### PR TITLE
fix: GetAccount info response type

### DIFF
--- a/src/js/core/methods/GetAccountInfo.js
+++ b/src/js/core/methods/GetAccountInfo.js
@@ -216,7 +216,7 @@ export default class GetAccountInfo extends AbstractMethod {
         }
     }
 
-    async run(): Promise<AccountInfo | Array<AccountInfo | null> | null> {
+    async run(): Promise<AccountInfo | null | Array<AccountInfo | null>> {
         // address_n and descriptor are not set. use discovery
         if (this.params.length === 1 && !this.params[0].address_n && !this.params[0].descriptor) {
             return this.discover(this.params[0]);

--- a/src/js/types/__tests__/bitcoin.js
+++ b/src/js/types/__tests__/bitcoin.js
@@ -485,7 +485,7 @@ export const getAccountInfo = async () => {
         },
         defaultAccountType: 'normal',
     });
-    if (account.success) {
+    if (account.success && account.payload) {
         const { payload } = account;
         (payload.empty: boolean);
         (payload.path: string);
@@ -541,7 +541,9 @@ export const getAccountInfo = async () => {
     (bundlePK.success: boolean);
     if (bundlePK.success) {
         bundlePK.payload.forEach(item => {
-            (item.empty: boolean);
+            if (item !== null) {
+                (item.empty: boolean);
+            }
         });
     } else {
         (bundlePK.payload.error: string);

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -216,7 +216,7 @@ export type API = {
      * Bitcoin, Bitcoin-like, Ethereum-like, Ripple
      * Gets an info of specified account.
      */
-    getAccountInfo: Bundled<Account.GetAccountInfo, Account.AccountInfo>,
+    getAccountInfo: Bundled<Account.GetAccountInfo, Account.AccountInfo | null>,
 
     /**
      * Bitcoin and Bitcoin-like

--- a/src/ts/types/__tests__/bitcoin.ts
+++ b/src/ts/types/__tests__/bitcoin.ts
@@ -472,6 +472,7 @@ export const getAccountInfo = async () => {
     });
     if (account.success) {
         const { payload } = account;
+        if (payload === null) return;
         payload.empty;
         payload.path;
         payload.descriptor;

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -156,10 +156,10 @@ export namespace TrezorConnect {
      * Bitcoin, Bitcoin-like, Ethereum-like, Ripple
      * Gets an info of specified account.
      */
-    function getAccountInfo(params: P.CommonParams & Account.GetAccountInfo): P.Response<Account.AccountInfo>;
+    function getAccountInfo(params: P.CommonParams & Account.GetAccountInfo): P.Response<Account.AccountInfo | null>;
     function getAccountInfo(
         params: P.CommonParams & P.Bundle<Account.GetAccountInfo>,
-    ): P.BundledResponse<Account.AccountInfo>;
+    ): P.BundledResponse<Account.AccountInfo | null>;
 
     /**
      * Bitcoin and Bitcoin-like


### PR DESCRIPTION
there is an [issue](https://github.com/trezor/trezor-suite/issues/3461) with GetAccountInfo method having its root in incomplete type in connect