### PR TITLE
fix: enable eslint in typescript files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
     },
     "overrides": [
         {
-            "files": ["**/types/__tests__/*.js"],
+            "files": ["**/types/__tests__/*.js", "**/types/__tests__/*.ts"],
             "rules": {
                 "no-unused-expressions": "off"
             }
@@ -67,6 +67,22 @@
             "files": [ "**/examples/**/*.js" ],
             "rules": {
                 "import/no-unresolved": "off"
+            }
+        },
+        {
+            "files": [
+                "**/*.ts"
+            ],
+            "parser": "@typescript-eslint/parser",
+            "plugins": ["import", "@typescript-eslint"],
+            "rules": {
+                "flowtype/no-types-missing-file-annotation": "off", // flowtype errors are irrelevant for typescript
+                "import/no-unresolved": "off", // imports are resolved below
+                "import/extensions": ["error", { "parser": "typescript" } ], // import typescript *.d.ts files
+                "no-unused-vars": "off", // api method params mostly
+                "no-shadow": "off", // typescript enum, use parser below
+                "@typescript-eslint/no-shadow": ["error"],
+                "prettier/prettier": ["error", {"semicolon": true, "parser": "typescript"}] // use ";" instead of ","
             }
         }
     ]

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,6 +6,7 @@
 .*/_old/.*
 .*/build/.*
 .*/trezor-common/.*
+.*/ts/.*
 
 [libs]
 ./node_modules/trezor-link/flowtype/chrome.js

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
         "@trezor/rollout": "^1.2.1",
         "@trezor/transport": "1.0.1",
         "@trezor/utxo-lib": "1.0.0-beta.10",
+        "@typescript-eslint/eslint-plugin": "^4.29.1",
+        "@typescript-eslint/parser": "^4.29.1",
         "assert": "^2.0.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.6.3",

--- a/src/ts/types/__tests__/bitcoin.ts
+++ b/src/ts/types/__tests__/bitcoin.ts
@@ -527,7 +527,12 @@ export const signMessage = async () => {
         payload.address;
         payload.signature;
     }
-    const verify = await TrezorConnect.verifyMessage({ address: 'a', signature: 'a', message: 'foo', coin: 'btc' });
+    const verify = await TrezorConnect.verifyMessage({
+        address: 'a',
+        signature: 'a',
+        message: 'foo',
+        coin: 'btc',
+    });
     if (verify.success) {
         const { payload } = verify;
         payload.message;

--- a/src/ts/types/__tests__/blockchain.ts
+++ b/src/ts/types/__tests__/blockchain.ts
@@ -75,7 +75,7 @@ export const blockchainGetTransactions = async () => {
     }
 };
 
-export const others = async () => {
+export const others = () => {
     const accounts = [
         {
             descriptor: 'xpub',

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -1,4 +1,11 @@
-import { CardanoAddressType, CardanoCertificateType, CardanoNativeScriptHashDisplayFormat, CardanoNativeScriptType, CardanoPoolRelayType, CardanoTxSigningMode } from 'types/trezor/protobuf';
+import {
+    CardanoAddressType,
+    CardanoCertificateType,
+    CardanoNativeScriptHashDisplayFormat,
+    CardanoNativeScriptType,
+    CardanoPoolRelayType,
+    CardanoTxSigningMode,
+} from 'types/trezor/protobuf';
 import TrezorConnect from '../index';
 
 export const cardanoGetAddress = async () => {

--- a/src/ts/types/__tests__/ethereum.ts
+++ b/src/ts/types/__tests__/ethereum.ts
@@ -156,7 +156,11 @@ export const ethereumSignTransaction = async () => {
 };
 
 export const signMessage = async () => {
-    const sign = await TrezorConnect.ethereumSignMessage({ path: 'm/44', message: 'foo', hex: false });
+    const sign = await TrezorConnect.ethereumSignMessage({
+        path: 'm/44',
+        message: 'foo',
+        hex: false,
+    });
     if (sign.success) {
         const { payload } = sign;
         payload.address;

--- a/src/ts/types/__tests__/index.ts
+++ b/src/ts/types/__tests__/index.ts
@@ -60,7 +60,7 @@ export const init = async () => {
     TrezorConnect.disableWebUSB();
 };
 
-export const events = async () => {
+export const events = () => {
     TrezorConnect.on(DEVICE_EVENT, event => {
         const { payload } = event;
         event.type;

--- a/src/ts/types/__tests__/management.ts
+++ b/src/ts/types/__tests__/management.ts
@@ -1,6 +1,6 @@
 import TrezorConnect from '../index';
 
-export const management = async () => {
+export const management = () => {
     TrezorConnect.resetDevice({
         strength: 1,
         label: 'My Trezor',

--- a/src/ts/types/__tests__/misc.ts
+++ b/src/ts/types/__tests__/misc.ts
@@ -27,23 +27,23 @@ export const cipherKeyValue = async () => {
     }
 };
 
-export const customMessage = async () => {
+export const customMessage = () => {
     TrezorConnect.customMessage({
         messages: {},
         message: 'MyCustomSignTx',
         params: {
             inputs: { index: 1, hash: '0' },
         },
-        callback: async (request: any) => {
+        callback: (request: any) => {
             if (request.type === 'MyCustomTxReq') {
-                return {
+                return Promise.resolve({
                     message: 'MyCustomTxAck',
                     params: {
                         index: 1,
                     },
-                };
+                });
             }
-            return { message: 'MyCustomSigned' };
+            return Promise.resolve({ message: 'MyCustomSigned' });
         },
     });
 };
@@ -90,7 +90,7 @@ export const requestLogin = async () => {
     TrezorConnect.requestLogin({ challengeVisual: 1 });
 };
 
-export const debugLink = async () => {
+export const debugLink = () => {
     TrezorConnect.debugLinkDecision({ device: { path: '1' } });
     TrezorConnect.debugLinkGetState({ device: { path: '1' } });
 };

--- a/src/ts/types/__tests__/nem.ts
+++ b/src/ts/types/__tests__/nem.ts
@@ -16,7 +16,9 @@ export const nemGetAddress = async () => {
     }
 
     // bundle
-    const bundleAddress = await TrezorConnect.nemGetAddress({ bundle: [{ path: 'm/44', network: 1 }] });
+    const bundleAddress = await TrezorConnect.nemGetAddress({
+        bundle: [{ path: 'm/44', network: 1 }],
+    });
 
     if (bundleAddress.success) {
         bundleAddress.payload.forEach(item => {
@@ -94,7 +96,8 @@ export const nemSignTransaction = async () => {
             modifications: [
                 {
                     modificationType: 1,
-                    cosignatoryAccount: 'c5f54ba980fcbb657dbaaa42700539b207873e134d2375efeab5f1ab52f87844',
+                    cosignatoryAccount:
+                        'c5f54ba980fcbb657dbaaa42700539b207873e134d2375efeab5f1ab52f87844',
                 },
             ],
             minCosignatories: {

--- a/src/ts/types/account.d.ts
+++ b/src/ts/types/account.d.ts
@@ -60,8 +60,8 @@ export interface AccountUtxo {
     coinbase?: boolean;
     required?: boolean;
     cardanoSpecific?: {
-        unit: string,
-    },
+        unit: string;
+    };
 }
 
 // Transaction object
@@ -152,7 +152,6 @@ export interface AccountInfo {
             rewards: string;
             poolId: string | null;
         };
-
     };
     page?: {
         // blockbook

--- a/src/ts/types/api.d.ts
+++ b/src/ts/types/api.d.ts
@@ -48,21 +48,65 @@ export namespace TrezorConnect {
     /**
      * Event listeners
      */
-    function on(type: typeof CONSTANTS.DEVICE_EVENT, cb: (event: Device.DeviceEvent & { event: typeof CONSTANTS.DEVICE_EVENT }) => void): void;
-    function on(type: typeof CONSTANTS.TRANSPORT_EVENT, cb: (event: Events.TransportEvent & { event: typeof CONSTANTS.TRANSPORT_EVENT }) => void): void;
-    function on(type: typeof CONSTANTS.UI_EVENT, cb: (event: Events.UiEvent & { event: typeof CONSTANTS.UI_EVENT }) => void): void;
-    function on(type: typeof CONSTANTS.BLOCKCHAIN_EVENT, cb: (event: Blockchain.BlockchainEvent & { event: typeof CONSTANTS.BLOCKCHAIN_EVENT }) => void): void;
+    function on(
+        type: typeof CONSTANTS.DEVICE_EVENT,
+        cb: (event: Device.DeviceEvent & { event: typeof CONSTANTS.DEVICE_EVENT }) => void,
+    ): void;
+    function on(
+        type: typeof CONSTANTS.TRANSPORT_EVENT,
+        cb: (event: Events.TransportEvent & { event: typeof CONSTANTS.TRANSPORT_EVENT }) => void,
+    ): void;
+    function on(
+        type: typeof CONSTANTS.UI_EVENT,
+        cb: (event: Events.UiEvent & { event: typeof CONSTANTS.UI_EVENT }) => void,
+    ): void;
+    function on(
+        type: typeof CONSTANTS.BLOCKCHAIN_EVENT,
+        cb: (
+            event: Blockchain.BlockchainEvent & { event: typeof CONSTANTS.BLOCKCHAIN_EVENT },
+        ) => void,
+    ): void;
     function on(type: Events.MessageWithoutPayload['type'], cb: () => void): void;
-    function on(type: Events.DeviceMessage['type'], cb: (event: Events.DeviceMessage['payload']) => void): void;
-    function on(type: Events.ButtonRequestMessage['type'], cb: (event: Events.ButtonRequestMessage['payload']) => void): void;
-    function on(type: Events.AddressValidationMessage['type'], cb: (event: Events.AddressValidationMessage['payload']) => void): void;
-    function on(type: Events.RequestPermission['type'], cb: (event: Events.RequestPermission['payload']) => void): void;
-    function on(type: Events.RequestConfirmation['type'], cb: (event: Events.RequestConfirmation['payload']) => void): void;
-    function on(type: Events.UnexpectedDeviceMode['type'], cb: (event: Events.UnexpectedDeviceMode['payload']) => void): void;
-    function on(type: Events.FirmwareException['type'], cb: (event: Events.FirmwareException['payload']) => void): void;
-    function on<R>(type: typeof CONSTANTS.UI.BUNDLE_PROGRESS, cb: (event: Events.BundleProgress<R>['payload']) => void): void;
-    function on(type: Events.FirmwareProgress['type'], cb: (event: Events.FirmwareProgress['payload']) => void): void;
-    function on(type: Events.CustomMessageRequest['type'], cb: (event: Events.CustomMessageRequest['payload']) => void): void;
+    function on(
+        type: Events.DeviceMessage['type'],
+        cb: (event: Events.DeviceMessage['payload']) => void,
+    ): void;
+    function on(
+        type: Events.ButtonRequestMessage['type'],
+        cb: (event: Events.ButtonRequestMessage['payload']) => void,
+    ): void;
+    function on(
+        type: Events.AddressValidationMessage['type'],
+        cb: (event: Events.AddressValidationMessage['payload']) => void,
+    ): void;
+    function on(
+        type: Events.RequestPermission['type'],
+        cb: (event: Events.RequestPermission['payload']) => void,
+    ): void;
+    function on(
+        type: Events.RequestConfirmation['type'],
+        cb: (event: Events.RequestConfirmation['payload']) => void,
+    ): void;
+    function on(
+        type: Events.UnexpectedDeviceMode['type'],
+        cb: (event: Events.UnexpectedDeviceMode['payload']) => void,
+    ): void;
+    function on(
+        type: Events.FirmwareException['type'],
+        cb: (event: Events.FirmwareException['payload']) => void,
+    ): void;
+    function on<R>(
+        type: typeof CONSTANTS.UI.BUNDLE_PROGRESS,
+        cb: (event: Events.BundleProgress<R>['payload']) => void,
+    ): void;
+    function on(
+        type: Events.FirmwareProgress['type'],
+        cb: (event: Events.FirmwareProgress['payload']) => void,
+    ): void;
+    function on(
+        type: Events.CustomMessageRequest['type'],
+        cb: (event: Events.CustomMessageRequest['payload']) => void,
+    ): void;
     function off(type: string, cb: any): void;
     function removeAllListeners(): void;
 
@@ -75,13 +119,13 @@ export namespace TrezorConnect {
         params: P.CommonParams & Blockchain.BlockchainEstimateFee,
     ): P.Response<Blockchain.BlockchainEstimatedFee>;
     function blockchainGetAccountBalanceHistory(
-        params: Blockchain.BlockchainGetAccountBalanceHistory
+        params: Blockchain.BlockchainGetAccountBalanceHistory,
     ): P.Response<Blockchain.BlockchainAccountBalanceHistory[]>;
     function blockchainGetCurrentFiatRates(
-        params: Blockchain.BlockchainGetCurrentFiatRates
+        params: Blockchain.BlockchainGetCurrentFiatRates,
     ): P.Response<Blockchain.BlockchainTimestampedFiatRates>;
     function blockchainGetFiatRatesForTimestamps(
-        params: Blockchain.BlockchainGetFiatRatesForTimestamps
+        params: Blockchain.BlockchainGetFiatRatesForTimestamps,
     ): P.Response<Blockchain.BlockchainFiatRatesForTimestamps>;
     function blockchainGetTransactions(
         params: P.CommonParams & Blockchain.BlockchainGetTransactions,
@@ -93,18 +137,17 @@ export namespace TrezorConnect {
         params: P.CommonParams & Blockchain.BlockchainSubscribe,
     ): P.Response<Blockchain.BlockchainSubscribed>;
     function blockchainSubscribeFiatRates(
-        params: Blockchain.BlockchainSubscribeFiatRates
+        params: Blockchain.BlockchainSubscribeFiatRates,
     ): P.Response<Blockchain.BlockchainSubscribed>;
     function blockchainUnsubscribe(
         params: P.CommonParams & Blockchain.BlockchainSubscribe,
     ): P.Response<Blockchain.BlockchainSubscribed>;
     function blockchainUnsubscribeFiatRates(
-        params: Blockchain.BlockchainSubscribeFiatRates
+        params: Blockchain.BlockchainSubscribeFiatRates,
     ): P.Response<Blockchain.BlockchainSubscribed>;
     function blockchainDisconnect(
         params: P.CommonParams & Blockchain.BlockchainDisconnect,
     ): P.Response<Blockchain.BlockchainDisconnected>;
-
 
     /**
      * Bitcoin and Bitcoin-like
@@ -112,7 +155,9 @@ export namespace TrezorConnect {
      * returns it to caller. User is asked to confirm the export on Trezor.
      */
     function getAddress(params: P.CommonParams & Bitcoin.GetAddress): P.Response<Bitcoin.Address>;
-    function getAddress(params: P.CommonParams & P.Bundle<Bitcoin.GetAddress>): P.BundledResponse<Bitcoin.Address>;
+    function getAddress(
+        params: P.CommonParams & P.Bundle<Bitcoin.GetAddress>,
+    ): P.BundledResponse<Bitcoin.Address>;
 
     /**
      * Bitcoin and Bitcoin-like
@@ -120,7 +165,9 @@ export namespace TrezorConnect {
      * User is presented with a description of the requested key and asked to
      * confirm the export.
      */
-    function getPublicKey(params: P.CommonParams & Bitcoin.GetPublicKey): P.Response<Bitcoin.HDNodeResponse>;
+    function getPublicKey(
+        params: P.CommonParams & Bitcoin.GetPublicKey,
+    ): P.Response<Bitcoin.HDNodeResponse>;
     function getPublicKey(
         params: P.CommonParams & P.Bundle<Bitcoin.GetPublicKey>,
     ): P.BundledResponse<Bitcoin.HDNodeResponse>;
@@ -130,13 +177,17 @@ export namespace TrezorConnect {
      * Asks device to sign given inputs and outputs of pre-composed transaction.
      * User is asked to confirm all transaction details on Trezor.
      */
-    function signTransaction(params: P.CommonParams & Bitcoin.SignTransaction): P.Response<Bitcoin.SignedTransaction>;
+    function signTransaction(
+        params: P.CommonParams & Bitcoin.SignTransaction,
+    ): P.Response<Bitcoin.SignedTransaction>;
 
     /**
      * Bitcoin, Bitcoin-like, Ethereum-like, Ripple
      * Broadcasts the transaction to the selected network.
      */
-    function pushTransaction(params: P.CommonParams & Bitcoin.PushTransaction): P.Response<Bitcoin.PushedTransaction>;
+    function pushTransaction(
+        params: P.CommonParams & Bitcoin.PushTransaction,
+    ): P.Response<Bitcoin.PushedTransaction>;
 
     /**
      * Bitcoin and Bitcoin-like
@@ -147,7 +198,9 @@ export namespace TrezorConnect {
      * returned in hexadecimal format. Change output is added automatically, if
      * needed.
      */
-    function composeTransaction(params: P.CommonParams & Account.ComposeParams): P.Response<Bitcoin.SignedTransaction>;
+    function composeTransaction(
+        params: P.CommonParams & Account.ComposeParams,
+    ): P.Response<Bitcoin.SignedTransaction>;
     function composeTransaction(
         params: P.CommonParams & Account.PrecomposeParams,
     ): P.Response<Account.PrecomposedTransaction[]>;
@@ -156,7 +209,9 @@ export namespace TrezorConnect {
      * Bitcoin, Bitcoin-like, Ethereum-like, Ripple
      * Gets an info of specified account.
      */
-    function getAccountInfo(params: P.CommonParams & Account.GetAccountInfo): P.Response<Account.AccountInfo>;
+    function getAccountInfo(
+        params: P.CommonParams & Account.GetAccountInfo,
+    ): P.Response<Account.AccountInfo>;
     function getAccountInfo(
         params: P.CommonParams & P.Bundle<Account.GetAccountInfo>,
     ): P.BundledResponse<Account.AccountInfo>;
@@ -166,16 +221,22 @@ export namespace TrezorConnect {
      * Asks device to sign a message using the private key derived by given BIP32
      * path.
      */
-    function signMessage(params: P.CommonParams & Bitcoin.SignMessage): P.Response<Protobuf.MessageSignature>;
+    function signMessage(
+        params: P.CommonParams & Bitcoin.SignMessage,
+    ): P.Response<Protobuf.MessageSignature>;
 
     /**
      * Bitcoin and Bitcoin-like
      * Asks device to verify a message using the signer address and signature.
      */
-    function verifyMessage(params: P.CommonParams & Bitcoin.VerifyMessage): P.Response<P.DefaultMessage>;
+    function verifyMessage(
+        params: P.CommonParams & Bitcoin.VerifyMessage,
+    ): P.Response<P.DefaultMessage>;
 
     // Binance
-    function binanceGetAddress(params: P.CommonParams & Binance.BinanceGetAddress): P.Response<Binance.BinanceAddress>;
+    function binanceGetAddress(
+        params: P.CommonParams & Binance.BinanceGetAddress,
+    ): P.Response<Binance.BinanceAddress>;
     function binanceGetAddress(
         params: P.CommonParams & P.Bundle<Binance.BinanceGetAddress>,
     ): P.BundledResponse<Binance.BinanceAddress>;
@@ -190,7 +251,9 @@ export namespace TrezorConnect {
     ): P.Response<Protobuf.BinanceSignedTx>;
 
     // Cardano (ADA)
-    function cardanoGetAddress(params: P.CommonParams & Cardano.CardanoGetAddress): P.Response<Cardano.CardanoAddress>;
+    function cardanoGetAddress(
+        params: P.CommonParams & Cardano.CardanoGetAddress,
+    ): P.Response<Cardano.CardanoAddress>;
     function cardanoGetAddress(
         params: P.CommonParams & P.Bundle<Cardano.CardanoGetAddress>,
     ): P.BundledResponse<Cardano.CardanoAddress>;
@@ -208,11 +271,15 @@ export namespace TrezorConnect {
     ): P.Response<Cardano.CardanoSignedTxData>;
 
     // EOS
-    function eosGetPublicKey(params: P.CommonParams & EOS.EosGetPublicKey): P.Response<EOS.EosPublicKey>;
+    function eosGetPublicKey(
+        params: P.CommonParams & EOS.EosGetPublicKey,
+    ): P.Response<EOS.EosPublicKey>;
     function eosGetPublicKey(
         params: P.CommonParams & P.Bundle<EOS.EosGetPublicKey>,
     ): P.BundledResponse<EOS.EosPublicKey>;
-    function eosSignTransaction(params: P.CommonParams & EOS.EosSignTransaction): P.Response<Protobuf.EosSignedTx>;
+    function eosSignTransaction(
+        params: P.CommonParams & EOS.EosSignTransaction,
+    ): P.Response<Protobuf.EosSignedTx>;
 
     // Ethereum and Ethereum-like
     function ethereumGetAddress(
@@ -242,11 +309,17 @@ export namespace TrezorConnect {
 
     // NEM
     function nemGetAddress(params: P.CommonParams & NEM.NEMGetAddress): P.Response<NEM.NEMAddress>;
-    function nemGetAddress(params: P.CommonParams & P.Bundle<NEM.NEMGetAddress>): P.BundledResponse<NEM.NEMAddress>;
-    function nemSignTransaction(params: P.CommonParams & NEM.NEMSignTransaction): P.Response<Protobuf.NEMSignedTx>;
+    function nemGetAddress(
+        params: P.CommonParams & P.Bundle<NEM.NEMGetAddress>,
+    ): P.BundledResponse<NEM.NEMAddress>;
+    function nemSignTransaction(
+        params: P.CommonParams & NEM.NEMSignTransaction,
+    ): P.Response<Protobuf.NEMSignedTx>;
 
     // Ripple
-    function rippleGetAddress(params: P.CommonParams & Ripple.RippleGetAddress): P.Response<Ripple.RippleAddress>;
+    function rippleGetAddress(
+        params: P.CommonParams & Ripple.RippleGetAddress,
+    ): P.Response<Ripple.RippleAddress>;
     function rippleGetAddress(
         params: P.CommonParams & P.Bundle<Ripple.RippleGetAddress>,
     ): P.BundledResponse<Ripple.RippleAddress>;
@@ -255,7 +328,9 @@ export namespace TrezorConnect {
     ): P.Response<Ripple.RippleSignedTx>;
 
     // Stellar
-    function stellarGetAddress(params: P.CommonParams & Stellar.StellarGetAddress): P.Response<Stellar.StellarAddress>;
+    function stellarGetAddress(
+        params: P.CommonParams & Stellar.StellarGetAddress,
+    ): P.Response<Stellar.StellarAddress>;
     function stellarGetAddress(
         params: P.CommonParams & P.Bundle<Stellar.StellarGetAddress>,
     ): P.BundledResponse<Stellar.StellarAddress>;
@@ -264,11 +339,15 @@ export namespace TrezorConnect {
     ): P.Response<Stellar.StellarSignedTx>;
 
     // // Tezos
-    function tezosGetAddress(params: P.CommonParams & Tezos.TezosGetAddress): P.Response<Tezos.TezosAddress>;
+    function tezosGetAddress(
+        params: P.CommonParams & Tezos.TezosGetAddress,
+    ): P.Response<Tezos.TezosAddress>;
     function tezosGetAddress(
         params: P.CommonParams & P.Bundle<Tezos.TezosGetAddress>,
     ): P.BundledResponse<Tezos.TezosAddress>;
-    function tezosGetPublicKey(params: P.CommonParams & Tezos.TezosGetPublicKey): P.Response<Tezos.TezosPublicKey>;
+    function tezosGetPublicKey(
+        params: P.CommonParams & Tezos.TezosGetPublicKey,
+    ): P.Response<Tezos.TezosPublicKey>;
     function tezosGetPublicKey(
         params: P.CommonParams & P.Bundle<Tezos.TezosGetPublicKey>,
     ): P.BundledResponse<Tezos.TezosPublicKey>;
@@ -290,7 +369,9 @@ export namespace TrezorConnect {
      * Asks device to encrypt value using the private key derived by given BIP32
      * path and the given key. IV is always computed automatically.
      */
-    function cipherKeyValue(params: P.CommonParams & Misc.CipherKeyValue): P.Response<Misc.CipheredValue>;
+    function cipherKeyValue(
+        params: P.CommonParams & Misc.CipherKeyValue,
+    ): P.Response<Misc.CipheredValue>;
     function cipherKeyValue(
         params: P.CommonParams & P.Bundle<Misc.CipherKeyValue>,
     ): P.BundledResponse<Misc.CipheredValue>;
@@ -318,7 +399,9 @@ export namespace TrezorConnect {
     /**
      * Applies device setup
      */
-    function applySettings(params: P.CommonParams & Protobuf.ApplySettings): P.Response<P.DefaultMessage>;
+    function applySettings(
+        params: P.CommonParams & Protobuf.ApplySettings,
+    ): P.Response<P.DefaultMessage>;
 
     /**
      * Increment saved flag on device
@@ -333,8 +416,12 @@ export namespace TrezorConnect {
     /**
      * Sends FirmwareErase message followed by FirmwareUpdate message
      */
-    function firmwareUpdate(params: P.CommonParams & Mgmnt.FirmwareUpdate): P.Response<P.DefaultMessage>;
-    function firmwareUpdate(params: P.CommonParams & Mgmnt.FirmwareUpdateBinary): P.Response<P.DefaultMessage>;
+    function firmwareUpdate(
+        params: P.CommonParams & Mgmnt.FirmwareUpdate,
+    ): P.Response<P.DefaultMessage>;
+    function firmwareUpdate(
+        params: P.CommonParams & Mgmnt.FirmwareUpdateBinary,
+    ): P.Response<P.DefaultMessage>;
 
     /**
      * Asks device to initiate seed backup procedure
@@ -344,7 +431,9 @@ export namespace TrezorConnect {
     /**
      * Ask device to initiate recovery procedure
      */
-    function recoveryDevice(params: P.CommonParams & Mgmnt.RecoveryDevice): P.Response<P.DefaultMessage>;
+    function recoveryDevice(
+        params: P.CommonParams & Mgmnt.RecoveryDevice,
+    ): P.Response<P.DefaultMessage>;
 
     /**
      * Get static coin info

--- a/src/ts/types/backend/blockchain.d.ts
+++ b/src/ts/types/backend/blockchain.d.ts
@@ -148,22 +148,22 @@ export interface BlockchainSetCustomBackend {
 
 export type BlockchainEvent =
     | {
-        type: typeof BLOCKCHAIN.CONNECT;
-        payload: BlockchainInfo;
-    }
+          type: typeof BLOCKCHAIN.CONNECT;
+          payload: BlockchainInfo;
+      }
     | {
-        type: typeof BLOCKCHAIN.ERROR;
-        payload: BlockchainError;
-    }
+          type: typeof BLOCKCHAIN.ERROR;
+          payload: BlockchainError;
+      }
     | {
-        type: typeof BLOCKCHAIN.BLOCK;
-        payload: BlockchainBlock;
-    }
+          type: typeof BLOCKCHAIN.BLOCK;
+          payload: BlockchainBlock;
+      }
     | {
-        type: typeof BLOCKCHAIN.NOTIFICATION;
-        payload: BlockchainNotification;
-    }
+          type: typeof BLOCKCHAIN.NOTIFICATION;
+          payload: BlockchainNotification;
+      }
     | {
-        type: typeof BLOCKCHAIN.FIAT_RATES_UPDATE;
-        payload: BlockchainFiatRatesUpdate;
-    };
+          type: typeof BLOCKCHAIN.FIAT_RATES_UPDATE;
+          payload: BlockchainFiatRatesUpdate;
+      };

--- a/src/ts/types/backend/transactions.d.ts
+++ b/src/ts/types/backend/transactions.d.ts
@@ -97,10 +97,10 @@ export interface RippleLibTransaction {
 
 export type TypedRawTransaction =
     | {
-        type: 'blockbook';
-        tx: BlockbookTransaction;
-    }
+          type: 'blockbook';
+          tx: BlockbookTransaction;
+      }
     | {
-        type: 'ripple';
-        tx: RippleLibTransaction;
-    };
+          type: 'ripple';
+          tx: RippleLibTransaction;
+      };

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -83,6 +83,8 @@ export namespace DEVICE {
 }
 
 export namespace UI {
+    // TRANSPORT is also defined as standalone namespace. plugin bug or invalid syntax?
+    // eslint-disable-next-line @typescript-eslint/no-shadow
     const TRANSPORT = 'ui-no_transport';
     const BOOTLOADER = 'ui-device_bootloader_mode';
     const NOT_IN_BOOTLOADER = 'ui-device_not_in_bootloader_mode';
@@ -164,6 +166,6 @@ export namespace CARDANO {
         StakeRegistration = 0,
         StakeDeregistration = 1,
         StakeDelegation = 2,
-        StakePoolRegistration = 3
+        StakePoolRegistration = 3,
     }
 }

--- a/src/ts/types/events.d.ts
+++ b/src/ts/types/events.d.ts
@@ -129,7 +129,7 @@ export type IFrameLoaded = {
     payload: {
         useBroadcastChannel: boolean;
     };
-}
+};
 
 export interface PopupInit {
     type: typeof POPUP.INIT;

--- a/src/ts/types/misc.d.ts
+++ b/src/ts/types/misc.d.ts
@@ -1,7 +1,7 @@
 export interface CipherKeyValue {
     path: string | number[];
     key?: string;
-    value?: string  | Buffer;
+    value?: string | Buffer;
     encrypt?: boolean;
     askOnEncrypt?: boolean;
     askOnDecrypt?: boolean;

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -43,33 +43,35 @@ export interface HDNodeResponse {
 }
 
 // based on PROTO.TransactionType, with required fields
-export type RefTransaction = {
-    hash: string;
-    version: number;
-    inputs: PrevInput[];
-    bin_outputs: TxOutputBinType[];
-    outputs?: undefined;
-    lock_time: number;
-    extra_data?: string;
-    expiry?: number;
-    overwintered?: boolean;
-    version_group_id?: number;
-    timestamp?: number;
-    branch_id?: number;
-} | {
-    hash: string;
-    version: number;
-    inputs: OrigTxInputType[];
-    bin_outputs?: undefined;
-    outputs: TxOutputType[];
-    lock_time: number;
-    extra_data?: string;
-    expiry?: number;
-    overwintered?: boolean;
-    version_group_id?: number;
-    timestamp?: number;
-    branch_id?: number;
-}
+export type RefTransaction =
+    | {
+          hash: string;
+          version: number;
+          inputs: PrevInput[];
+          bin_outputs: TxOutputBinType[];
+          outputs?: undefined;
+          lock_time: number;
+          extra_data?: string;
+          expiry?: number;
+          overwintered?: boolean;
+          version_group_id?: number;
+          timestamp?: number;
+          branch_id?: number;
+      }
+    | {
+          hash: string;
+          version: number;
+          inputs: OrigTxInputType[];
+          bin_outputs?: undefined;
+          outputs: TxOutputType[];
+          lock_time: number;
+          extra_data?: string;
+          expiry?: number;
+          overwintered?: boolean;
+          version_group_id?: number;
+          timestamp?: number;
+          branch_id?: number;
+      };
 
 // based on PROTO.SignTx, only optional fields
 export type TransactionOptions = {
@@ -88,7 +90,8 @@ export interface SignTransaction {
     inputs: TxInputType[];
     outputs: TxOutputType[];
     refTxs?: RefTransaction[];
-    account?: { // Partial account (addresses)
+    account?: {
+        // Partial account (addresses)
         addresses: {
             used: { path: string; address: string }[];
             unused: { path: string; address: string }[];

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -97,12 +97,12 @@ export type CardanoToken = {
     assetNameBytes: string;
     amount?: string;
     mintAmount?: string;
-}
+};
 
 export type CardanoAssetGroup = {
     policyId: string;
     tokenAmounts: CardanoToken[];
-}
+};
 
 export type CardanoOutput =
     | {
@@ -114,12 +114,12 @@ export type CardanoOutput =
           address: string;
           amount: string;
           tokenBundle?: CardanoAssetGroup[];
-      }
+      };
 
 export type CardanoPoolOwner = {
     stakingKeyPath?: string | number[];
     stakingKeyHash?: string;
-}
+};
 
 export type CardanoPoolRelay = {
     type: CardanoPoolRelayType;
@@ -127,17 +127,17 @@ export type CardanoPoolRelay = {
     ipv6Address?: string;
     port?: number;
     hostName?: string;
-}
+};
 
 export type CardanoPoolMetadata = {
     url: string;
     hash: string;
-}
+};
 
 export type CardanoPoolMargin = {
     numerator: string;
     denominator: string;
-}
+};
 
 export type CardanoPoolParameters = {
     poolId: string;
@@ -149,7 +149,7 @@ export type CardanoPoolParameters = {
     owners: CardanoPoolOwner[];
     relays: CardanoPoolRelay[];
     metadata: CardanoPoolMetadata;
-}
+};
 
 export type CardanoCertificate = {
     type: CardanoCertificateType;
@@ -157,27 +157,27 @@ export type CardanoCertificate = {
     pool?: string;
     poolParameters?: CardanoPoolParameters;
     scriptHash?: string;
-}
+};
 
 export type CardanoWithdrawal = {
     path?: string | number[];
     amount: string;
     scriptHash?: string;
-}
+};
 
-export type CardanoMint = CardanoAssetGroup[]
+export type CardanoMint = CardanoAssetGroup[];
 
 export type CardanoCatalystRegistrationParameters = {
     votingPublicKey: string;
     stakingPath: string | number[];
     rewardAddressParameters: CardanoAddressParameters;
     nonce: string;
-}
+};
 
 export type CardanoAuxiliaryData = {
     hash?: string;
     catalystRegistrationParameters?: CardanoCatalystRegistrationParameters;
-}
+};
 
 export interface CardanoSignTransaction {
     inputs: CardanoInput[];
@@ -201,13 +201,13 @@ export type CardanoSignedTxWitness = {
     pubKey: string;
     signature: string;
     chainCode?: string;
-}
+};
 
 export type CardanoAuxiliaryDataSupplement = {
     type: CardanoTxAuxiliaryDataSupplementType;
     auxiliaryDataHash: string;
     catalystSignature?: string;
-}
+};
 
 export interface CardanoSignedTxData {
     hash: string;

--- a/src/ts/types/networks/coinInfo.d.ts
+++ b/src/ts/types/networks/coinInfo.d.ts
@@ -91,4 +91,4 @@ export type CoinInfo = BitcoinNetworkInfo | EthereumNetworkInfo | MiscNetworkInf
 
 export type GetCoinInfo = {
     coin: string;
-}
+};

--- a/src/ts/types/networks/ethereum.d.ts
+++ b/src/ts/types/networks/ethereum.d.ts
@@ -29,8 +29,8 @@ export interface EthereumTransaction {
     value: string;
     gasPrice: string;
     gasLimit: string;
-    maxFeePerGas?: typeof undefined,
-    maxPriorityFeePerGas?: typeof undefined,
+    maxFeePerGas?: typeof undefined;
+    maxPriorityFeePerGas?: typeof undefined;
     nonce: string;
     data?: string;
     chainId: number;

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -300,31 +300,34 @@ export type TxOutputBinType = {
 // type Exclude<A, B> = $Keys<$Diff<typeof Enum_OutputScriptType, { PAYTOOPRETURN: 3 }>>; // flowtype equivalent of typescript Exclude
 export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
 
-export type TxOutputType = {
-    address: string;
-    address_n?: typeof undefined;
-    script_type: 'PAYTOADDRESS';
-    amount: string;
-    multisig?: MultisigRedeemScriptType;
-    orig_hash?: string;
-    orig_index?: number;
-} | {
-    address?: typeof undefined;
-    address_n: number[];
-    script_type: ChangeOutputScriptType;
-    amount: string;
-    multisig?: MultisigRedeemScriptType;
-    orig_hash?: string;
-    orig_index?: number;
-} | {
-    address?: typeof undefined;
-    address_n?: typeof undefined;
-    amount: '0';
-    op_return_data: string;
-    script_type: 'PAYTOOPRETURN';
-    orig_hash?: string;
-    orig_index?: number;
-};
+export type TxOutputType =
+    | {
+          address: string;
+          address_n?: typeof undefined;
+          script_type: 'PAYTOADDRESS';
+          amount: string;
+          multisig?: MultisigRedeemScriptType;
+          orig_hash?: string;
+          orig_index?: number;
+      }
+    | {
+          address?: typeof undefined;
+          address_n: number[];
+          script_type: ChangeOutputScriptType;
+          amount: string;
+          multisig?: MultisigRedeemScriptType;
+          orig_hash?: string;
+          orig_index?: number;
+      }
+    | {
+          address?: typeof undefined;
+          address_n?: typeof undefined;
+          amount: '0';
+          op_return_data: string;
+          script_type: 'PAYTOOPRETURN';
+          orig_hash?: string;
+          orig_index?: number;
+      };
 // - TxOutputType replacement end
 
 // TxInput
@@ -388,26 +391,31 @@ export type PrevOutput = {
 // PrevInput and TxInputType requires exact responses in TxAckResponse
 // main difference: PrevInput should not contain address_n (unexpected field by protobuf)
 
-export type TxAckResponse = {
-    inputs: Array<TxInputType | PrevInput>;
-} | {
-    bin_outputs: TxOutputBinType[];
-} | {
-    outputs: TxOutputType[];
-} | {
-    extra_data: string;
-} | {
-    version?: number;
-    lock_time?: number;
-    inputs_cnt: number;
-    outputs_cnt: number;
-    extra_data?: string;
-    extra_data_len?: number;
-    timestamp?: number;
-    version_group_id?: number;
-    expiry?: number;
-    branch_id?: number;
-};
+export type TxAckResponse =
+    | {
+          inputs: Array<TxInputType | PrevInput>;
+      }
+    | {
+          bin_outputs: TxOutputBinType[];
+      }
+    | {
+          outputs: TxOutputType[];
+      }
+    | {
+          extra_data: string;
+      }
+    | {
+          version?: number;
+          lock_time?: number;
+          inputs_cnt: number;
+          outputs_cnt: number;
+          extra_data?: string;
+          extra_data_len?: number;
+          timestamp?: number;
+          version_group_id?: number;
+          expiry?: number;
+          branch_id?: number;
+      };
 
 export type TxAck = {
     tx: TxAckResponse;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,7 +1969,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -2053,6 +2053,32 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^4.29.1":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    debug "^4.3.1"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
+  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.2.0.tgz#3d0b5cd4aa61f5eb7aa1e873dea0db1410b062d2"
@@ -2065,6 +2091,16 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/parser@^4.29.1":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
+
 "@typescript-eslint/scope-manager@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.2.0.tgz#d10e6854a65e175b22a28265d372a97c8cce4bfc"
@@ -2073,10 +2109,23 @@
     "@typescript-eslint/types" "4.2.0"
     "@typescript-eslint/visitor-keys" "4.2.0"
 
+"@typescript-eslint/scope-manager@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
+  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+
 "@typescript-eslint/types@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.2.0.tgz#6f6b094329e72040f173123832397c7c0b910fc8"
   integrity sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg==
+
+"@typescript-eslint/types@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
+  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
 
 "@typescript-eslint/typescript-estree@4.2.0":
   version "4.2.0"
@@ -2092,12 +2141,33 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
+  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.2.0.tgz#ae13838e3a260b63ae51021ecaf1d0cdea8dbba5"
   integrity sha512-WIf4BNOlFOH2W+YqGWa6YKLcK/EB3gEj2apCrqLw6mme1RzBy0jtJ9ewJgnrZDB640zfnv8L+/gwGH5sYp/rGw==
   dependencies:
     "@typescript-eslint/types" "4.2.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
+  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -3812,6 +3882,13 @@ debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debug@~4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
@@ -4436,6 +4513,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
@@ -5562,6 +5646,11 @@ ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
+ignore@^5.1.8:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 image-size@~0.5.0:
   version "0.5.5"
@@ -9646,6 +9735,13 @@ tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
`eslint` wasn't enabled properly on typescript files. it didn't throw any errors, yet didn't work as well.
errors was visible in vscode while manually editing `*.ts` files

changes may affect https://github.com/trezor/connect/pull/983 (conflict in ts files)