### PR TITLE
feat: Support Ethereum EIP-712 Sign Typed Data for Trezor T

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,8 @@
         "no-unused-vars": [
             "error",
             {
-                "argsIgnorePattern": "^_" // allow underscored args
+                "argsIgnorePattern": "^_", // allow underscored args,
+                "varsIgnorePattern": "^_" // allow underscored variables
             }
         ],
         "no-param-reassign": "off", // TODO: needs refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 ### Changed
 - trezor-link was replaced with @trezor/transport
 
+### Added
+
+- Ethereum: Support for EthereumSignTypedData operation (Trezor T only)
+
 # 8.2.3
 
 ### Added

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -29,6 +29,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 * [TrezorConnect.ethereumGetAddress](methods/ethereumGetAddress.md)
 * [TrezorConnect.ethereumSignTransaction](methods/ethereumSignTransaction.md)
 * [TrezorConnect.ethereumSignMessage](methods/ethereumSignMessage.md)
+* [TrezorConnect.ethereumSignTypedData](methods/ethereumSignTypedData.md)
 * [TrezorConnect.ethereumVerifyMessage](methods/ethereumVerifyMessage.md)
 
 ### Eos

--- a/docs/methods/ethereumSignTypedData.md
+++ b/docs/methods/ethereumSignTypedData.md
@@ -1,0 +1,94 @@
+## Ethereum: Sign Typed Data
+
+Asks device to sign an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data message using the private key derived by given BIP32 path.
+
+User is asked to confirm all signing details on Trezor Model T.
+
+ES6
+
+```javascript
+const result = await TrezorConnect.ethereumSignTypedData(params);
+```
+
+CommonJS
+
+```javascript
+TrezorConnect.ethereumSignTypedData(params).then(function(result) {
+
+});
+```
+
+> :warning: **Supported only by Trezor T with Firmware 2.4.3 or higher!** 
+
+### Params
+
+[****Optional common params****](commonParams.md)
+
+###### [flowtype](../../src/js/types/networks/ethereum.js#L102-105)
+
+* `path` — *obligatory* `string | Array<number>` minimum length is `3`. [read more](path.md)
+* `data` - *obligatory* `Object` type of [`EthereumSignTypedDataMessage`](../../src/js/types/networks/ethereum.js#L90)`. A JSON Schema definition can be found in the [EIP-712 spec]([EIP-712](https://eips.ethereum.org/EIPS/eip-712)).
+* `metamask_v4_compat` - *obligatory* `boolean` set to `true` for compatibility with [MetaMask's signTypedData_v4](https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4).
+
+### Example
+
+```javascript
+TrezorConnect.ethereumSignMessage({
+    path: "m/44'/60'/0'",
+    data: {
+        types: {
+            EIP712Domain: [
+                {
+                    name: 'name',
+                    type: 'string',
+                },
+            ],
+            Message: [
+                {
+                    name: "Best Wallet",
+                    type: "string"
+                },
+                {
+                    name: "Number",
+                    type: "uint64"
+                }
+            ]
+        },
+        primaryType: 'Message',
+        domain: {
+            name: 'example.trezor.io',
+        },
+        message: {
+            "Best Wallet": "Trezor Model T",
+            // be careful with JavaScript numbers: MAX_SAFE_INTEGER is quite low
+            "Number": `${2n ** 55n}`,
+        },
+    },
+    metamask_v4_compat: true,
+});
+```
+
+### Result
+
+###### [flowtype](../../src/js/types/api.js#L257)
+
+```javascript
+{
+    success: true,
+    payload: {
+        address: string,
+        signature: string, // hexadecimal string with "0x" prefix
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -162,6 +162,11 @@
             "methods": ["signTransaction"],
             "min": ["1.10.1", "2.4.0"],
             "comment": [""]
+        },
+        {
+            "methods": ["ethereumSignTypedData"],
+            "min": ["0", "2.4.3"],
+            "comment": ["EIP-712 typed signing support added in 2.4.3"]
         }
     ]
 }

--- a/src/js/core/methods/EthereumSignTypedData.js
+++ b/src/js/core/methods/EthereumSignTypedData.js
@@ -1,0 +1,163 @@
+/* @flow */
+
+import AbstractMethod from './AbstractMethod';
+import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
+import { validatePath } from '../../utils/pathUtils';
+import { getEthereumNetwork } from '../../data/CoinInfo';
+import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
+import type { CoreMessage, EthereumNetworkInfo } from '../../types';
+import type { MessageResponse, EthereumTypedDataStructAck } from '../../types/trezor/protobuf';
+import { ERRORS } from '../../constants';
+import type { EthereumSignTypedData as EthereumSignTypedDataParams } from '../../types/networks/ethereum';
+import { getFieldType, parseArrayType, encodeData } from './helpers/ethereumSignTypedData';
+
+type Params = {
+    ...EthereumSignTypedDataParams,
+    path: number[],
+    network?: EthereumNetworkInfo,
+};
+
+export default class EthereumSignTypedData extends AbstractMethod {
+    params: Params;
+
+    constructor(message: CoreMessage) {
+        super(message);
+
+        this.requiredPermissions = ['read', 'write'];
+
+        const { payload } = message;
+
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'path', obligatory: true },
+            { name: 'data', type: 'object', obligatory: true },
+            { name: 'metamask_v4_compat', type: 'boolean', obligatory: true },
+        ]);
+
+        const path = validatePath(payload.path, 3);
+        const network = getEthereumNetwork(path);
+        this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+
+        this.info = getNetworkLabel('Sign #NETWORK typed data', network);
+
+        const { data, metamask_v4_compat } = payload;
+
+        this.params = {
+            path,
+            network,
+            data,
+            metamask_v4_compat,
+        };
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+        const { path: address_n, network, data, metamask_v4_compat } = this.params;
+
+        const { types, primaryType, domain, message } = data;
+
+        let response: MessageResponse<
+            | 'EthereumTypedDataStructRequest'
+            | 'EthereumTypedDataValueRequest'
+            | 'EthereumTypedDataSignature',
+        > = await cmd.typedCall(
+            'EthereumSignTypedData',
+            // $FlowIssue typedCall problem with unions in response, TODO: accept unions
+            'EthereumTypedDataStructRequest|EthereumTypedDataValueRequest|EthereumTypedDataSignature',
+            {
+                address_n,
+                primary_type: primaryType,
+                metamask_v4_compat,
+            },
+        );
+
+        // sending all the type data
+        while (response.type === 'EthereumTypedDataStructRequest') {
+            // $FlowIssue disjoint union Refinements not working, TODO: check if new Flow versions fix this
+            const { name: typeDefinitionName } = response.message;
+            const typeDefinition = types[typeDefinitionName];
+            if (typeDefinition === undefined) {
+                throw ERRORS.TypedError(
+                    'Runtime',
+                    `Type ${typeDefinitionName} was not defined in types object`,
+                );
+            }
+            const dataStruckAck: EthereumTypedDataStructAck = {
+                members: typeDefinition.map(({ name, type: typeName }) => ({
+                    name,
+                    type: getFieldType(typeName, types),
+                })),
+            };
+            response = await cmd.typedCall(
+                'EthereumTypedDataStructAck',
+                // $FlowIssue typedCall problem with unions in response, TODO: accept unions
+                'EthereumTypedDataStructRequest|EthereumTypedDataValueRequest|EthereumTypedDataSignature',
+                dataStruckAck,
+            );
+        }
+
+        // sending the whole message to be signed
+        while (response.type === 'EthereumTypedDataValueRequest') {
+            // $FlowIssue disjoint union Refinements not working, TODO: check if new Flow versions fix this
+            const { member_path } = response.message;
+
+            let memberData;
+            let memberTypeName;
+
+            const [rootIndex, ...nestedMemberPath] = member_path;
+            switch (rootIndex) {
+                case 0:
+                    memberData = domain;
+                    memberTypeName = 'EIP712Domain';
+                    break;
+                case 1:
+                    memberData = message;
+                    memberTypeName = primaryType;
+                    break;
+                default:
+                    throw ERRORS.TypedError('Runtime', 'Root index can only be 0 or 1');
+            }
+
+            // It can be asking for a nested structure (the member path being [X, Y, Z, ...])
+            for (const index of nestedMemberPath) {
+                if (Array.isArray(memberData)) {
+                    memberTypeName = parseArrayType(memberTypeName).entryTypeName;
+                    memberData = memberData[index];
+                } else if (typeof memberData === 'object' && memberData !== null) {
+                    const memberTypeDefinition = types[memberTypeName][index];
+                    memberTypeName = memberTypeDefinition.type;
+                    memberData = memberData[memberTypeDefinition.name];
+                } else {
+                    // TODO: what to do when the value is missing (for example in recursive types)?
+                }
+            }
+
+            let encodedData;
+            // If we were asked for a list, first sending its length and we will be receiving
+            // requests for individual elements later
+            if (Array.isArray(memberData)) {
+                // Sending the length as uint16
+                encodedData = encodeData('uint16', memberData.length);
+            } else {
+                encodedData = encodeData(memberTypeName, memberData);
+            }
+
+            // $FlowIssue with `await` and Promises: https://github.com/facebook/flow/issues/5294, TODO: Update flow
+            response = await cmd.typedCall(
+                'EthereumTypedDataValueAck',
+                // $FlowIssue typedCall problem with unions in response, TODO: accept unions
+                'EthereumTypedDataValueRequest|EthereumTypedDataSignature',
+                {
+                    value: encodedData,
+                },
+            );
+        }
+
+        // $FlowIssue disjoint union Refinements not working, TODO: check if new Flow versions fix this
+        const { address, signature } = response.message;
+        return {
+            address: toChecksumAddress(address, network),
+            signature: `0x${signature}`,
+        };
+    }
+}

--- a/src/js/core/methods/helpers/__fixtures__/ethereumSignTypedData.js
+++ b/src/js/core/methods/helpers/__fixtures__/ethereumSignTypedData.js
@@ -1,0 +1,318 @@
+import BigNumber from 'bignumber.js';
+import { TrezorError } from '../../../../constants/errors';
+import { Enum_EthereumDataType } from '../../../../types/trezor/protobuf';
+
+export const parseArrayType = [
+    {
+        description: 'should parse sized arrays',
+        input: 'uint8[26]',
+        output: {
+            entryTypeName: 'uint8',
+            arraySize: 26,
+        },
+    },
+    {
+        description: 'should parse dynamic arrays',
+        input: 'int32[]',
+        output: {
+            entryTypeName: 'int32',
+            arraySize: null,
+        },
+    },
+    {
+        // Decode last [] first
+        // Can't find an official source, but this is what Metamask's signTypedData_v4 does:
+        // https://github.com/MetaMask/eth-sig-util/blob/5f2259463990050606cd58b43e64e4bffcb715f4/src/sign-typed-data.ts#L202-L211
+        description: 'should parse nested arrays',
+        input: 'int32[5][12]',
+        output: {
+            entryTypeName: 'int32[5]',
+            arraySize: 12,
+        },
+    },
+    {
+        description: 'should throw error for non-array type',
+        input: 'bytes',
+        error: [TrezorError, 'could not be parsed'],
+    },
+];
+
+export const getFieldType = [
+    {
+        description: `should parse uints`,
+        input: {
+            typeName: 'uint256',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.UINT,
+            size: 32,
+        },
+    },
+    {
+        description: `should parse ints`,
+        input: {
+            typeName: 'int8',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.INT,
+            size: 1,
+        },
+    },
+    {
+        description: `should parse booleans`,
+        input: {
+            typeName: 'bool',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.BOOL,
+        },
+    },
+    {
+        description: `should parse address`,
+        input: {
+            typeName: 'address',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.ADDRESS,
+        },
+    },
+    {
+        description: `should parse dynamic bytes`,
+        input: {
+            typeName: 'bytes',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.BYTES,
+            size: undefined,
+        },
+    },
+    {
+        description: `should parse fixed-size bytes`,
+        input: {
+            typeName: 'bytes18',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.BYTES,
+            size: 18,
+        },
+    },
+    {
+        description: `should parse array types`,
+        input: {
+            typeName: 'uint256[57]',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.ARRAY,
+            size: 57,
+            entry_type: {
+                data_type: Enum_EthereumDataType.UINT,
+                size: 32,
+            },
+        },
+    },
+    {
+        description: `should parse dynamic array types`,
+        input: {
+            typeName: 'uint256[]',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.ARRAY,
+            size: undefined,
+            entry_type: {
+                data_type: Enum_EthereumDataType.UINT,
+                size: 32,
+            },
+        },
+    },
+    {
+        // Unsupported in Trezor firmware as of v2.4.3
+        description: 'should parse nested arrays',
+        input: {
+            typeName: 'int32[5][12]',
+            types: {},
+        },
+        output: {
+            data_type: Enum_EthereumDataType.ARRAY,
+            size: 12,
+            entry_type: {
+                data_type: Enum_EthereumDataType.ARRAY,
+                size: 5,
+                entry_type: {
+                    data_type: Enum_EthereumDataType.INT,
+                    size: 4,
+                },
+            },
+        },
+    },
+    {
+        description: `should parse Struct types`,
+        input: {
+            typeName: 'ExampleStruct',
+            types: {
+                ExampleStruct: [
+                    { name: 'message', type: 'string' },
+                    { name: 'cost', type: 'int8' },
+                ],
+            },
+        },
+        output: {
+            data_type: Enum_EthereumDataType.STRUCT,
+            size: 2,
+            struct_name: 'ExampleStruct',
+        },
+    },
+    {
+        description: `should throw if Struct type not defined`,
+        input: {
+            typeName: 'MissingType',
+            types: {
+                // empty
+            },
+        },
+        error: [TrezorError, 'No type definition specified: MissingType'],
+    },
+];
+
+export const encodeData = [
+    {
+        description: 'should remove leading `0x` from byte hex-string',
+        input: {
+            typeName: 'bytes',
+            data: '0x123456789abcdef',
+        },
+        output: '123456789abcdef',
+    },
+    {
+        description: 'should remove leading `0x` from Ethereum address',
+        input: {
+            typeName: 'address',
+            data: '0x000000000000000000000000000000000000dead',
+        },
+        output: '000000000000000000000000000000000000dead',
+    },
+    // INTEGER CONVERSIONS
+    {
+        description: `should encode unsigned integers`,
+        input: {
+            typeName: 'uint8',
+            data: 255,
+        },
+        output: 'ff',
+    },
+    {
+        description: `should encode positive signed integers`,
+        input: {
+            typeName: 'int8',
+            data: 127,
+        },
+        output: '7f',
+    },
+    {
+        description: `should encode negative signed integers`,
+        input: {
+            typeName: 'int8',
+            data: -1,
+        },
+        output: 'ff',
+    },
+    {
+        description: `should encode int from bigint`,
+        input: {
+            typeName: 'int256',
+            // `1n << 254n` instead of `2n ** 254n` since Babel replaces ** with Math.pow()
+            data: -(1n << 254n) + 1n,
+        },
+        // Python (-(2 ** 254) + 1).to_bytes(32, "big", signed=True).hex()
+        output: 'c000000000000000000000000000000000000000000000000000000000000001',
+    },
+    {
+        description: `should encode int from string`,
+        input: {
+            typeName: 'int256',
+            data: `${-(1n << 254n) + 1n}`,
+        },
+        // Python (-(2 ** 254) + 1).to_bytes(32, "big", signed=True).hex()
+        output: 'c000000000000000000000000000000000000000000000000000000000000001',
+    },
+    {
+        description: `should encode int from BigNumber`,
+        input: {
+            typeName: 'int256',
+            data: new BigNumber(2).pow(254).negated().plus(1),
+        },
+        // Python (-(2 ** 254) + 1).to_bytes(32, "big", signed=True).hex()
+        output: 'c000000000000000000000000000000000000000000000000000000000000001',
+    },
+    {
+        description: `should throw overflow error when signed int is too large`,
+        input: {
+            typeName: 'int8',
+            data: 128,
+        },
+        error: [TrezorError, 'overflow'],
+    },
+    {
+        description: `should throw overflow error when signed int is too small`,
+        input: {
+            typeName: 'int8',
+            data: -129,
+        },
+        error: [TrezorError, 'overflow'],
+    },
+    {
+        description: `should throw overflow error when unsigned int is too large`,
+        input: {
+            typeName: 'uint8',
+            data: 256,
+        },
+        error: [TrezorError, 'overflow'],
+    },
+    {
+        description: `should throw error when unsigned int is negative`,
+        input: {
+            typeName: 'uint8',
+            data: -1,
+        },
+        error: [TrezorError, 'negative'],
+    },
+    {
+        description: 'should encode string as utf-8',
+        input: {
+            typeName: 'string',
+            data: 'Trezor Model T is an amazing piece of hardware. 😋😋',
+        },
+        output: '5472657a6f72204d6f64656c205420697320616e20616d617a696e67207069656365206f662068617264776172652e20f09f988bf09f988b',
+    },
+    {
+        description: 'should encode bool as a single byte',
+        input: {
+            typeName: 'bool',
+            data: true,
+        },
+        output: '01',
+    },
+    {
+        description: 'should encode bool as a single byte',
+        input: {
+            typeName: 'bool',
+            data: false,
+        },
+        output: '00',
+    },
+    {
+        description: 'should throw for array types',
+        input: {
+            typeName: 'bool[1]',
+            data: [true],
+        },
+        error: [TrezorError, 'Unsupported'],
+    },
+];

--- a/src/js/core/methods/helpers/__tests__/ethereumSignTypedData.test.js
+++ b/src/js/core/methods/helpers/__tests__/ethereumSignTypedData.test.js
@@ -1,0 +1,42 @@
+import { parseArrayType, encodeData, getFieldType } from '../ethereumSignTypedData';
+import * as fixtures from '../__fixtures__/ethereumSignTypedData';
+
+describe('helpers/ethereumSignTypeData', () => {
+    describe('parseArrayType', () => {
+        fixtures.parseArrayType.forEach(f => {
+            it(`${f.description} - ${f.input}`, () => {
+                if (f.error) {
+                    expect(() => parseArrayType(f.input)).toThrowError(...f.error);
+                } else {
+                    expect(parseArrayType(f.input)).toEqual(f.output);
+                }
+            });
+        });
+    });
+
+    describe('getFieldType', () => {
+        fixtures.getFieldType.forEach(f => {
+            const { typeName, types } = f.input;
+            it(`${f.description} - ${typeName}`, () => {
+                if (f.error) {
+                    expect(() => getFieldType(typeName, types)).toThrowError(...f.error);
+                } else {
+                    expect(getFieldType(typeName, types)).toEqual(f.output);
+                }
+            });
+        });
+    });
+
+    describe('encodeData', () => {
+        fixtures.encodeData.forEach(f => {
+            const { typeName, data } = f.input;
+            it(`${f.description}`, () => {
+                if (f.error) {
+                    expect(() => encodeData(typeName, data)).toThrowError(...f.error);
+                } else {
+                    expect(encodeData(typeName, data)).toEqual(f.output);
+                }
+            });
+        });
+    });
+});

--- a/src/js/core/methods/helpers/ethereumSignTypedData.js
+++ b/src/js/core/methods/helpers/ethereumSignTypedData.js
@@ -1,0 +1,190 @@
+/* @flow */
+
+import BigNumber from 'bignumber.js';
+import type { EthereumSignTypedDataTypes } from '../../../types/networks/ethereum';
+import type { EthereumFieldType } from '../../../types/trezor/protobuf';
+import { Enum_EthereumDataType } from '../../../types/trezor/protobuf';
+import { ERRORS } from '../../../constants';
+import { stripHexPrefix } from '../../../utils/formatUtils';
+
+// Copied from https://github.com/ethers-io/ethers.js/blob/v5.5.2/packages/abi/src.ts/fragments.ts#L249
+const paramTypeArray = new RegExp(/^(.*)\[([0-9]*)\]$/);
+const paramTypeBytes = new RegExp(/^bytes([0-9]*)$/);
+const paramTypeNumber = new RegExp(/^(u?int)([0-9]*)$/);
+
+/**
+ * Parse the given EIP-712 array type into its entries, and its length (if not dynamic)
+ * E.g. `uint16[32]` will return `{entryTypeName: 'uint16', arraySize: 32}`.
+ */
+export function parseArrayType(arrayTypeName: string): {
+    entryTypeName: string,
+    arraySize: number | null,
+} {
+    const arrayMatch = paramTypeArray.exec(arrayTypeName);
+    if (arrayMatch === null) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            `typename ${arrayTypeName} could not be parsed as an EIP-712 array`,
+        );
+    }
+    const [_, entryTypeName, arraySize] = arrayMatch;
+    return {
+        entryTypeName,
+        arraySize: parseInt(arraySize, 10) || null,
+    };
+}
+
+/**
+ * Converts a number to a two's complement representation.
+ *
+ * E.g. -128 would be 0x80 in two's complement, while 127 would be 0x7F.
+ *
+ * BigNumber.js has no built-in function, unlike https://www.npmjs.com/package/bn.js
+ */
+function twosComplement(number: BigNumber, bytes: number): BigNumber {
+    if (bytes < 1 || bytes > 32) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            'Int byte size must be between 1 and 32 (8 and 256 bits)',
+        );
+    }
+    // Determine value range
+    const minValue = new BigNumber(2).exponentiatedBy(bytes * 8 - 1).negated();
+    const maxValue = minValue.negated().minus(1);
+
+    const bigNumber = new BigNumber(number);
+
+    if (bigNumber.isGreaterThan(maxValue) || bigNumber.isLessThan(minValue)) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            `Overflow when trying to convert number ${number} into ${bytes} bytes`,
+        );
+    }
+
+    if (bigNumber.isPositive()) {
+        return bigNumber;
+    }
+    return bigNumber.minus(minValue).minus(minValue);
+}
+
+function intToHex(
+    // $FlowIssue bigint-unsupported, TODO: Update flow when bigint is supported
+    number: number | bigint | BigNumber | string,
+    bytes: number,
+    signed: boolean,
+): string {
+    let bigNumber = new BigNumber(number);
+    if (signed) {
+        bigNumber = twosComplement(bigNumber, bytes);
+    }
+    if (bigNumber.isNegative()) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            `Cannot convert negative number to unsigned interger: ${number}`,
+        );
+    }
+    const hex = bigNumber.toString(16);
+    const hexChars = bytes * 2;
+    if (hex.length > hexChars) {
+        throw ERRORS.TypedError(
+            'Runtime',
+            `Overflow when trying to convert number ${number} into ${bytes} bytes`,
+        );
+    }
+    return hex.padStart(bytes * 2, '0');
+}
+
+/**
+ * Encodes the given primitive data to a big-endian hex string.
+ *
+ * @param typeName - Primitive Solidity data type (e.g. `uint16`)
+ * @param data - The actual data to convert.
+ * @returns Hex string of the data.
+ */
+export function encodeData(typeName: string, data: any): string {
+    if (paramTypeBytes.test(typeName) || typeName === 'address') {
+        return stripHexPrefix(data);
+    }
+    if (typeName === 'string') {
+        return Buffer.from(data, 'utf-8').toString('hex');
+    }
+    const numberMatch = paramTypeNumber.exec(typeName);
+    if (numberMatch) {
+        const [_, intType, bits] = numberMatch;
+        const bytes = Math.ceil(parseInt(bits, 10) / 8);
+        return intToHex(data, bytes, intType === 'int');
+    }
+    if (typeName === 'bool') {
+        return data ? '01' : '00';
+    }
+
+    // We should be receiving only atomic, non-array types
+    throw ERRORS.TypedError(
+        'Runtime',
+        `Unsupported data type for direct field encoding: ${typeName}`,
+    );
+}
+
+// these are simple types, so we can just do a string-match
+const paramTypesMap = {
+    string: Enum_EthereumDataType.STRING,
+    bool: Enum_EthereumDataType.BOOL,
+    address: Enum_EthereumDataType.ADDRESS,
+};
+
+/**
+ * Converts the given EIP-712 typename into a Protobuf package.
+ *
+ * @param typeName - The EIP-712 typename (e.g. `uint16` for simple types, `Example` for structs)
+ * @param types - Map of types, required for recursive (`struct`) types.
+ */
+export function getFieldType(
+    typeName: string,
+    types: EthereumSignTypedDataTypes,
+): EthereumFieldType {
+    const arrayMatch = paramTypeArray.exec(typeName);
+    if (arrayMatch) {
+        const [_, arrayItemTypeName, arraySize] = arrayMatch;
+        const entryType = getFieldType(arrayItemTypeName, types);
+        return {
+            data_type: Enum_EthereumDataType.ARRAY,
+            size: parseInt(arraySize, 10) || undefined,
+            entry_type: entryType,
+        };
+    }
+
+    const numberMatch = paramTypeNumber.exec(typeName);
+    if (numberMatch) {
+        const [_, type, bits] = numberMatch;
+        return {
+            data_type: type === 'uint' ? Enum_EthereumDataType.UINT : Enum_EthereumDataType.INT,
+            size: Math.floor(parseInt(bits, 10) / 8),
+        };
+    }
+
+    const bytesMatch = paramTypeBytes.exec(typeName);
+    if (bytesMatch) {
+        const [_, size] = bytesMatch;
+        return {
+            data_type: Enum_EthereumDataType.BYTES,
+            size: parseInt(size, 10) || undefined,
+        };
+    }
+
+    const fixedSizeTypeMatch = paramTypesMap[typeName];
+    if (fixedSizeTypeMatch) {
+        return {
+            data_type: fixedSizeTypeMatch,
+        };
+    }
+
+    if (typeName in types) {
+        return {
+            data_type: Enum_EthereumDataType.STRUCT,
+            size: types[typeName].length,
+            struct_name: typeName,
+        };
+    }
+
+    throw ERRORS.TypedError('Runtime', `No type definition specified: ${typeName}`);
+}

--- a/src/js/core/methods/index.js
+++ b/src/js/core/methods/index.js
@@ -29,6 +29,7 @@ import ethereumGetAddress from './EthereumGetAddress';
 import ethereumGetPublicKey from './EthereumGetPublicKey';
 import ethereumSignMessage from './EthereumSignMessage';
 import ethereumSignTransaction from './EthereumSignTransaction';
+import ethereumSignTypedData from './EthereumSignTypedData';
 import ethereumVerifyMessage from './EthereumVerifyMessage';
 import getAccountInfo from './GetAccountInfo';
 import getAddress from './GetAddress';
@@ -93,6 +94,7 @@ const METHODS = {
     ethereumGetPublicKey,
     ethereumSignMessage,
     ethereumSignTransaction,
+    ethereumSignTypedData,
     ethereumVerifyMessage,
     getAccountInfo,
     getAddress,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -98,6 +98,8 @@ const TrezorConnect: API = {
 
     ethereumSignTransaction: params => call({ method: 'ethereumSignTransaction', ...params }),
 
+    ethereumSignTypedData: params => call({ method: 'ethereumSignTypedData', ...params }),
+
     ethereumVerifyMessage: params => call({ method: 'ethereumVerifyMessage', ...params }),
 
     getAccountInfo: params => call({ method: 'getAccountInfo', ...params }),

--- a/src/js/types/__tests__/ethereum.js
+++ b/src/js/types/__tests__/ethereum.js
@@ -191,3 +191,52 @@ export const signMessage = async () => {
         (payload.message: string);
     }
 };
+
+export const signTypedData = async () => {
+    // $FlowIssue with `await` and Promises: https://github.com/facebook/flow/issues/5294 TODO: Update flow
+    const sign = await TrezorConnect.ethereumSignTypedData({
+        path: 'm/44',
+        data: {
+            types: {
+                EIP712Domain: [
+                    {
+                        name: 'name',
+                        type: 'string',
+                    },
+                    {
+                        name: 'version',
+                        type: 'string',
+                    },
+                    {
+                        name: 'chainId',
+                        type: 'uint256',
+                    },
+                    {
+                        name: 'verifyingContract',
+                        type: 'address',
+                    },
+                    {
+                        name: 'salt',
+                        type: 'bytes32',
+                    },
+                ],
+            },
+            primaryType: 'EIP712Domain',
+            domain: {
+                name: 'example.metamask.io',
+                version: '1',
+                chainId: 1,
+                verifyingContract: '0x0000000000000000000000000000000000000000',
+                salt: new Int32Array([1, 2, 3]).buffer,
+            },
+            message: {},
+        },
+        metamask_v4_compat: true,
+    });
+
+    if (sign.success) {
+        const { payload } = sign;
+        (payload.signature: string);
+        (payload.network: string);
+    }
+};

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -254,6 +254,10 @@ export type API = {
     ethereumGetPublicKey: Bundled<Ethereum.EthereumGetPublicKey, Bitcoin.HDNodeResponse>,
     ethereumSignTransaction: Bundled<Ethereum.EthereumSignTransaction, Ethereum.EthereumSignedTx>,
     ethereumSignMessage: Method<Ethereum.EthereumSignMessage, Protobuf.EthereumMessageSignature>,
+    ethereumSignTypedData: Method<
+        Ethereum.EthereumSignTypedData,
+        Protobuf.EthereumTypedDataSignature,
+    >,
     ethereumVerifyMessage: Method<Ethereum.EthereumVerifyMessage, P.DefaultMessage>,
 
     // NEM

--- a/src/js/types/networks/ethereum.js
+++ b/src/js/types/networks/ethereum.js
@@ -75,6 +75,37 @@ export type EthereumSignMessage = {
     hex?: boolean,
 };
 
+// sign typed message (eip-712)
+
+type EthereumSignTypedDataTypeProperty = {
+    name: string,
+    type: string,
+};
+
+export type EthereumSignTypedDataTypes = {
+    EIP712Domain: EthereumSignTypedDataTypeProperty[],
+    [additionalProperties: string]: EthereumSignTypedDataTypeProperty[],
+};
+
+type EthereumSignTypedDataMessage<T: EthereumSignTypedDataTypes> = {
+    types: T,
+    primaryType: $Keys<T>,
+    domain: {
+        name?: string,
+        version?: string,
+        chainId?: number,
+        verifyingContract?: string,
+        salt?: ArrayBuffer,
+    },
+    message: { [fieldName: string]: any },
+};
+
+export type EthereumSignTypedData = {
+    path: string | number[],
+    data: EthereumSignTypedDataMessage<any>,
+    metamask_v4_compat: boolean,
+};
+
 // verify message
 
 export type EthereumVerifyMessage = {

--- a/src/ts/types/__tests__/ethereum.ts
+++ b/src/ts/types/__tests__/ethereum.ts
@@ -177,3 +177,59 @@ export const signMessage = async () => {
         payload.message;
     }
 };
+
+export const signTypedData = async () => {
+    const sign = await TrezorConnect.ethereumSignTypedData({
+        path: 'm/44',
+        data: {
+            types: {
+                EIP712Domain: [
+                    {
+                        name: 'name',
+                        type: 'string',
+                    },
+                    {
+                        name: 'version',
+                        type: 'string',
+                    },
+                    {
+                        name: 'chainId',
+                        type: 'uint256',
+                    },
+                    {
+                        name: 'verifyingContract',
+                        type: 'address',
+                    },
+                    {
+                        name: 'salt',
+                        type: 'bytes32',
+                    },
+                ],
+                Message: [
+                    {
+                        name: 'Test Field',
+                        type: 'string',
+                    },
+                ],
+            },
+            primaryType: 'Message',
+            domain: {
+                name: 'example.metamask.io',
+                version: '1',
+                chainId: 1,
+                verifyingContract: '0x0000000000000000000000000000000000000000',
+                salt: new Int32Array([1, 2, 3]).buffer,
+            },
+            message: {
+                'Test Field': 'Hello World',
+            },
+        },
+        metamask_v4_compat: true,
+    });
+
+    if (sign.success) {
+        const { payload } = sign;
+        payload.address;
+        payload.signature;
+    }
+};

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -303,6 +303,9 @@ export namespace TrezorConnect {
     function ethereumSignMessage(
         params: P.CommonParams & Ethereum.EthereumSignMessage,
     ): P.Response<Protobuf.MessageSignature>;
+    function ethereumSignTypedData<T extends Ethereum.EthereumSignTypedDataTypes>(
+        params: P.CommonParams & Ethereum.EthereumSignTypedData<T>,
+    ): P.Response<Protobuf.EthereumTypedDataSignature>;
     function ethereumVerifyMessage(
         params: P.CommonParams & Ethereum.EthereumVerifyMessage,
     ): P.Response<P.DefaultMessage>;

--- a/src/ts/types/networks/ethereum.d.ts
+++ b/src/ts/types/networks/ethereum.d.ts
@@ -74,6 +74,37 @@ export interface EthereumSignMessage {
     hex?: boolean;
 }
 
+// sign typed message (eip-712)
+
+interface EthereumSignTypedDataTypeProperty {
+    name: string;
+    type: string;
+}
+
+interface EthereumSignTypedDataTypes {
+    EIP712Domain: EthereumSignTypedDataTypeProperty[];
+    [additionalProperties: string]: EthereumSignTypedDataTypeProperty[];
+}
+
+interface EthereumSignTypedDataMessage<T extends EthereumSignTypedDataTypes> {
+    types: T;
+    primaryType: keyof T;
+    domain: {
+        name?: string;
+        version?: string;
+        chainId?: number | bigint;
+        verifyingContract?: string;
+        salt?: ArrayBuffer;
+    };
+    message: { [fieldName: string]: any };
+}
+
+export interface EthereumSignTypedData<T extends EthereumSignTypedDataTypes> {
+    path: string | number[];
+    data: EthereumSignTypedDataMessage<T>;
+    metamask_v4_compat: boolean;
+}
+
 // verify message
 
 export interface EthereumVerifyMessage {

--- a/tests/__fixtures__/ethereumSignTypedData.js
+++ b/tests/__fixtures__/ethereumSignTypedData.js
@@ -1,0 +1,20 @@
+import commonFixtures from '../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
+
+export default {
+    method: 'ethereumSignTypedData',
+    setup: {
+        mnemonic: commonFixtures.setup.mnemonic,
+    },
+    tests: commonFixtures.tests.flatMap(({ name, parameters, result }) => {
+        const fixture = {
+            description: `${name} ${parameters.comment ?? ''}`,
+            name,
+            params: parameters,
+            result: {
+                address: result.address,
+                signature: result.sig,
+            },
+        };
+        return fixture;
+    }),
+};

--- a/tests/__fixtures__/index.js
+++ b/tests/__fixtures__/index.js
@@ -22,6 +22,7 @@ import ethereumSignMessage from './ethereumSignMessage';
 import ethereumSignTransaction from './ethereumSignTransaction';
 import ethereumSignTransactionEip155 from './ethereumSignTransactionEip155';
 import ethereumSignTransactionEip1559 from './ethereumSignTransactionEip1559';
+import ethereumSignTypedData from './ethereumSignTypedData';
 import ethereumVerifyMessage from './ethereumVerifyMessage';
 import getAccountInfo from './getAccountInfo';
 import getFeatures from './getFeatures';
@@ -77,6 +78,7 @@ let fixtures = [
     ethereumSignTransaction,
     ethereumSignTransactionEip155,
     ethereumSignTransactionEip1559,
+    ethereumSignTypedData,
     ethereumVerifyMessage,
     // todo: probably no way todo: FirmwareUpdate.js
     // todo: ripple worker problem


### PR DESCRIPTION
Adds support for EIP-712 Typed Signed Data #825.

This is mostly adapted from the Python implementation in `python/src/trezorlib/ethereum.py` in  https://github.com/trezor/trezor-firmware/pull/1835

~One potential issue is [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder), which is what I'm using to convert a UTF-8 string to bytes. It's supported in all the browsers Trezor Connect targets, **except IE**, and I'm unsure if Babel/Webpack is polyfilling it automatically. I've only run `karma` tests on Chrome.~ Replaced with `Buffer.from('utf-8').toString('hex')` in 0103d17334c81e9ba7e1b7b3ed39c7b396f35ba7

I also found quite a few Flow issues that I'm pretty sure would be fixed by updating Flow, (e.g. `await Promise` not always resolving the promise type) but unfortunately our [`.flowconfig` has deprecated options](https://github.com/trezor/connect/blob/240d017c9744792dd9747e73b9d34eb4e68bddca/.flowconfig#L16-L19) that aren't supported in the latest versions, so it's not trivial to update.