### PR TITLE
fix: protobuf build script ignore unknown top level option

### DIFF
--- a/scripts/protobuf-build.sh
+++ b/scripts/protobuf-build.sh
@@ -20,6 +20,7 @@ grep -hv -e '^import ' -e '^syntax' -e '^package' -e 'option java_' $SRC/message
 | sed 's/ hw\.trezor\.messages\.common\./ /' \
 | sed 's/ common\./ /' \
 | sed 's/ management\./ /' \
+| sed 's/^option /\/\/ option /' \
 | grep -v '    reserved '>> $DIST/messages.proto
 
 # BUILD messages.json from message.proto


### PR DESCRIPTION
remove/comment `option (include_in_bitcoin_only) = true;` from top level of combined `message.proto` file