### PR TITLE
chore: remove ethereum checksum address

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "karma-jasmine-async": "^0.0.1",
         "karma-sourcemap-loader": "^0.3.8",
         "karma-webpack": "^5.0.0",
-        "keccak": "^3.0.2",
         "less": "4.1.1",
         "less-loader": "^10.0.1",
         "less-plugin-autoprefix": "^2.0.0",
@@ -137,7 +136,6 @@
         "bignumber.js": "^9.0.1",
         "bowser": "^2.11.0",
         "cbor-web": "^7.0.6",
-        "keccak": "^3.0.2",
         "parse-uri": "^1.0.3",
         "tiny-worker": "^2.3.0"
     }

--- a/src/js/core/methods/EthereumGetAddress.js
+++ b/src/js/core/methods/EthereumGetAddress.js
@@ -143,15 +143,12 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         return uiResp.payload;
     }
 
-    _call({ address_n, show_display, network }: Params) {
+    _call({ address_n, show_display }: Params) {
         const cmd = this.device.getCommands();
-        return cmd.ethereumGetAddress(
-            {
-                address_n,
-                show_display,
-            },
-            network,
-        );
+        return cmd.ethereumGetAddress({
+            address_n,
+            show_display,
+        });
     }
 
     async run() {

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -4,14 +4,12 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
-import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
+import { getNetworkLabel } from '../../utils/ethereumUtils';
 import { messageToHex } from '../../utils/formatUtils';
-import type { EthereumNetworkInfo } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
     ...$ElementType<MessageType, 'EthereumSignMessage'>,
-    network?: EthereumNetworkInfo,
 };
 
 export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMessage'> {
@@ -41,18 +39,16 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
         this.params = {
             address_n: path,
             message: messageHex,
-            network,
         };
     }
 
     async run() {
         const cmd = this.device.getCommands();
-        const { address_n, message, network } = this.params;
+        const { address_n, message } = this.params;
         const response = await cmd.typedCall('EthereumSignMessage', 'EthereumMessageSignature', {
             address_n,
             message,
         });
-        response.message.address = toChecksumAddress(response.message.address, network);
         return response.message;
     }
 }

--- a/src/js/core/methods/EthereumSignTypedData.js
+++ b/src/js/core/methods/EthereumSignTypedData.js
@@ -4,8 +4,7 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
-import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
-import type { EthereumNetworkInfo } from '../../types';
+import { getNetworkLabel } from '../../utils/ethereumUtils';
 import type { MessageResponse, EthereumTypedDataStructAck } from '../../types/trezor/protobuf';
 import { ERRORS } from '../../constants';
 import type { EthereumSignTypedData as EthereumSignTypedDataParams } from '../../types/networks/ethereum';
@@ -14,7 +13,6 @@ import { getFieldType, parseArrayType, encodeData } from './helpers/ethereumSign
 type Params = {
     ...EthereumSignTypedDataParams,
     path: number[],
-    network?: EthereumNetworkInfo,
 };
 
 export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignTypedData'> {
@@ -42,7 +40,6 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
 
         this.params = {
             path,
-            network,
             data,
             metamask_v4_compat,
         };
@@ -50,7 +47,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
 
     async run() {
         const cmd = this.device.getCommands();
-        const { path: address_n, network, data, metamask_v4_compat } = this.params;
+        const { path: address_n, data, metamask_v4_compat } = this.params;
 
         const { types, primaryType, domain, message } = data;
 
@@ -154,7 +151,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
         // $FlowIssue disjoint union Refinements not working, TODO: check if new Flow versions fix this
         const { address, signature } = response.message;
         return {
-            address: toChecksumAddress(address, network),
+            address,
             signature: `0x${signature}`,
         };
     }

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -16,19 +16,12 @@ import {
     toHardened,
 } from '../utils/pathUtils';
 import { getAccountAddressN } from '../utils/accountUtils';
-import { toChecksumAddress } from '../utils/ethereumUtils';
 import { versionCompare } from '../utils/versionUtils';
 
 import { getSegwitNetwork, getBech32Network } from '../data/CoinInfo';
 
 import type { IDevice } from './Device';
-import type {
-    CoinInfo,
-    BitcoinNetworkInfo,
-    EthereumNetworkInfo,
-    Network,
-    HDNodeResponse,
-} from '../types';
+import type { CoinInfo, BitcoinNetworkInfo, Network, HDNodeResponse } from '../types';
 import type { CardanoDerivationType } from '../types/trezor/protobuf';
 import * as PROTO from '../types/trezor/protobuf';
 
@@ -278,10 +271,7 @@ export default class DeviceCommands {
         };
     }
 
-    async ethereumGetAddress(
-        { address_n, show_display }: PROTO.EthereumGetAddress,
-        network?: EthereumNetworkInfo,
-    ) {
+    async ethereumGetAddress({ address_n, show_display }: PROTO.EthereumGetAddress) {
         const response = await this.typedCall('EthereumGetAddress', 'EthereumAddress', {
             address_n,
             show_display,
@@ -289,7 +279,7 @@ export default class DeviceCommands {
         return {
             path: address_n,
             serializedPath: getSerializedPath(address_n),
-            address: toChecksumAddress(response.message.address, network),
+            address: response.message.address,
         };
     }
 
@@ -616,7 +606,7 @@ export default class DeviceCommands {
             };
         }
         if (coinInfo.type === 'ethereum') {
-            const resp = await this.ethereumGetAddress({ address_n }, coinInfo);
+            const resp = await this.ethereumGetAddress({ address_n });
             return {
                 descriptor: resp.address,
                 address_n,

--- a/src/js/utils/ethereumUtils.js
+++ b/src/js/utils/ethereumUtils.js
@@ -1,24 +1,5 @@
 /* @flow */
-import createKeccakHash from 'keccak';
-import type { EthereumNetworkInfo, CoinInfo } from '../types';
-import { hasHexPrefix, stripHexPrefix } from './formatUtils';
-
-export const toChecksumAddress = (address: string, network: ?EthereumNetworkInfo) => {
-    if (hasHexPrefix(address)) return address;
-    let clean = stripHexPrefix(address);
-    // different checksum for RSK
-    if (network && network.rskip60) clean = `${network.chainId}0x${address}`;
-    const hash = createKeccakHash('keccak256').update(clean).digest('hex');
-    let response = '0x';
-    for (let i = 0; i < address.length; i++) {
-        if (parseInt(hash[i], 16) >= 8) {
-            response += address[i].toUpperCase();
-        } else {
-            response += address[i];
-        }
-    }
-    return response;
-};
+import type { CoinInfo } from '../types';
 
 export const getNetworkLabel = (label: string, network: ?CoinInfo) => {
     if (network) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6853,15 +6853,6 @@ karma@^6.3.0:
     ua-parser-js "^0.7.28"
     yargs "^16.1.1"
 
-keccak@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
-  integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
-  dependencies:
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
-    readable-stream "^3.6.0"
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -7433,11 +7424,6 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
 node-addon-api@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -7460,11 +7446,6 @@ node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
-
-node-gyp-build@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
-  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp-build@^4.2.2:
   version "4.3.0"


### PR DESCRIPTION
since min required versions to work with eth are `1.8.0` and  `2.1.0`, we can most likely remove client side address checksum.
