### PR TITLE
fix: rename skip_passphrase to _skip_passphrase

### DIFF
--- a/src/js/device/Device.js
+++ b/src/js/device/Device.js
@@ -426,7 +426,7 @@ class Device extends EventEmitter {
             if (legacy && !this.isT1()) {
                 payload.state = internalState;
                 if (useEmptyPassphrase) {
-                    payload.skip_passphrase = useEmptyPassphrase;
+                    payload._skip_passphrase = useEmptyPassphrase;
                     payload.state = null;
                 }
             }


### PR DESCRIPTION
Found a bug when I was testing connect changes after https://github.com/trezor/connect/pull/928/files

```
1. suie.trezor.io/web
- connect device
- device asks: device | host
- enter host
- suite asks: standard | hidden
- enter standard
- device asks: enable labeling?
- confirm on device
- done

1. https://suite.corp.sldev.cz/suite-web/develop/web/
- connect device
- device asks: 'device | host
- enter host
- suite asks: standard | hidden
- enter standard
- device asks: enable labeling?
- confirm on device
- device asks: device | host
```

The problem was that original PR did not rename skip_passphrase to _skip_passphrase which is the name now defined in messages.json


