### PR TITLE
fix: ethereumSignTransaction eip1559 support for T1

### DIFF
--- a/src/data/config.json
+++ b/src/data/config.json
@@ -149,12 +149,12 @@
         {
             "capabilities": ["decreaseOutput"],
             "min": ["1.10.0", "2.4.0"],
-            "comment": ["allow reduce output in RBF transaction since /2.4.0"]
+            "comment": ["allow reduce output in RBF transaction since 1.10.0/2.4.0"]
         },
         {
             "capabilities": ["eip1559"],
-            "min": ["0", "2.4.2"],
-            "comment": ["new eth transaction pricing mechanism (EIP1559) since 2.4.2"]
+            "min": ["1.10.4", "2.4.2"],
+            "comment": ["new eth transaction pricing mechanism (EIP1559) since 1.10.4/2.4.2"]
         }
     ]
 }


### PR DESCRIPTION
In trezor/trezor-firmware#1861 we've added [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) support to T1, and @bosomt found that it doesn't work with mycrypto wallet. It looks like it needs to be whitelisted here?