### PR TITLE
tests: fix getAccountInfo fixture for xrp account

### DIFF
--- a/tests/__fixtures__/getAccountInfo.js
+++ b/tests/__fixtures__/getAccountInfo.js
@@ -106,7 +106,7 @@ export default {
             },
             result: {
                 descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
-                balance: '20000000',
+                empty: false,
             },
         },
         {


### PR DESCRIPTION
tested account balance was reduced (again) since xrp reserve changed :)
test are failing in [gitlab ci](https://gitlab.com/satoshilabs/trezor/connect/-/jobs/1703112786) while checking real data on real backends.

i'm changing tests scenario to check only if account is or is not empty