### PR TITLE
feat: AOPP support for signMessage method

### DIFF
--- a/src/data/config.json
+++ b/src/data/config.json
@@ -157,9 +157,12 @@
             "comment": ["new eth transaction pricing mechanism (EIP1559) since 1.10.4/2.4.2"]
         },
         {
-            "capabilities": ["taproot"],
+            "capabilities": ["taproot", "aopp"],
             "min": ["1.10.4", "2.4.3"],
-            "comment": ["new btc accounts taproot since 1.10.4/2.4.3 (BTC + TEST only)"]
+            "comment": [
+                "new btc accounts taproot since 1.10.4/2.4.3 (BTC + TEST only)",
+                "SignMessage with AOPP support"
+            ]
         }
     ]
 }

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -711,6 +711,13 @@
                     "type": "InputScriptType",
                     "name": "script_type",
                     "id": 4
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "bool",
+                    "name": "no_script_type",
+                    "id": 5
                 }
             ],
             "enums": [],

--- a/src/js/core/methods/SignMessage.js
+++ b/src/js/core/methods/SignMessage.js
@@ -24,6 +24,7 @@ export default class SignMessage extends AbstractMethod {
             { name: 'coin', type: 'string' },
             { name: 'message', type: 'string', obligatory: true },
             { name: 'hex', type: 'boolean' },
+            { name: 'no_script_type', type: 'boolean' },
         ]);
 
         const path = validatePath(payload.path);
@@ -37,10 +38,13 @@ export default class SignMessage extends AbstractMethod {
 
         this.info = getLabel('Sign #NETWORK message', coinInfo);
 
-        if (coinInfo) {
-            // check required firmware with coinInfo support
-            this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
-        }
+        // firmware range depends on used no_script_type parameter
+        // AOPP is possible since 1.10/42.4.3
+        this.firmwareRange = getFirmwareRange(
+            payload.no_script_type ? 'aopp' : this.name,
+            coinInfo,
+            this.firmwareRange,
+        );
 
         const messageHex = payload.hex
             ? messageToHex(payload.message)
@@ -51,6 +55,7 @@ export default class SignMessage extends AbstractMethod {
             message: messageHex,
             coin_name: coinInfo ? coinInfo.name : undefined,
             script_type: scriptType && scriptType !== 'SPENDMULTISIG' ? scriptType : 'SPENDADDRESS', // script_type 'SPENDMULTISIG' throws Failure_FirmwareError
+            no_script_type: payload.no_script_type,
         };
     }
 

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -301,6 +301,7 @@ export type SignMessage = {
     message: string,
     coin_name?: string,
     script_type?: InputScriptType,
+    no_script_type?: boolean,
 };
 
 // MessageSignature

--- a/src/js/utils/__tests__/deviceFeaturesUtils.test.js
+++ b/src/js/utils/__tests__/deviceFeaturesUtils.test.js
@@ -119,6 +119,7 @@ describe('utils/deviceFeaturesUtils', () => {
             decreaseOutput: 'update-required',
             eip1559: 'update-required',
             taproot: 'update-required',
+            aopp: 'update-required',
         });
 
         const feat2 = {
@@ -135,6 +136,7 @@ describe('utils/deviceFeaturesUtils', () => {
             decreaseOutput: 'update-required',
             eip1559: 'update-required',
             taproot: 'update-required',
+            aopp: 'update-required',
         });
 
         // added new capability

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -282,6 +282,7 @@ export type SignMessage = {
     message: string;
     coin_name?: string;
     script_type?: InputScriptType;
+    no_script_type?: boolean;
 };
 
 // MessageSignature

--- a/tests/__fixtures__/signMessage.js
+++ b/tests/__fixtures__/signMessage.js
@@ -187,5 +187,53 @@ export default {
                 ).toString('base64'),
             },
         },
+        {
+            description: 'BTC AOPP p2pkh',
+            params: {
+                coin: 'Bitcoin',
+                path: ADDRESS_N("m/44'/0'/0'/0/0"),
+                message: 'This is an example of a signed message.',
+                no_script_type: true,
+            },
+            result: {
+                address: '1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL',
+                signature: Buffer.from(
+                    '20fd8f2f7db5238fcdd077d5204c3e6949c261d700269cefc1d9d2dcef6b95023630ee617f6c8acf9eb40c8edd704c9ca74ea4afc393f43f35b4e8958324cbdd1c',
+                    'hex',
+                ).toString('base64'),
+            },
+        },
+        {
+            description: 'BTC AOPP p2sh',
+            params: {
+                coin: 'Bitcoin',
+                path: ADDRESS_N("m/49'/0'/0'/0/0"),
+                message: 'This is an example of a signed message.',
+                no_script_type: true,
+            },
+            result: {
+                address: '3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2',
+                signature: Buffer.from(
+                    '1f744de4516fac5c140808015664516a32fead94de89775cec7e24dbc24fe133075ac09301c4cc8e197bea4b6481661d5b8e9bf19d8b7b8a382ecdb53c2ee0750d',
+                    'hex',
+                ).toString('base64'),
+            },
+        },
+        {
+            description: 'BTC AOPP p2wpkh',
+            params: {
+                coin: 'Bitcoin',
+                path: ADDRESS_N("m/84'/0'/0'/0/0"),
+                message: 'This is an example of a signed message.',
+                no_script_type: true,
+            },
+            result: {
+                address: 'bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk',
+                signature: Buffer.from(
+                    '20b55d7600d9e9a7e2a49155ddf3cfdb8e796c207faab833010fa41fb7828889bc47cf62348a7aaa0923c0832a589fab541e8f12eb54fb711c90e2307f0f66b194',
+                    'hex',
+                ).toString('base64'),
+            },
+        },
     ],
 };


### PR DESCRIPTION
closes https://github.com/trezor/connect/issues/941

- added capability/feature to config.json
- added fallback for older firmware when using `no_script_type` option

 
![Screenshot from 2021-11-16 13-56-58](https://user-images.githubusercontent.com/3435913/141990389-ed56b1da-041d-402e-a495-db4bea00c74e.png)


