### PR TITLE
Cardano derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trezor Connect API version 8.2.3-beta.2
+# Trezor Connect API version 8.2.3-beta.3
 [![Build Status](https://github.com/trezor/connect/actions/workflows/tests.yml/badge.svg)](https://github.com/trezor/connect/actions/workflows/tests.yml)
 [![NPM](https://img.shields.io/npm/v/trezor-connect.svg)](https://www.npmjs.org/package/trezor-connect)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/connect?targetFile=package.json)

--- a/docs/methods/cardanoGetAddress.md
+++ b/docs/methods/cardanoGetAddress.md
@@ -21,6 +21,7 @@ TrezorConnect.cardanoGetAddress(params).then(function(result) {
 * `protocolMagic` - *obligatory* `Integer` 764824073 for Mainnet, 42 for Testnet
 * `networkId` - *obligatory* `Integer` 1 for Mainnet, 0 for Testnet
 * `showOnTrezor` — *optional* `boolean` determines if address will be displayed on device. Default is set to `true`
+* `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
 
 #### Exporting bundle of addresses
 * `bundle` - `Array` of Objects with single address fields

--- a/docs/methods/cardanoGetNativeScriptHash.md
+++ b/docs/methods/cardanoGetNativeScriptHash.md
@@ -18,6 +18,7 @@ TrezorConnect.cardanoGetNativeScriptHash(params).then(function(result) {
 ##### [flowtype](../../src/js/types/networks/cardano.js#L76-L79)
 * `script` — *obligatory* `CardanoNativeScript` see description below.
 * `displayFormat` — *obligatory* `CardanoNativeScriptHashDisplayFormat` enum.
+* `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2 
 
 #### CardanoNativeScript
 ###### [flowtype](../../src/js/types/networks/cardano.js#L66-74)

--- a/docs/methods/cardanoGetPublicKey.md
+++ b/docs/methods/cardanoGetPublicKey.md
@@ -19,6 +19,7 @@ TrezorConnect.cardanoGetPublicKey(params).then(function(result) {
 #### Exporting single public key
 * `path` — *obligatory* `string | Array<number>` minimum length is `3`. [read more](path.md)
 * `showOnTrezor` — *optional* `boolean` determines if publick key will be displayed on device. Default is set to `true`
+* `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
 
 #### Exporting bundle of publick keys
 * `bundle` - `Array` of Objects with `path` and `showOnTrezor` fields

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -32,6 +32,7 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L164)
 * `additionalWitnessRequests` - *optional* `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 * `metadata` - *removed* - use `auxiliaryData` instead
+* `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
 
 ### CardanoTxSigningMode
 

--- a/docs/methods/commonParams.md
+++ b/docs/methods/commonParams.md
@@ -8,9 +8,14 @@ All common parameters are optional.
     - `instance` - *optional* `number` sets an instance of device. Useful when working with one device and multiple passphrases. This value is emitted by [`TrezorConnectEvent`](../events.md)
 * `useEmptyPassphrase` — *optional* `boolean` method will not ask for a passphrase. Default is set to `false`
 * `allowSeedlessDevice` — *optional* `boolean` allows to use TrezorConnect methods with device with seedless setup. Default is set to `false`
-* `keepSession` — `optional boolean` Advanced feature. After method return a response device session will NOT! be released. Session shoul be released after all calls are performed by calling any method with `keepSession` set to false or `undefined`. Useful when you need to do multiple different calls to TrezorConnect API without releasing. Example sequence loop for 10 account should look like: 
+* `keepSession` — `optional boolean` Advanced feature. After method return a response device session will NOT! be released. Session should be released after all calls are performed by calling any method with `keepSession` set to false or `undefined`. Useful when you need to do multiple different calls to TrezorConnect API without releasing. Example sequence loop for 10 account should look like: 
     - TrezorConnect.getPublicKey({ device: { path: "web01"}, keepSession: true, ...otherParams }) for first account,
     - Trezor.getAddress({ device: { path: "web01"}, ...otherParams }) for the same account,
     - looking up for balance in external blockchain
     - loop iteration
     - after last iteration call TrezorConnect.getFeatures({ device: { path: "web01"}, keepSession: false, ...otherParams })
+* useCardanoDerivation - *optional* `boolean`. default is set to `true` for all cardano related methods, otherwise it is set to `false`. This parameter determines whether device should derive cardano seed for current session. Derivation of cardano seed takes longer then it does for other coins. A wallet that works with both cardano and other coins might want to set this param to `true` for every call or it must be able to cope with the following scenario:
+    - Connected device is using passhprase
+    - Wallet calls `getPublicKey` with `useCardanoDerivation=false`, passhprase is entered, seed derived
+    - Wallet calls `cardanoGetPublicKey`.
+    - At this moment user will be prompted to enter passhprase again.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-connect",
-    "version": "8.2.3-beta.2",
+    "version": "8.2.3-beta.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/scripts/protobuf-types.js
+++ b/scripts/protobuf-types.js
@@ -167,6 +167,7 @@ const ORDER = {
     CardanoAssetGroupType: 'CardanoTxOutputType',
     CardanoTokenType: 'CardanoAssetGroupType',
     TxAck: 'TxAckInputWrapper',
+    EthereumFieldType: 'EthereumStructMember',
 };
 Object.keys(ORDER).forEach(key => {
     // find indexes

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1255,6 +1255,13 @@
                                     "type": "DecredStakingSpendType",
                                     "name": "decred_staking_spend",
                                     "id": 18
+                                },
+                                {
+                                    "rule": "optional",
+                                    "options": {},
+                                    "type": "bytes",
+                                    "name": "script_pubkey",
+                                    "id": 19
                                 }
                             ],
                             "enums": [],
@@ -1480,6 +1487,13 @@
                     "type": "DecredStakingSpendType",
                     "name": "decred_staking_spend",
                     "id": 18
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "script_pubkey",
+                    "id": 19
                 }
             ],
             "enums": [],
@@ -2234,6 +2248,13 @@
                     "type": "CardanoNativeScriptHashDisplayFormat",
                     "name": "display_format",
                     "id": 2
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoDerivationType",
+                    "name": "derivation_type",
+                    "id": 3
                 }
             ],
             "enums": [],
@@ -2347,6 +2368,13 @@
                     "type": "CardanoAddressParametersType",
                     "name": "address_parameters",
                     "id": 5
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoDerivationType",
+                    "name": "derivation_type",
+                    "id": 6
                 }
             ],
             "enums": [],
@@ -2386,6 +2414,13 @@
                     "type": "bool",
                     "name": "show_display",
                     "id": 2
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoDerivationType",
+                    "name": "derivation_type",
+                    "id": 3
                 }
             ],
             "enums": [],
@@ -2509,6 +2544,13 @@
                     "type": "uint32",
                     "name": "minting_asset_groups_count",
                     "id": 13
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "CardanoDerivationType",
+                    "name": "derivation_type",
+                    "id": 14
                 }
             ],
             "enums": [],
@@ -5578,6 +5620,225 @@
             "oneofs": {}
         },
         {
+            "name": "EthereumSignTypedData",
+            "fields": [
+                {
+                    "rule": "repeated",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "address_n",
+                    "id": 1
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "string",
+                    "name": "primary_type",
+                    "id": 2
+                },
+                {
+                    "rule": "optional",
+                    "options": {
+                        "default": true
+                    },
+                    "type": "bool",
+                    "name": "metamask_v4_compat",
+                    "id": 3
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "EthereumTypedDataStructRequest",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "string",
+                    "name": "name",
+                    "id": 1
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "EthereumTypedDataStructAck",
+            "fields": [
+                {
+                    "rule": "repeated",
+                    "options": {},
+                    "type": "EthereumStructMember",
+                    "name": "members",
+                    "id": 1
+                }
+            ],
+            "enums": [
+                {
+                    "name": "EthereumDataType",
+                    "values": [
+                        {
+                            "name": "UINT",
+                            "id": 1
+                        },
+                        {
+                            "name": "INT",
+                            "id": 2
+                        },
+                        {
+                            "name": "BYTES",
+                            "id": 3
+                        },
+                        {
+                            "name": "STRING",
+                            "id": 4
+                        },
+                        {
+                            "name": "BOOL",
+                            "id": 5
+                        },
+                        {
+                            "name": "ADDRESS",
+                            "id": 6
+                        },
+                        {
+                            "name": "ARRAY",
+                            "id": 7
+                        },
+                        {
+                            "name": "STRUCT",
+                            "id": 8
+                        }
+                    ],
+                    "options": {}
+                }
+            ],
+            "messages": [
+                {
+                    "name": "EthereumStructMember",
+                    "fields": [
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "EthereumFieldType",
+                            "name": "type",
+                            "id": 1
+                        },
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "string",
+                            "name": "name",
+                            "id": 2
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "EthereumFieldType",
+                    "fields": [
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "EthereumDataType",
+                            "name": "data_type",
+                            "id": 1
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint32",
+                            "name": "size",
+                            "id": 2
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "EthereumFieldType",
+                            "name": "entry_type",
+                            "id": 3
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "string",
+                            "name": "struct_name",
+                            "id": 4
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                }
+            ],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "EthereumTypedDataValueRequest",
+            "fields": [
+                {
+                    "rule": "repeated",
+                    "options": {},
+                    "type": "uint32",
+                    "name": "member_path",
+                    "id": 1
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "EthereumTypedDataValueAck",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "value",
+                    "id": 1
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
+            "name": "EthereumTypedDataSignature",
+            "fields": [
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "bytes",
+                    "name": "signature",
+                    "id": 1
+                },
+                {
+                    "rule": "required",
+                    "options": {},
+                    "type": "string",
+                    "name": "address",
+                    "id": 2
+                }
+            ],
+            "enums": [],
+            "messages": [],
+            "options": {},
+            "oneofs": {}
+        },
+        {
             "name": "EthereumGetPublicKey",
             "fields": [
                 {
@@ -6012,6 +6273,13 @@
                     "type": "bytes",
                     "name": "session_id",
                     "id": 1
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bool",
+                    "name": "derive_cardano",
+                    "id": 3
                 }
             ],
             "enums": [],
@@ -11228,6 +11496,24 @@
             "options": {}
         },
         {
+            "name": "CardanoDerivationType",
+            "values": [
+                {
+                    "name": "LEDGER",
+                    "id": 0
+                },
+                {
+                    "name": "ICARUS",
+                    "id": 1
+                },
+                {
+                    "name": "ICARUS_TREZOR",
+                    "id": 2
+                }
+            ],
+            "options": {}
+        },
+        {
             "name": "CardanoAddressType",
             "values": [
                 {
@@ -11825,6 +12111,30 @@
                 {
                     "name": "MessageType_EthereumMessageSignature",
                     "id": 66
+                },
+                {
+                    "name": "MessageType_EthereumSignTypedData",
+                    "id": 464
+                },
+                {
+                    "name": "MessageType_EthereumTypedDataStructRequest",
+                    "id": 465
+                },
+                {
+                    "name": "MessageType_EthereumTypedDataStructAck",
+                    "id": 466
+                },
+                {
+                    "name": "MessageType_EthereumTypedDataValueRequest",
+                    "id": 467
+                },
+                {
+                    "name": "MessageType_EthereumTypedDataValueAck",
+                    "id": 468
+                },
+                {
+                    "name": "MessageType_EthereumTypedDataSignature",
+                    "id": 469
                 },
                 {
                     "name": "MessageType_NEMGetAddress",

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -572,7 +572,10 @@ export const onCall = async (message: CoreMessage) => {
                         if (uiResp.payload) {
                             // reset internal device state and try again
                             device.setInternalState(undefined);
-                            await device.initialize(method.useEmptyPassphrase);
+                            await device.initialize(
+                                method.useEmptyPassphrase,
+                                method.useCardanoDerivation,
+                            );
                             return inner();
                         }
                         // set new state as requested
@@ -627,6 +630,7 @@ export const onCall = async (message: CoreMessage) => {
             keepSession: method.keepSession,
             useEmptyPassphrase: method.useEmptyPassphrase,
             skipFinalReload: method.skipFinalReload,
+            useCardanoDerivation: method.useCardanoDerivation,
         });
     } catch (error) {
         // corner case: Device was disconnected during authorization

--- a/src/js/core/methods/AbstractMethod.js
+++ b/src/js/core/methods/AbstractMethod.js
@@ -70,6 +70,8 @@ export default class AbstractMethod implements MethodInterface {
 
     network: string;
 
+    useCardanoDerivation: boolean;
+
     +confirmation: () => Promise<boolean>;
 
     +noBackupConfirmation: () => Promise<boolean>;
@@ -132,6 +134,11 @@ export default class AbstractMethod implements MethodInterface {
         this.useDevice = true;
         this.useDeviceState = true;
         this.useUi = true;
+        // should derive cardano seed? respect provided option or fall back to do it only when cardano method is called
+        this.useCardanoDerivation =
+            typeof payload.useCardanoDerivation === 'boolean'
+                ? payload.useCardanoDerivation
+                : payload.method.startsWith('cardano');
     }
 
     setDevice(device: IDevice) {

--- a/src/js/core/methods/CardanoGetAddress.js
+++ b/src/js/core/methods/CardanoGetAddress.js
@@ -17,6 +17,7 @@ import type { CoreMessage } from '../../types';
 import type { CardanoAddress } from '../../types/networks/cardano';
 import { CardanoAddressType } from '../../types/networks/cardano';
 import type { CardanoAddressParametersType, MessageType } from '../../types/trezor/protobuf';
+import { Enum_CardanoDerivationType as CardanoDerivationType } from '../../types/trezor/protobuf';
 
 type Params = {
     ...$ElementType<MessageType, 'CardanoGetAddress'>,
@@ -60,6 +61,7 @@ export default class CardanoGetAddress extends AbstractMethod {
                 { name: 'addressParameters', type: 'object', obligatory: true },
                 { name: 'networkId', type: 'number', obligatory: true },
                 { name: 'protocolMagic', type: 'number', obligatory: true },
+                { name: 'derivationType', type: 'number' },
                 { name: 'address', type: 'string' },
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
@@ -76,6 +78,10 @@ export default class CardanoGetAddress extends AbstractMethod {
                 address: batch.address,
                 protocol_magic: batch.protocolMagic,
                 network_id: batch.networkId,
+                derivation_type:
+                    typeof batch.derivationType !== 'undefined'
+                        ? batch.derivationType
+                        : CardanoDerivationType.ICARUS_TREZOR,
                 show_display: showOnTrezor,
             });
         });
@@ -152,12 +158,19 @@ export default class CardanoGetAddress extends AbstractMethod {
         return uiResp.payload;
     }
 
-    async _call({ address_parameters, protocol_magic, network_id, show_display }: Params) {
+    async _call({
+        address_parameters,
+        protocol_magic,
+        network_id,
+        derivation_type,
+        show_display,
+    }: Params) {
         const cmd = this.device.getCommands();
         const response = await cmd.typedCall('CardanoGetAddress', 'CardanoAddress', {
             address_parameters,
             protocol_magic,
             network_id,
+            derivation_type,
             show_display,
         });
         return response.message;

--- a/src/js/core/methods/CardanoGetNativeScriptHash.js
+++ b/src/js/core/methods/CardanoGetNativeScriptHash.js
@@ -8,12 +8,12 @@ import { validatePath } from '../../utils/pathUtils';
 import type { CoreMessage } from '../../types';
 import type { CardanoNativeScript } from '../../types/networks/cardano';
 import type {
-    CardanoGetNativeScriptHash as CardanoGetNativeScriptHashProto,
     CardanoNativeScript as CardanoNativeScriptProto,
+    MessageType,
 } from '../../types/trezor/protobuf';
+import { Enum_CardanoDerivationType as CardanoDerivationType } from '../../types/trezor/protobuf';
 
-type Params = CardanoGetNativeScriptHashProto;
-
+type Params = $ElementType<MessageType, 'CardanoGetNativeScriptHash'>;
 export default class CardanoGetNativeScriptHash extends AbstractMethod {
     params: Params;
 
@@ -33,6 +33,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod {
         validateParams(payload, [
             { name: 'script', type: 'object', obligatory: true },
             { name: 'displayFormat', type: 'number', obligatory: true },
+            { name: 'derivationType', type: 'number' },
         ]);
 
         this.validateScript(payload.script);
@@ -40,6 +41,10 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod {
         this.params = {
             script: this.scriptToProto(payload.script),
             display_format: payload.displayFormat,
+            derivation_type:
+                typeof payload.derivationType !== 'undefined'
+                    ? payload.derivationType
+                    : CardanoDerivationType.ICARUS_TREZOR,
         };
     }
 
@@ -90,6 +95,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod {
             .typedCall('CardanoGetNativeScriptHash', 'CardanoNativeScriptHash', {
                 script: this.params.script,
                 display_format: this.params.display_format,
+                derivation_type: this.params.derivation_type,
             });
 
         return {

--- a/src/js/core/methods/CardanoGetPublicKey.js
+++ b/src/js/core/methods/CardanoGetPublicKey.js
@@ -11,6 +11,7 @@ import { UiMessage } from '../../message/builder';
 import type { CoreMessage } from '../../types';
 import type { CardanoPublicKey } from '../../types/networks/cardano';
 import type { MessageType } from '../../types/trezor/protobuf';
+import { Enum_CardanoDerivationType as CardanoDerivationType } from '../../types/trezor/protobuf';
 
 export default class CardanoGetPublicKey extends AbstractMethod {
     params: $ElementType<MessageType, 'CardanoGetPublicKey'>[] = [];
@@ -43,6 +44,7 @@ export default class CardanoGetPublicKey extends AbstractMethod {
             // validate incoming parameters for each batch
             validateParams(batch, [
                 { name: 'path', obligatory: true },
+                { name: 'derivationType', type: 'number' },
                 { name: 'showOnTrezor', type: 'boolean' },
             ]);
 
@@ -54,6 +56,10 @@ export default class CardanoGetPublicKey extends AbstractMethod {
 
             this.params.push({
                 address_n: path,
+                derivation_type:
+                    typeof batch.derivationType !== 'undefined'
+                        ? batch.derivationType
+                        : CardanoDerivationType.ICARUS_TREZOR,
                 show_display: showOnTrezor,
             });
         });

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -15,12 +15,14 @@ import {
     Enum_CardanoTxAuxiliaryDataSupplementType as CardanoTxAuxiliaryDataSupplementType,
     Enum_CardanoTxSigningMode as CardanoTxSigningModeEnum,
     Enum_CardanoTxWitnessType as CardanoTxWitnessType,
+    Enum_CardanoDerivationType,
 } from '../../types/trezor/protobuf';
 import type {
     CardanoTxInput,
     CardanoTxWithdrawal,
     CardanoTxAuxiliaryData,
     CardanoTxSigningMode,
+    CardanoDerivationType,
 } from '../../types/trezor/protobuf';
 import type { CoreMessage } from '../../types';
 import type {
@@ -68,6 +70,7 @@ export type CardanoSignTransactionParams = {
     networkId: number,
     witnessPaths: Path[],
     additionalWitnessRequests: Path[],
+    derivationType: CardanoDerivationType,
 };
 
 export default class CardanoSignTransaction extends AbstractMethod {
@@ -113,6 +116,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             { name: 'protocolMagic', type: 'number', obligatory: true },
             { name: 'networkId', type: 'number', obligatory: true },
             { name: 'additionalWitnessRequests', type: 'array', allowEmpty: true },
+            { name: 'derivationType', type: 'number' },
         ]);
 
         const inputsWithPath: InputWithPath[] = payload.inputs.map(input => {
@@ -191,6 +195,10 @@ export default class CardanoSignTransaction extends AbstractMethod {
                 payload.signingMode,
             ),
             additionalWitnessRequests,
+            derivationType:
+                typeof payload.derivationType !== 'undefined'
+                    ? payload.derivationType
+                    : Enum_CardanoDerivationType.ICARUS_TREZOR,
         };
     }
 
@@ -273,6 +281,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             validity_interval_start: this.params.validityIntervalStart,
             witness_requests_count: this.params.witnessPaths.length,
             minting_asset_groups_count: this.params.mint.length,
+            derivation_type: this.params.derivationType,
         };
 
         // init

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -7,7 +7,7 @@ import type { Manifest, ConnectSettings } from '../types';
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION = '8.2.3-beta.2';
+const VERSION = '8.2.3-beta.3';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '8.2.3-beta.2';
+const VERSION = '8.2.3-beta.3';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -11,6 +11,7 @@ import type {
     CardanoTxAuxiliaryDataSupplementType,
     CardanoTxSigningMode,
     CardanoTxWitnessType,
+    CardanoDerivationType,
 } from '../trezor/protobuf';
 
 // GetPublicKey
@@ -18,6 +19,7 @@ import type {
 export type CardanoGetPublicKey = {
     path: string | number[],
     showOnTrezor?: boolean,
+    derivationType?: CardanoDerivationType,
 };
 
 export type CardanoPublicKey = {
@@ -50,6 +52,7 @@ export type CardanoGetAddress = {
     networkId: number,
     address?: string,
     showOnTrezor?: boolean,
+    derivationType?: CardanoDerivationType,
 };
 
 export type CardanoAddress = {
@@ -76,6 +79,7 @@ export type CardanoNativeScript = {
 export type CardanoGetNativeScriptHash = {
     script: CardanoNativeScript,
     displayFormat: CardanoNativeScriptHashDisplayFormat,
+    derivationType?: CardanoDerivationType,
 };
 
 export type CardanoNativeScriptHash = {
@@ -190,6 +194,7 @@ export type CardanoSignTransaction = {
     protocolMagic: number,
     networkId: number,
     signingMode: CardanoTxSigningMode,
+    derivationType?: CardanoDerivationType,
 };
 
 export type CardanoSignedTxWitness = {

--- a/src/js/types/params.js
+++ b/src/js/types/params.js
@@ -60,6 +60,7 @@ export type CommonParams = {
     allowSeedlessDevice?: boolean,
     keepSession?: boolean,
     skipFinalReload?: boolean,
+    useCardanoDerivaton?: boolean,
 };
 
 export type Bundle<T> = {

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -35,6 +35,13 @@ export const Enum_AmountUnit = Object.freeze({
 });
 export type AmountUnit = $Values<typeof Enum_AmountUnit>;
 
+export const Enum_CardanoDerivationType = Object.freeze({
+    LEDGER: 0,
+    ICARUS: 1,
+    ICARUS_TREZOR: 2,
+});
+export type CardanoDerivationType = $Values<typeof Enum_CardanoDerivationType>;
+
 export const Enum_CardanoAddressType = Object.freeze({
     BASE: 0,
     BASE_SCRIPT_KEY: 1,
@@ -381,6 +388,7 @@ export type TxInputType = {
     orig_hash?: string,
     orig_index?: number,
     decred_staking_spend?: DecredStakingSpendType,
+    script_pubkey?: string,
 };
 
 export type TxOutputBinType = {
@@ -443,6 +451,7 @@ export type TxInput = {
     orig_hash?: string,
     orig_index?: number,
     decred_staking_spend?: DecredStakingSpendType,
+    script_pubkey?: string,
 };
 
 // TxOutput
@@ -639,6 +648,7 @@ export type CardanoNativeScript = {
 export type CardanoGetNativeScriptHash = {
     script: CardanoNativeScript,
     display_format: CardanoNativeScriptHashDisplayFormat,
+    derivation_type: CardanoDerivationType,
 };
 
 // CardanoNativeScriptHash
@@ -663,6 +673,7 @@ export type CardanoGetAddress = {
     protocol_magic: number,
     network_id: number,
     address_parameters: CardanoAddressParametersType,
+    derivation_type: CardanoDerivationType,
 };
 
 // CardanoAddress
@@ -674,6 +685,7 @@ export type CardanoAddress = {
 export type CardanoGetPublicKey = {
     address_n: number[],
     show_display?: boolean,
+    derivation_type: CardanoDerivationType,
 };
 
 // CardanoPublicKey
@@ -697,6 +709,7 @@ export type CardanoSignTxInit = {
     validity_interval_start?: string | number,
     witness_requests_count: number,
     minting_asset_groups_count: number,
+    derivation_type: CardanoDerivationType,
 };
 
 // CardanoTxInput
@@ -1354,6 +1367,63 @@ export type EosSignedTx = {
     signature: string,
 };
 
+// EthereumSignTypedData
+export type EthereumSignTypedData = {
+    address_n: number[],
+    primary_type: string,
+    metamask_v4_compat?: boolean,
+};
+
+// EthereumTypedDataStructRequest
+export type EthereumTypedDataStructRequest = {
+    name: string,
+};
+
+export const Enum_EthereumDataType = Object.freeze({
+    UINT: 1,
+    INT: 2,
+    BYTES: 3,
+    STRING: 4,
+    BOOL: 5,
+    ADDRESS: 6,
+    ARRAY: 7,
+    STRUCT: 8,
+});
+export type EthereumDataType = $Values<typeof Enum_EthereumDataType>;
+
+export type EthereumFieldType = {
+    data_type: EthereumDataType,
+    size?: number,
+    entry_type?: EthereumFieldType,
+    struct_name?: string,
+};
+
+export type EthereumStructMember = {
+    type: EthereumFieldType,
+    name: string,
+};
+
+// EthereumTypedDataStructAck
+export type EthereumTypedDataStructAck = {
+    members: EthereumStructMember[],
+};
+
+// EthereumTypedDataValueRequest
+export type EthereumTypedDataValueRequest = {
+    member_path: number[],
+};
+
+// EthereumTypedDataValueAck
+export type EthereumTypedDataValueAck = {
+    value: string,
+};
+
+// EthereumTypedDataSignature
+export type EthereumTypedDataSignature = {
+    signature: string,
+    address: string,
+};
+
 // EthereumGetPublicKey
 export type EthereumGetPublicKey = {
     address_n: number[],
@@ -1447,6 +1517,7 @@ export type EthereumVerifyMessage = {
 // Initialize
 export type Initialize = {
     session_id?: string,
+    derive_cardano?: boolean,
 };
 
 // GetFeatures
@@ -2229,7 +2300,7 @@ export type MessageType = {
     CardanoAddressParametersType: $Exact<CardanoAddressParametersType>,
     CardanoGetAddress: $Exact<CardanoGetAddress>,
     CardanoAddress: $Exact<CardanoAddress>,
-    CardanoGetPublicKey: CardanoGetPublicKey,
+    CardanoGetPublicKey: $Exact<CardanoGetPublicKey>,
     CardanoPublicKey: $Exact<CardanoPublicKey>,
     CardanoSignTxInit: $Exact<CardanoSignTxInit>,
     CardanoTxInput: $Exact<CardanoTxInput>,
@@ -2324,6 +2395,14 @@ export type MessageType = {
     EosActionUnknown: $Exact<EosActionUnknown>,
     EosTxActionAck: EosTxActionAck,
     EosSignedTx: $Exact<EosSignedTx>,
+    EthereumSignTypedData: $Exact<EthereumSignTypedData>,
+    EthereumTypedDataStructRequest: $Exact<EthereumTypedDataStructRequest>,
+    EthereumFieldType: $Exact<EthereumFieldType>,
+    EthereumStructMember: $Exact<EthereumStructMember>,
+    EthereumTypedDataStructAck: EthereumTypedDataStructAck,
+    EthereumTypedDataValueRequest: EthereumTypedDataValueRequest,
+    EthereumTypedDataValueAck: $Exact<EthereumTypedDataValueAck>,
+    EthereumTypedDataSignature: $Exact<EthereumTypedDataSignature>,
     EthereumGetPublicKey: EthereumGetPublicKey,
     EthereumPublicKey: $Exact<EthereumPublicKey>,
     EthereumGetAddress: EthereumGetAddress,

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -9,6 +9,7 @@ import {
     CardanoTxAuxiliaryDataSupplementType,
     CardanoTxSigningMode,
     CardanoTxWitnessType,
+    CardanoDerivationType,
 } from '../trezor/protobuf';
 
 // GetPublicKey
@@ -16,6 +17,7 @@ import {
 export interface CardanoGetPublicKey {
     path: string | number[];
     showOnTrezor?: boolean;
+    derivationType?: CardanoDerivationType;
 }
 
 export interface CardanoPublicKey {
@@ -49,6 +51,7 @@ export interface CardanoGetAddress {
     networkId: number;
     address?: string;
     showOnTrezor?: boolean;
+    derivationType?: CardanoDerivationType;
 }
 
 export interface CardanoAddress {
@@ -75,6 +78,7 @@ export interface CardanoNativeScript {
 export interface CardanoGetNativeScriptHash {
     script: CardanoNativeScript;
     displayFormat: CardanoNativeScriptHashDisplayFormat;
+    derivationType?: CardanoDerivationType;
 }
 
 export interface CardanoNativeScriptHash {
@@ -189,6 +193,7 @@ export interface CardanoSignTransaction {
     protocolMagic: number;
     networkId: number;
     signingMode: CardanoTxSigningMode;
+    derivationType?: CardanoDerivationType;
 }
 
 export type CardanoSignedTxWitness = {

--- a/src/ts/types/params.d.ts
+++ b/src/ts/types/params.d.ts
@@ -58,6 +58,7 @@ export interface CommonParams {
     allowSeedlessDevice?: boolean;
     keepSession?: boolean;
     skipFinalReload?: boolean;
+    useCardanoDerivation?: boolean;
 }
 
 export interface Bundle<T> {

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -32,6 +32,12 @@ export enum AmountUnit {
     SATOSHI = 3,
 }
 
+export enum CardanoDerivationType {
+    LEDGER = 0,
+    ICARUS = 1,
+    ICARUS_TREZOR = 2,
+}
+
 export enum CardanoAddressType {
     BASE = 0,
     BASE_SCRIPT_KEY = 1,
@@ -362,6 +368,7 @@ export type TxInputType = {
     orig_hash?: string;
     orig_index?: number;
     decred_staking_spend?: DecredStakingSpendType;
+    script_pubkey?: string;
 };
 
 export type TxOutputBinType = {
@@ -421,6 +428,7 @@ export type TxInput = {
     orig_hash?: string;
     orig_index?: number;
     decred_staking_spend?: DecredStakingSpendType;
+    script_pubkey?: string;
 };
 
 // TxOutput
@@ -612,6 +620,7 @@ export type CardanoNativeScript = {
 export type CardanoGetNativeScriptHash = {
     script: CardanoNativeScript;
     display_format: CardanoNativeScriptHashDisplayFormat;
+    derivation_type: CardanoDerivationType;
 };
 
 // CardanoNativeScriptHash
@@ -636,6 +645,7 @@ export type CardanoGetAddress = {
     protocol_magic: number;
     network_id: number;
     address_parameters: CardanoAddressParametersType;
+    derivation_type: CardanoDerivationType;
 };
 
 // CardanoAddress
@@ -647,6 +657,7 @@ export type CardanoAddress = {
 export type CardanoGetPublicKey = {
     address_n: number[];
     show_display?: boolean;
+    derivation_type: CardanoDerivationType;
 };
 
 // CardanoPublicKey
@@ -670,6 +681,7 @@ export type CardanoSignTxInit = {
     validity_interval_start?: string | number;
     witness_requests_count: number;
     minting_asset_groups_count: number;
+    derivation_type: CardanoDerivationType;
 };
 
 // CardanoTxInput
@@ -1325,6 +1337,62 @@ export type EosSignedTx = {
     signature: string;
 };
 
+// EthereumSignTypedData
+export type EthereumSignTypedData = {
+    address_n: number[];
+    primary_type: string;
+    metamask_v4_compat?: boolean;
+};
+
+// EthereumTypedDataStructRequest
+export type EthereumTypedDataStructRequest = {
+    name: string;
+};
+
+export enum EthereumDataType {
+    UINT = 1,
+    INT = 2,
+    BYTES = 3,
+    STRING = 4,
+    BOOL = 5,
+    ADDRESS = 6,
+    ARRAY = 7,
+    STRUCT = 8,
+}
+
+export type EthereumFieldType = {
+    data_type: EthereumDataType;
+    size?: number;
+    entry_type?: EthereumFieldType;
+    struct_name?: string;
+};
+
+export type EthereumStructMember = {
+    type: EthereumFieldType;
+    name: string;
+};
+
+// EthereumTypedDataStructAck
+export type EthereumTypedDataStructAck = {
+    members: EthereumStructMember[];
+};
+
+// EthereumTypedDataValueRequest
+export type EthereumTypedDataValueRequest = {
+    member_path: number[];
+};
+
+// EthereumTypedDataValueAck
+export type EthereumTypedDataValueAck = {
+    value: string;
+};
+
+// EthereumTypedDataSignature
+export type EthereumTypedDataSignature = {
+    signature: string;
+    address: string;
+};
+
 // EthereumGetPublicKey
 export type EthereumGetPublicKey = {
     address_n: number[];
@@ -1418,6 +1486,7 @@ export type EthereumVerifyMessage = {
 // Initialize
 export type Initialize = {
     session_id?: string;
+    derive_cardano?: boolean;
 };
 
 // GetFeatures


### PR DESCRIPTION
In this PR I would like to implement trezor-firmware changes as proposed here https://github.com/trezor/trezor-firmware/pull/1873

So far I have only added the additional params `derive_cardano` and `derivation_type`. Work in progress. 

> If the user has BIP-39 seed, and Initialize(derive_cardano=True) is not sent, all Cardano calls will fail because the root secret will not be available. The only way to preserve compatibility here would be to use True as default -- but that would incur start-up delay for all other wallets, which is undesirable.

- I believe we need a default value to be sent from Connect as we can't reasonably expect all 3rd parties to change their implementations. 
- the question is what value shoudl we decide for. My initial idea was to send `derive_cardano=true` unless specified otherwise for some period of time and with a next release change this fallback to `derive_cardano=false`. This is the defensive strategy. If we are sure that there are no wallets that support cardano together with other coins, we can safely set the aformentioned fallback to `derive_cardano=false`. 
 
> The cardano_derivation argument is required on every Cardano call. We could set a default value here. But it would have to be Icarus-Trezor (otherwise the wallets would silently start using a different derivation for people with 24-word seeds). And we kind of want the default to be Icarus going forward --- especially for new users creating new accounts. (This is why trezorctl already defaults to Icarus.)  This way, we pass the "default value" question onto Connect. Personally I believe that Connect should also require the argument and pass the decision to individual wallets, but this is up for debate with the Connect team.

- I believe we need a default value to be sent from Connect as we can't reasonably expect all 3rd parties to change their implementations. 
- TODO: Icarus-Trezor? 

