### PR TITLE
test: Improve OCI containers in `tests/run.sh`

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,9 @@ _Note: Running tests with custom firmware [is not currently possible](https://gi
 
 ### On Linux
 #### Prerequisites
+
 - [Docker](https://docs.docker.com/engine/install/)
+- [Podman](https://podman.io/getting-started/installation) using `tests/run.sh -D podman` (not officially supported)
 
 ### On MacOS
 _Note: As of now M1 Macs aren't supported. See [this issue](https://github.com/trezor/trezor-suite/issues/3616) for detailed information._

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,7 +10,7 @@ USER_ENV_IMAGE="registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-us
 cleanup() {
   if [ -n "${dockerID-}" ]; then
     echo "Stopping container with an ID $dockerID"
-    docker stop "$dockerID" && echo "trezor-user-env stopped"
+    "$DOCKER_PATH" stop "$dockerID" && echo "trezor-user-env stopped"
   fi
 }
 
@@ -31,16 +31,16 @@ trap cleanup EXIT
 
 runDocker() {
   echo "Pulling latest trezor-user-env"
-  docker pull "$USER_ENV_IMAGE"
+  "$DOCKER_PATH" pull "$USER_ENV_IMAGE"
   dockerID=$(
-    docker run -d \
+    "$DOCKER_PATH" run -d \
       -e SDL_VIDEODRIVER="dummy" \
       -p "9001:9001" \
       -p "21326:21326" \
       -p "21325:21326" \
       "$USER_ENV_IMAGE"
   )
-  docker logs -f "$dockerID" &
+  "$DOCKER_PATH" logs -f "$dockerID" &
   echo "Running docker container with ID $dockerID"
 }
 
@@ -70,6 +70,7 @@ show_usage() {
   echo "Options:"
   echo "  -c       Disable backend cache. default: enabled"
   echo "  -d       Disable docker. Useful when running own instance of trezor-user-env. default: enabled"
+  echo "  -D PATH  Set path to docker executable. Can be replaced with `podman`. default: docker"
   echo "  -e       All methods except excluded, example: applySettings,signTransaction"
   echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: 2-master"
   echo "  -i       Included methods only, example: applySettings,signTransaction"
@@ -86,16 +87,20 @@ FIRMWARE=$RELEASED_FIRMWARE
 INCLUDED_METHODS=""
 EXCLUDED_METHODS=""
 DOCKER=true
+DOCKER_PATH="docker"
 TEST_SCRIPT="yarn test:integration"
 USE_TX_CACHE=true
 USE_WS_CACHE=true
 
 # user options
 OPTIND=1
-while getopts ":i:e:f:s:hdc" opt; do
+while getopts ":i:e:f:s:D:hdc" opt; do
   case $opt in
   d)
     DOCKER=false
+    ;;
+  D)
+    DOCKER_PATH="$OPTARG"
     ;;
   c)
     USE_TX_CACHE=false

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,8 +32,9 @@ trap cleanup EXIT
 runDocker() {
   echo "Pulling latest trezor-user-env"
   "$DOCKER_PATH" pull "$USER_ENV_IMAGE"
+  # `--rm` flag will automatically delete container when done
   dockerID=$(
-    "$DOCKER_PATH" run -d \
+    "$DOCKER_PATH" run -d --rm \
       -e SDL_VIDEODRIVER="dummy" \
       -p "9001:9001" \
       -p "21326:21326" \


### PR DESCRIPTION
Two quality of life changes to running containers in `tests/run.sh`, since I ran this script multiple times for my PR #983.

#### Firstly, I added the flag `-D DOCKER_PATH` to `tests/run.sh`.

This allows running the script with `tests/run.sh -D podman`, using podman instead of docker to run containers.

`podman` has an almost identical CLI to `docker`, but it's:

  - open-source (no worry about Docker's licensing rules)
  - daemonless (only uses resources when a container is actually running, and more secure since it doesn't need root)

#### Secondly, I added the `--rm` flag to `docker run` ([see docs](https://docs.docker.com/engine/reference/run/#clean-up---rm)).

This automatically deletes the container when the container exits, so you don't have loads of unused containers left over after running integration tests a few times. If you run `docker ps --all`, you might see loads of stopped containers on your computer!

Docker keeps it by default in case you want to explore the file-system of the container/restart it later on, but I don't think that'd be common when testing `trezor-connect`.