### PR TITLE
docs(Core): increase delay after RebootToBootloader and fix comment

### DIFF
--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -657,9 +657,9 @@ export const onCall = async (message: CoreMessage) => {
 
         if (response) {
             if (method.name === 'rebootToBootloader' && response.success) {
-                // trezord may not detect auto reboot
-                // wait for device to switch to bootloader
-                await resolveAfter(501);
+                // Wait for device to switch to bootloader
+                // This delay is crucial see https://github.com/trezor/trezor-firmware/issues/1983
+                await resolveAfter(1000);
                 // call Device.run with empty function to fetch new Features
                 // (acquire > Initialize > nothing > release)
                 await device.run(() => Promise.resolve(), { skipFinalReload: true });


### PR DESCRIPTION
See this for rationale https://github.com/trezor/trezor-firmware/issues/1983. There is also a suggestion from @hiviah:

> 501 ms is minimum, 1 s should be OK. Although waiting 501 ms, then doing let's say 5 retry calls to GetFeatures until you get response instead of libusb error spaced 100 ms between each retry would make it slightly faster.

Which would be nice but I think we can leave it with 1s for now.