### PR TITLE
tests: stellar 2.4.2 fixtures and _ensureFeatureIsSupported

### DIFF
--- a/tests/__fixtures__/stellarSignTransaction.js
+++ b/tests/__fixtures__/stellarSignTransaction.js
@@ -134,6 +134,35 @@ const transformOperation = op => {
     }
 };
 
+const legacyResults = [
+    {
+        rules: ['<2.4.3'],
+        payload: false,
+    },
+];
+
+const legacyResultsMap = {
+    // newly added message in 2.4.3
+    StellarManageBuyOfferOp: legacyResults,
+    // newly added message in 2.4.3
+    StellarPathPaymentStrictSendOp: legacyResults,
+    'timebounds-0-0': [
+        {
+            rules: ['<2.4.3'],
+            payload: {
+                publicKey: '2f22b9c62f08b774f3ebe6dd6e7db93c3ec2cbde0279561a3d9c5225b8c32292',
+                // signature is different in 2.4.2 from what we get from 2-master
+                signature:
+                    '864eb69e7ecb30b0a27112742716ccfedf38167a78ffdb1890bd4d473f2ab4850f3e6e5523d88dfad7b7b308369406d69abb9ecaf8dfb7a87ed4e8b57bfc2201',
+            },
+        },
+        {
+            rules: ['<2.3.0'],
+            payload: false,
+        },
+    ],
+};
+
 export default {
     method: 'stellarSignTransaction',
     setup: {
@@ -165,12 +194,14 @@ export default {
             publicKey: result.public_key,
             signature: Buffer.from(result.signature, 'base64').toString('hex'),
         },
-        legacyResults: [
-            {
-                // stellar has required update
-                rules: ['<2.3.0'],
-                payload: false,
-            },
-        ],
+        legacyResults: legacyResultsMap[name]
+            ? legacyResultsMap[name]
+            : [
+                  {
+                      // stellar has required update
+                      rules: ['<2.3.0'],
+                      payload: false,
+                  },
+              ],
     })),
 };


### PR DESCRIPTION
hello @overcat 

I have just realized that after merging your PR https://github.com/trezor/connect/pull/930 we have problem to run tests against 2.4.2 firmware (which is currently the latest released firmware)

`./tests/run.sh -i stellarSignTransaction -f 2.4.2`

There are 2 problems: 
- unknown messages in older firmwares (StellarManageBuyOfferOp, StellarPathPaymentStrictSendOp). This might be fixed by adding something like this (inspiration from CardanoSign.tx). Basically when you detect that params contain some operation unknown to an older firmware, you may raise some more descriptive error than what is otherwise received from device. 
https://github.com/trezor/connect/blob/b23d81af875173b0f732e17d7ddf51e8a399962a/src/js/core/methods/CardanoSignTransaction.js#L209-L215

- the other problem is that fixture `timebounds-0-0` returns different signature. I would appreciate your input here.


