### PR TITLE
Refactor/method payload typed

### DIFF
--- a/scripts/protobuf-patches/index.js
+++ b/scripts/protobuf-patches/index.js
@@ -125,6 +125,8 @@ const TYPE_PATCH = {
     'CardanoToken.mint_amount': 'string | number',
     'CardanoTxOutputType.amount': 'string | number',
     'CardanoTxOutput.amount': 'string | number',
+    'CardanoTxWithdrawal.amount': 'string | number',
+    'CardanoTxWithdrawalType.amount': 'string | number',
     'CardanoNativeScript.invalid_before': 'string | number',
     'CardanoNativeScript.invalid_hereafter': 'string | number',
     'EosAsset.amount': 'string',
@@ -164,6 +166,7 @@ const TYPE_PATCH = {
     'EosActionNewAccount.creator': 'string',
     'EosActionNewAccount.name': 'string',
     'NEMTransfer.amount': 'string | number',
+    'ResetDevice.backup_type': 'string | number', // BackupType is a enum. in Features displayed as string, in resetDevice method param accepted as number
     'RipplePayment.amount': 'string | number',
     'RippleSignTx.fee': 'string | number',
     'StellarAssetType.type': '0 | 1 | 2',

--- a/src/js/core/Core.js
+++ b/src/js/core/Core.js
@@ -47,7 +47,7 @@ let _core: Core; // Class with event emitter
 let _deviceList: ?DeviceList; // Instance of DeviceList
 let _popupPromise: ?Deferred<void>; // Waiting for popup handshake
 let _uiPromises: Deferred<UiPromiseResponse>[] = []; // Waiting for ui response
-const _callMethods: AbstractMethod[] = [];
+const _callMethods: AbstractMethod<any>[] = []; // generic type is irrelevant. only common functions are called at this level
 let _preferredDevice: any; // TODO: type
 let _interactionTimeout: InteractionTimeout;
 
@@ -211,7 +211,7 @@ export const handleMessage = (message: CoreMessage, isTrustedOrigin: boolean = f
  * @returns {Promise<IDevice>}
  * @memberof Core
  */
-const initDevice = async (method: AbstractMethod) => {
+const initDevice = async (method: AbstractMethod<any>) => {
     if (!_deviceList) {
         throw ERRORS.TypedError('Transport_Missing');
     }
@@ -302,7 +302,7 @@ export const onCall = async (message: CoreMessage) => {
     }
 
     // find method and parse incoming params
-    let method: AbstractMethod;
+    let method: AbstractMethod<any>;
     let messageResponse: ?CoreMessage;
     try {
         method = findMethod(message);
@@ -312,6 +312,8 @@ export const onCall = async (message: CoreMessage) => {
         method.createUiPromise = createUiPromise;
         method.findUiPromise = findUiPromise;
         method.removeUiPromise = removeUiPromise;
+        // start validation process
+        method.init();
     } catch (error) {
         postMessage(UiMessage(POPUP.CANCEL_POPUP_REQUEST));
         postMessage(ResponseMessage(responseID, false, { error }));
@@ -722,7 +724,7 @@ const closePopup = () => {
 const onDeviceButtonHandler = async (
     device: IDevice,
     request: ButtonRequest,
-    method: AbstractMethod,
+    method: AbstractMethod<any>,
 ) => {
     // wait for popup handshake
     const addressRequest = request.code === 'ButtonRequest_Address';

--- a/src/js/core/methods/ApplyFlags.js
+++ b/src/js/core/methods/ApplyFlags.js
@@ -5,18 +5,16 @@ import { validateParams } from './helpers/paramsValidator';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class ApplyFlags extends AbstractMethod {
+export default class ApplyFlags extends AbstractMethod<'applyFlags'> {
     params: $ElementType<MessageType, 'ApplyFlags'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [{ name: 'flags', type: 'number', obligatory: true }]);
 

--- a/src/js/core/methods/ApplySettings.js
+++ b/src/js/core/methods/ApplySettings.js
@@ -5,17 +5,15 @@ import * as UI from '../../constants/ui';
 import { validateParams } from './helpers/paramsValidator';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class ApplySettings extends AbstractMethod {
+export default class ApplySettings extends AbstractMethod<'applySettings'> {
     params: $ElementType<MessageType, 'ApplySettings'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [
             { name: 'language', type: 'string' },
@@ -35,12 +33,13 @@ export default class ApplySettings extends AbstractMethod {
             label: payload.label,
             use_passphrase: payload.use_passphrase,
             homescreen: payload.homescreen,
-            passphrase_source: payload.passphrase_source,
             passphrase_always_on_device: payload.passphrase_always_on_device,
             auto_lock_delay_ms: payload.auto_lock_delay_ms,
             display_rotation: payload.display_rotation,
             safety_checks: payload.safety_checks,
             experimental_features: payload.experimental_features,
+            // $FlowIssue passphrase_source is a legacy param
+            _passphrase_source: payload.passphrase_source,
         };
     }
 

--- a/src/js/core/methods/BackupDevice.js
+++ b/src/js/core/methods/BackupDevice.js
@@ -4,11 +4,8 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
-
-export default class BackupDevice extends AbstractMethod {
-    constructor(message: CoreMessage) {
-        super(message);
+export default class BackupDevice extends AbstractMethod<'backupDevice'> {
+    init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
     }

--- a/src/js/core/methods/BinanceGetAddress.js
+++ b/src/js/core/methods/BinanceGetAddress.js
@@ -8,7 +8,6 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
 import type { BinanceAddress } from '../../types/networks/binance';
 import type { MessageType } from '../../types/trezor/protobuf';
 
@@ -17,7 +16,7 @@ type Params = {
     address?: string,
 };
 
-export default class BinanceGetAddress extends AbstractMethod {
+export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -26,17 +25,15 @@ export default class BinanceGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/BinanceGetPublicKey.js
+++ b/src/js/core/methods/BinanceGetPublicKey.js
@@ -9,28 +9,25 @@ import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
 import type { BinancePublicKey } from '../../types/networks/binance';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class BinanceGetPublicKey extends AbstractMethod {
+export default class BinanceGetPublicKey extends AbstractMethod<'binanceGetPublicKey'> {
     params: $ElementType<MessageType, 'BinanceGetPublicKey'>[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
         this.info = 'Export Binance public key';
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/BinanceSignTransaction.js
+++ b/src/js/core/methods/BinanceSignTransaction.js
@@ -6,7 +6,6 @@ import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/binanceSignTx';
 
-import type { CoreMessage } from '../../types';
 import type { BinancePreparedTransaction } from '../../types/networks/binance';
 
 type Params = {
@@ -14,16 +13,15 @@ type Params = {
     transaction: BinancePreparedTransaction,
 };
 
-export default class BinanceSignTransaction extends AbstractMethod {
+export default class BinanceSignTransaction extends AbstractMethod<'binanceSignTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
         this.info = 'Sign Binance transaction';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', type: 'string', obligatory: true },

--- a/src/js/core/methods/CardanoGetAddress.js
+++ b/src/js/core/methods/CardanoGetAddress.js
@@ -14,7 +14,6 @@ import {
 import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
 import type { CardanoAddress } from '../../types/networks/cardano';
 import { CardanoAddressType } from '../../types/networks/cardano';
 import type { MessageType } from '../../types/trezor/protobuf';
@@ -25,7 +24,7 @@ type Params = {
     address?: string,
 };
 
-export default class CardanoGetAddress extends AbstractMethod {
+export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -34,9 +33,7 @@ export default class CardanoGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -45,10 +42,10 @@ export default class CardanoGetAddress extends AbstractMethod {
         );
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/CardanoGetNativeScriptHash.js
+++ b/src/js/core/methods/CardanoGetNativeScriptHash.js
@@ -5,7 +5,6 @@ import { getFirmwareRange, validateParams } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 
-import type { CoreMessage } from '../../types';
 import type { CardanoNativeScript } from '../../types/networks/cardano';
 import type {
     CardanoNativeScript as CardanoNativeScriptProto,
@@ -14,12 +13,10 @@ import type {
 import { Enum_CardanoDerivationType as CardanoDerivationType } from '../../types/trezor/protobuf';
 
 type Params = $ElementType<MessageType, 'CardanoGetNativeScriptHash'>;
-export default class CardanoGetNativeScriptHash extends AbstractMethod {
+export default class CardanoGetNativeScriptHash extends AbstractMethod<'cardanoGetNativeScriptHash'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -28,7 +25,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod {
         );
         this.info = 'Get Cardano native script hash';
 
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [
             { name: 'script', type: 'object', obligatory: true },

--- a/src/js/core/methods/CardanoGetPublicKey.js
+++ b/src/js/core/methods/CardanoGetPublicKey.js
@@ -8,21 +8,18 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
 import type { CardanoPublicKey } from '../../types/networks/cardano';
 import type { MessageType } from '../../types/trezor/protobuf';
 import { Enum_CardanoDerivationType as CardanoDerivationType } from '../../types/trezor/protobuf';
 
-export default class CardanoGetPublicKey extends AbstractMethod {
+export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPublicKey'> {
     params: $ElementType<MessageType, 'CardanoGetPublicKey'>[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -32,10 +29,10 @@ export default class CardanoGetPublicKey extends AbstractMethod {
         this.info = 'Export Cardano public key';
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/ChangePin.js
+++ b/src/js/core/methods/ChangePin.js
@@ -2,19 +2,16 @@
 
 import AbstractMethod from './AbstractMethod';
 import { validateParams } from './helpers/paramsValidator';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class ChangePin extends AbstractMethod {
+export default class ChangePin extends AbstractMethod<'changePin'> {
     params: $ElementType<MessageType, 'ChangePin'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 
-        const { payload } = message;
+        const { payload } = this;
         validateParams(payload, [{ name: 'remove', type: 'boolean' }]);
 
         this.params = {

--- a/src/js/core/methods/CipherKeyValue.js
+++ b/src/js/core/methods/CipherKeyValue.js
@@ -5,28 +5,24 @@ import { UiMessage } from '../../message/builder';
 import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
-
-import type { CoreMessage } from '../../types';
 import type { MessageType, CipheredKeyValue } from '../../types/trezor/protobuf';
 
-export default class CipherKeyValue extends AbstractMethod {
+export default class CipherKeyValue extends AbstractMethod<'cipherKeyValue'> {
     params: $ElementType<MessageType, 'CipherKeyValue'>[] = [];
 
     hasBundle: boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.info = 'Cypher key value';
         this.useEmptyPassphrase = true;
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/ComposeTransaction.js
+++ b/src/js/core/methods/ComposeTransaction.js
@@ -29,7 +29,7 @@ import { verifyTx } from './helpers/signtxVerify';
 
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage, BitcoinNetworkInfo } from '../../types';
+import type { BitcoinNetworkInfo } from '../../types';
 import type { SignedTransaction, TransactionOptions } from '../../types/networks/bitcoin';
 import type {
     DiscoveryAccount,
@@ -50,16 +50,15 @@ type Params = {
     skipPermutation?: $ElementType<PrecomposeParams, 'skipPermutation'>,
 };
 
-export default class ComposeTransaction extends AbstractMethod {
+export default class ComposeTransaction extends AbstractMethod<'composeTransaction'> {
     params: Params;
 
     discovery: Discovery | typeof undefined;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'outputs', type: 'array', obligatory: true },

--- a/src/js/core/methods/CustomMessage.js
+++ b/src/js/core/methods/CustomMessage.js
@@ -5,31 +5,29 @@ import { validateParams } from './helpers/paramsValidator';
 import { UI, ERRORS } from '../../constants';
 
 import { UiMessage } from '../../message/builder';
-import type { CoreMessage } from '../../types';
 
 type Params = {
-    customMessages: JSON,
+    customMessages?: JSON,
     message: string,
     params: any,
 };
 
-export default class CustomMessage extends AbstractMethod {
+export default class CustomMessage extends AbstractMethod<'customMessage'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['custom-message', 'read', 'write'];
         this.info = 'Custom message';
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
-        validateParams(message.payload, [
+        validateParams(payload, [
             { name: 'message', type: 'string', obligatory: true },
             { name: 'params', type: 'object', obligatory: true },
         ]);
 
-        if (Object.prototype.hasOwnProperty.call(payload, 'messages')) {
+        if (payload.messages) {
             try {
                 JSON.parse(JSON.stringify(payload.messages));
             } catch (error) {

--- a/src/js/core/methods/EosGetPublicKey.js
+++ b/src/js/core/methods/EosGetPublicKey.js
@@ -8,28 +8,25 @@ import { validatePath, fromHardened, getSerializedPath } from '../../utils/pathU
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 import type { EosPublicKey } from '../../types/networks/eos';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class EosGetPublicKey extends AbstractMethod {
+export default class EosGetPublicKey extends AbstractMethod<'eosGetPublicKey'> {
     params: $ElementType<MessageType, 'EosGetPublicKey'>[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
         this.info = 'Export Eos public key';
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/EosSignTransaction.js
+++ b/src/js/core/methods/EosSignTransaction.js
@@ -7,7 +7,6 @@ import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/eosSignTx';
 
 import type { EosTxHeader, EosTxActionAck } from '../../types/trezor/protobuf';
-import type { CoreMessage } from '../../types';
 
 type Params = {
     path: number[],
@@ -16,16 +15,15 @@ type Params = {
     ack: EosTxActionAck[],
 };
 
-export default class EosSignTransaction extends AbstractMethod {
+export default class EosSignTransaction extends AbstractMethod<'eosSignTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
         this.info = 'Sign EOS transaction';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },

--- a/src/js/core/methods/EthereumGetAddress.js
+++ b/src/js/core/methods/EthereumGetAddress.js
@@ -11,7 +11,7 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { EthereumAddress } from '../../types/networks/ethereum';
-import type { CoreMessage, EthereumNetworkInfo } from '../../types';
+import type { EthereumNetworkInfo } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -20,7 +20,7 @@ type Params = {
     network?: EthereumNetworkInfo,
 };
 
-export default class EthereumGetAddress extends AbstractMethod {
+export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -29,16 +29,14 @@ export default class EthereumGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/EthereumGetPublicKey.js
+++ b/src/js/core/methods/EthereumGetPublicKey.js
@@ -9,7 +9,7 @@ import { getEthereumNetwork, getUniqueNetworks } from '../../data/CoinInfo';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage, EthereumNetworkInfo, HDNodeResponse } from '../../types';
+import type { EthereumNetworkInfo, HDNodeResponse } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -17,23 +17,21 @@ type Params = {
     network?: EthereumNetworkInfo,
 };
 
-export default class EthereumGetPublicKey extends AbstractMethod {
+export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPublicKey'> {
     params: Params[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/EthereumSignMessage.js
+++ b/src/js/core/methods/EthereumSignMessage.js
@@ -6,7 +6,7 @@ import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
 import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
 import { messageToHex } from '../../utils/formatUtils';
-import type { CoreMessage, EthereumNetworkInfo } from '../../types';
+import type { EthereumNetworkInfo } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -14,15 +14,13 @@ type Params = {
     network?: EthereumNetworkInfo,
 };
 
-export default class EthereumSignMessage extends AbstractMethod {
+export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMessage'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/EthereumSignTransaction.js
+++ b/src/js/core/methods/EthereumSignTransaction.js
@@ -7,8 +7,6 @@ import { getEthereumNetwork } from '../../data/CoinInfo';
 import { getNetworkLabel } from '../../utils/ethereumUtils';
 import { stripHexPrefix } from '../../utils/formatUtils';
 import * as helper from './helpers/ethereumSignTx';
-
-import type { CoreMessage } from '../../types';
 import type {
     EthereumTransaction,
     EthereumTransactionEIP1559,
@@ -40,15 +38,13 @@ const strip: (value: any) => any = value => {
     return value;
 };
 
-export default class EthereumSignTx extends AbstractMethod {
+export default class EthereumSignTx extends AbstractMethod<'ethereumSignTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/EthereumSignTypedData.js
+++ b/src/js/core/methods/EthereumSignTypedData.js
@@ -5,7 +5,7 @@ import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { validatePath } from '../../utils/pathUtils';
 import { getEthereumNetwork } from '../../data/CoinInfo';
 import { toChecksumAddress, getNetworkLabel } from '../../utils/ethereumUtils';
-import type { CoreMessage, EthereumNetworkInfo } from '../../types';
+import type { EthereumNetworkInfo } from '../../types';
 import type { MessageResponse, EthereumTypedDataStructAck } from '../../types/trezor/protobuf';
 import { ERRORS } from '../../constants';
 import type { EthereumSignTypedData as EthereumSignTypedDataParams } from '../../types/networks/ethereum';
@@ -17,15 +17,13 @@ type Params = {
     network?: EthereumNetworkInfo,
 };
 
-export default class EthereumSignTypedData extends AbstractMethod {
+export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignTypedData'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/EthereumVerifyMessage.js
+++ b/src/js/core/methods/EthereumVerifyMessage.js
@@ -3,20 +3,17 @@
 import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { stripHexPrefix, messageToHex } from '../../utils/formatUtils';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class EthereumVerifyMessage extends AbstractMethod {
+export default class EthereumVerifyMessage extends AbstractMethod<'ethereumVerifyMessage'> {
     params: $ElementType<MessageType, 'EthereumVerifyMessage'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.info = 'Verify message';
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/FirmwareUpdate.js
+++ b/src/js/core/methods/FirmwareUpdate.js
@@ -7,8 +7,6 @@ import { UiMessage } from '../../message/builder';
 import { validateParams } from './helpers/paramsValidator';
 import { getReleases } from '../../data/FirmwareInfo';
 
-import type { CoreMessage } from '../../types';
-
 type Params = {
     binary?: ArrayBuffer,
     version?: number[],
@@ -17,11 +15,10 @@ type Params = {
     intermediary?: boolean,
 };
 
-export default class FirmwareUpdate extends AbstractMethod {
+export default class FirmwareUpdate extends AbstractMethod<'firmwareUpdate'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useEmptyPassphrase = true;
         this.requiredPermissions = ['management'];
         this.allowDeviceMode = [UI.BOOTLOADER, UI.INITIALIZE];
@@ -29,7 +26,7 @@ export default class FirmwareUpdate extends AbstractMethod {
         this.useDeviceState = false;
         this.skipFirmwareCheck = true;
 
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [
             { name: 'version', type: 'array' },
@@ -74,13 +71,13 @@ export default class FirmwareUpdate extends AbstractMethod {
     }
 
     async run() {
-        const { device } = this;
+        const { device, params } = this;
 
         let binary: ArrayBuffer;
         try {
-            if (this.params.binary) {
+            if (params.binary) {
                 binary = modifyFirmware({
-                    fw: this.params.binary,
+                    fw: params.binary,
                     features: device.features,
                 });
             } else {
@@ -89,10 +86,10 @@ export default class FirmwareUpdate extends AbstractMethod {
                     features: device.features,
                     releases: getReleases(device.features.major_version),
                     // version argument is used to find and fetch concrete release from releases list
-                    version: this.params.version,
-                    btcOnly: this.params.btcOnly,
-                    baseUrl: this.params.baseUrl,
-                    intermediary: this.params.intermediary,
+                    version: params.version,
+                    btcOnly: params.btcOnly,
+                    baseUrl: params.baseUrl,
+                    intermediary: params.intermediary,
                 });
                 binary = firmware.binary;
             }

--- a/src/js/core/methods/GetAccountInfo.js
+++ b/src/js/core/methods/GetAccountInfo.js
@@ -12,7 +12,7 @@ import { UiMessage } from '../../message/builder';
 
 import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 
-import type { CoreMessage, CoinInfo } from '../../types';
+import type { CoinInfo } from '../../types';
 import type {
     GetAccountInfo as GetAccountInfoParams,
     AccountInfo,
@@ -24,7 +24,7 @@ import { Enum_CardanoDerivationType } from '../../types/trezor/protobuf';
 type Request = GetAccountInfoParams & { address_n: number[], coinInfo: CoinInfo };
 type Params = Request[];
 
-export default class GetAccountInfo extends AbstractMethod {
+export default class GetAccountInfo extends AbstractMethod<'getAccountInfo'> {
     params: Params;
 
     disposed: boolean = false;
@@ -35,9 +35,7 @@ export default class GetAccountInfo extends AbstractMethod {
 
     derivationType: ?CardanoDerivationType;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.info = 'Export account info';
         this.useDevice = true;
@@ -47,10 +45,10 @@ export default class GetAccountInfo extends AbstractMethod {
         let willUseDevice = false;
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [
@@ -58,7 +56,7 @@ export default class GetAccountInfo extends AbstractMethod {
             { name: 'derivationType', type: 'number' },
         ]);
 
-        payload.bundle.forEach(batch => {
+        this.params = payload.bundle.map(batch => {
             // validate incoming parameters
             validateParams(batch, [
                 { name: 'coin', type: 'string', obligatory: true },
@@ -85,8 +83,9 @@ export default class GetAccountInfo extends AbstractMethod {
             // validate backend
             isBackendSupported(coinInfo);
             // validate path if exists
+            let address_n = [];
             if (batch.path) {
-                batch.address_n = validatePath(batch.path, 3);
+                address_n = validatePath(batch.path, 3);
                 // since there is no descriptor device will be used
                 willUseDevice = typeof batch.descriptor !== 'string';
             }
@@ -97,13 +96,18 @@ export default class GetAccountInfo extends AbstractMethod {
                 // device will be used in Discovery
                 willUseDevice = true;
             }
-            batch.coinInfo = coinInfo;
 
             // set firmware range
             this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+
+            return {
+                ...batch,
+                address_n,
+                coinInfo,
+            };
         });
 
-        this.params = payload.bundle;
+        // this.params = payload.bundle;
 
         this.useDevice = willUseDevice;
         this.useUi = willUseDevice;

--- a/src/js/core/methods/GetAddress.js
+++ b/src/js/core/methods/GetAddress.js
@@ -9,7 +9,7 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { Address } from '../../types/networks/bitcoin';
-import type { CoreMessage, BitcoinNetworkInfo } from '../../types';
+import type { BitcoinNetworkInfo } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -18,7 +18,7 @@ type Params = {
     coinInfo: BitcoinNetworkInfo,
 };
 
-export default class GetAddress extends AbstractMethod {
+export default class GetAddress extends AbstractMethod<'getAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -27,16 +27,14 @@ export default class GetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/GetCoinInfo.js
+++ b/src/js/core/methods/GetCoinInfo.js
@@ -5,22 +5,21 @@ import { validateParams } from './helpers/paramsValidator';
 import { ERRORS } from '../../constants';
 
 import { getCoinInfo } from '../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../types';
+import type { CoinInfo } from '../../types';
 
 type Params = {
     coinInfo: CoinInfo,
 };
 
-export default class GetCoinInfo extends AbstractMethod {
+export default class GetCoinInfo extends AbstractMethod<'getCoinInfo'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [{ name: 'coin', type: 'string', obligatory: true }]);
 

--- a/src/js/core/methods/GetDeviceState.js
+++ b/src/js/core/methods/GetDeviceState.js
@@ -1,11 +1,9 @@
 /* @flow */
 
 import AbstractMethod from './AbstractMethod';
-import type { CoreMessage } from '../../types';
 
-export default class GetDeviceState extends AbstractMethod {
-    constructor(message: CoreMessage) {
-        super(message);
+export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {
+    init() {
         this.requiredPermissions = [];
     }
 

--- a/src/js/core/methods/GetFeatures.js
+++ b/src/js/core/methods/GetFeatures.js
@@ -1,13 +1,10 @@
 /* @flow */
 
 import AbstractMethod from './AbstractMethod';
-
-import type { CoreMessage } from '../../types';
 import * as UI from '../../constants/ui';
 
-export default class GetFeatures extends AbstractMethod {
-    constructor(message: CoreMessage) {
-        super(message);
+export default class GetFeatures extends AbstractMethod<'getFeatures'> {
+    init() {
         this.requiredPermissions = [];
         this.useUi = false;
         this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE, UI.BOOTLOADER];

--- a/src/js/core/methods/GetPublicKey.js
+++ b/src/js/core/methods/GetPublicKey.js
@@ -9,7 +9,7 @@ import { UiMessage } from '../../message/builder';
 
 import { getBitcoinNetwork } from '../../data/CoinInfo';
 import { getPublicKeyLabel } from '../../utils/accountUtils';
-import type { CoreMessage, BitcoinNetworkInfo, HDNodeResponse } from '../../types';
+import type { BitcoinNetworkInfo, HDNodeResponse } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -17,24 +17,22 @@ type Params = {
     coinInfo: ?BitcoinNetworkInfo,
 };
 
-export default class GetPublicKey extends AbstractMethod {
+export default class GetPublicKey extends AbstractMethod<'getPublicKey'> {
     params: Params[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.info = 'Export public key';
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/GetSettings.js
+++ b/src/js/core/methods/GetSettings.js
@@ -2,11 +2,9 @@
 
 import AbstractMethod from './AbstractMethod';
 import DataManager from '../../data/DataManager';
-import type { CoreMessage } from '../../types';
 
-export default class GetSettings extends AbstractMethod {
-    constructor(message: CoreMessage) {
-        super(message);
+export default class GetSettings extends AbstractMethod<'getSettings'> {
+    init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/src/js/core/methods/LiskDeprecated.js
+++ b/src/js/core/methods/LiskDeprecated.js
@@ -6,10 +6,8 @@ import AbstractMethod from './AbstractMethod';
 // FirmwareRange is set to "0" for both T1 and TT
 // This should be removed in next major version of connect
 
-export default class LiskDeprecated extends AbstractMethod {
-    constructor(message: any) {
-        super(message);
-
+export default class LiskDeprecated extends AbstractMethod<any> {
+    init() {
         this.firmwareRange = {
             '1': { min: '0', max: '0' },
             '2': { min: '0', max: '0' },

--- a/src/js/core/methods/LoadDevice.js
+++ b/src/js/core/methods/LoadDevice.js
@@ -4,22 +4,21 @@ import AbstractMethod from './AbstractMethod';
 import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 import { validateParams } from './helpers/paramsValidator';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class LoadDevice extends AbstractMethod {
+// TODO: this method is not used in API
+export default class LoadDevice extends AbstractMethod<any> {
     params: $ElementType<MessageType, 'LoadDevice'>;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
         this.info = 'Load device';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate bundle type
         validateParams(payload, [
             { name: 'mnemonics', type: 'array' },

--- a/src/js/core/methods/NEMGetAddress.js
+++ b/src/js/core/methods/NEMGetAddress.js
@@ -9,7 +9,6 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { NEMAddress } from '../../types/networks/nem';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -21,7 +20,7 @@ const MAINNET = 0x68; // 104
 const TESTNET = 0x98; // 152
 const MIJIN = 0x60; // 96
 
-export default class NEMGetAddress extends AbstractMethod {
+export default class NEMGetAddress extends AbstractMethod<'nemGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -30,17 +29,15 @@ export default class NEMGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/NEMSignTransaction.js
+++ b/src/js/core/methods/NEMSignTransaction.js
@@ -6,19 +6,17 @@ import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/nemSignTx';
 
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class NEMSignTransaction extends AbstractMethod {
+export default class NEMSignTransaction extends AbstractMethod<'nemSignTransaction'> {
     params: $ElementType<MessageType, 'NEMSignTx'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
         this.info = 'Sign NEM transaction';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },

--- a/src/js/core/methods/PushTransaction.js
+++ b/src/js/core/methods/PushTransaction.js
@@ -6,23 +6,22 @@ import { getCoinInfo } from '../../data/CoinInfo';
 import { ERRORS } from '../../constants';
 import { isBackendSupported, initBlockchain } from '../../backend/BlockchainLink';
 
-import type { CoreMessage, CoinInfo } from '../../types';
+import type { CoinInfo } from '../../types';
 
 type Params = {
     tx: string,
     coinInfo: CoinInfo,
 };
 
-export default class PushTransaction extends AbstractMethod {
+export default class PushTransaction extends AbstractMethod<'pushTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = [];
         this.useUi = false;
         this.useDevice = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/RebootToBootloader.js
+++ b/src/js/core/methods/RebootToBootloader.js
@@ -6,14 +6,10 @@ import { getFirmwareRange } from './helpers/paramsValidator';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
-import type { CoreMessage } from '../../types';
-
-export default class RebootToBootloader extends AbstractMethod {
+export default class RebootToBootloader extends AbstractMethod<'rebootToBootloader'> {
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.skipFinalReload = true;
         this.keepSession = false;

--- a/src/js/core/methods/RecoveryDevice.js
+++ b/src/js/core/methods/RecoveryDevice.js
@@ -4,18 +4,16 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { validateParams } from './helpers/paramsValidator';
 import { UiMessage } from '../../message/builder';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class RecoveryDevice extends AbstractMethod {
+export default class RecoveryDevice extends AbstractMethod<'recoveryDevice'> {
     params: $ElementType<MessageType, 'RecoveryDevice'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['management'];
         this.useEmptyPassphrase = true;
 
-        const { payload } = message;
+        const { payload } = this;
 
         validateParams(payload, [
             { name: 'word_count', type: 'number' },

--- a/src/js/core/methods/RequestLogin.js
+++ b/src/js/core/methods/RequestLogin.js
@@ -7,22 +7,21 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 import DataManager from '../../data/DataManager';
 
-import type { ConnectSettings, CoreMessage } from '../../types';
+import type { ConnectSettings } from '../../types';
 import type { MessageType, IdentityType } from '../../types/trezor/protobuf';
 
-export default class RequestLogin extends AbstractMethod {
+export default class RequestLogin extends AbstractMethod<'requestLogin'> {
     params: $ElementType<MessageType, 'SignIdentity'>;
 
     asyncChallenge: boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.info = 'Login';
         this.useEmptyPassphrase = true;
 
-        const { payload } = message;
+        const { payload } = this;
 
         const identity: IdentityType = {};
         const settings: ConnectSettings = DataManager.getSettings();
@@ -48,7 +47,7 @@ export default class RequestLogin extends AbstractMethod {
             challenge_hidden: payload.challengeHidden || '',
             challenge_visual: payload.challengeVisual || '',
         };
-        this.asyncChallenge = payload.asyncChallenge;
+        this.asyncChallenge = !!payload.asyncChallenge;
     }
 
     async run() {

--- a/src/js/core/methods/ResetDevice.js
+++ b/src/js/core/methods/ResetDevice.js
@@ -4,24 +4,21 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class ResetDevice extends AbstractMethod {
+export default class ResetDevice extends AbstractMethod<'resetDevice'> {
     params: $ElementType<MessageType, 'ResetDevice'>;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.info = 'Setup device';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate bundle type
         validateParams(payload, [
             { name: 'display_random', type: 'boolean' },

--- a/src/js/core/methods/RippleGetAddress.js
+++ b/src/js/core/methods/RippleGetAddress.js
@@ -9,7 +9,6 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { RippleAddress } from '../../types/networks/ripple';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -17,7 +16,7 @@ type Params = {
     address?: string,
 };
 
-export default class RippleGetAddress extends AbstractMethod {
+export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -26,9 +25,7 @@ export default class RippleGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -37,10 +34,10 @@ export default class RippleGetAddress extends AbstractMethod {
         );
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/RippleSignTransaction.js
+++ b/src/js/core/methods/RippleSignTransaction.js
@@ -4,15 +4,12 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
-
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class RippleSignTransaction extends AbstractMethod {
+export default class RippleSignTransaction extends AbstractMethod<'rippleSignTransaction'> {
     params: $ElementType<MessageType, 'RippleSignTx'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -21,7 +18,7 @@ export default class RippleSignTransaction extends AbstractMethod {
         );
         this.info = 'Sign Ripple transaction';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },

--- a/src/js/core/methods/SignMessage.js
+++ b/src/js/core/methods/SignMessage.js
@@ -5,18 +5,16 @@ import { validateParams, validateCoinPath, getFirmwareRange } from './helpers/pa
 import { validatePath, getLabel, getScriptType } from '../../utils/pathUtils';
 import { getBitcoinNetwork } from '../../data/CoinInfo';
 import { messageToHex } from '../../utils/formatUtils';
-import type { CoreMessage, BitcoinNetworkInfo } from '../../types';
+import type { BitcoinNetworkInfo } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class SignMessage extends AbstractMethod {
+export default class SignMessage extends AbstractMethod<'signMessage'> {
     params: $ElementType<MessageType, 'SignMessage'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/SignTransaction.js
+++ b/src/js/core/methods/SignTransaction.js
@@ -25,7 +25,7 @@ import {
 
 import type { RefTransaction, TransactionOptions } from '../../types/networks/bitcoin';
 import type { TxInputType, TxOutputType } from '../../types/trezor/protobuf';
-import type { CoreMessage, BitcoinNetworkInfo, AccountAddresses } from '../../types';
+import type { BitcoinNetworkInfo, AccountAddresses } from '../../types';
 
 type Params = {
     inputs: TxInputType[],
@@ -37,15 +37,14 @@ type Params = {
     push: boolean,
 };
 
-export default class SignTransaction extends AbstractMethod {
+export default class SignTransaction extends AbstractMethod<'signTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.info = 'Sign transaction';
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/StellarGetAddress.js
+++ b/src/js/core/methods/StellarGetAddress.js
@@ -9,7 +9,6 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { StellarAddress } from '../../types/networks/stellar';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -17,7 +16,7 @@ type Params = {
     address?: string,
 };
 
-export default class StellarGetAddress extends AbstractMethod {
+export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -26,9 +25,7 @@ export default class StellarGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -37,10 +34,10 @@ export default class StellarGetAddress extends AbstractMethod {
         );
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/StellarSignTransaction.js
+++ b/src/js/core/methods/StellarSignTransaction.js
@@ -7,8 +7,6 @@ import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/stellarSignTx';
 import { ERRORS } from '../../constants';
 
-import type { CoreMessage } from '../../types';
-
 type Params = {
     path: number[],
     networkPassphrase: string,
@@ -20,11 +18,10 @@ const StellarSignTransactionFeatures = Object.freeze({
     pathPaymentStrictSend: ['1.10.4', '2.4.3'],
 });
 
-export default class StellarSignTransaction extends AbstractMethod {
+export default class StellarSignTransaction extends AbstractMethod<'stellarSignTransaction'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -33,7 +30,7 @@ export default class StellarSignTransaction extends AbstractMethod {
         );
         this.info = 'Sign Stellar transaction';
 
-        const { payload } = message;
+        const { payload } = this;
         // validate incoming parameters
         validateParams(payload, [
             { name: 'path', obligatory: true },

--- a/src/js/core/methods/TezosGetAddress.js
+++ b/src/js/core/methods/TezosGetAddress.js
@@ -9,7 +9,6 @@ import { UI, ERRORS } from '../../constants';
 import { UiMessage } from '../../message/builder';
 
 import type { TezosAddress } from '../../types/networks/tezos';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
 type Params = {
@@ -17,7 +16,7 @@ type Params = {
     address?: string,
 };
 
-export default class TezosGetAddress extends AbstractMethod {
+export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress'> {
     params: Params[] = [];
 
     hasBundle: boolean;
@@ -26,9 +25,7 @@ export default class TezosGetAddress extends AbstractMethod {
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -37,10 +34,10 @@ export default class TezosGetAddress extends AbstractMethod {
         );
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [

--- a/src/js/core/methods/TezosGetPublicKey.js
+++ b/src/js/core/methods/TezosGetPublicKey.js
@@ -9,19 +9,16 @@ import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 
 import type { TezosPublicKey } from '../../types/networks/tezos';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class TezosGetPublicKey extends AbstractMethod {
+export default class TezosGetPublicKey extends AbstractMethod<'tezosGetPublicKey'> {
     params: $ElementType<MessageType, 'TezosGetPublicKey'>[] = [];
 
     hasBundle: boolean;
 
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -31,10 +28,10 @@ export default class TezosGetPublicKey extends AbstractMethod {
         this.info = 'Export Tezos public key';
 
         // create a bundle with only one batch if bundle doesn't exists
-        this.hasBundle = Object.prototype.hasOwnProperty.call(message.payload, 'bundle');
-        const payload = !this.hasBundle
-            ? { ...message.payload, bundle: [message.payload] }
-            : message.payload;
+        this.hasBundle = !!this.payload.bundle;
+        const payload = !this.payload.bundle
+            ? { ...this.payload, bundle: [this.payload] }
+            : this.payload;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);

--- a/src/js/core/methods/TezosSignTransaction.js
+++ b/src/js/core/methods/TezosSignTransaction.js
@@ -5,15 +5,12 @@ import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import * as helper from './helpers/tezosSignTx';
-
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class TezosSignTransaction extends AbstractMethod {
+export default class TezosSignTransaction extends AbstractMethod<'tezosSignTransaction'> {
     params: $ElementType<MessageType, 'TezosSignTx'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,
@@ -22,7 +19,7 @@ export default class TezosSignTransaction extends AbstractMethod {
         );
         this.info = 'Sign Tezos transaction';
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/VerifyMessage.js
+++ b/src/js/core/methods/VerifyMessage.js
@@ -6,19 +6,16 @@ import { getBitcoinNetwork } from '../../data/CoinInfo';
 import { getLabel } from '../../utils/pathUtils';
 import { messageToHex } from '../../utils/formatUtils';
 import { ERRORS } from '../../constants';
-import type { CoreMessage } from '../../types';
 import type { MessageType } from '../../types/trezor/protobuf';
 
-export default class VerifyMessage extends AbstractMethod {
+export default class VerifyMessage extends AbstractMethod<'verifyMessage'> {
     params: $ElementType<MessageType, 'VerifyMessage'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.requiredPermissions = ['read', 'write'];
         this.info = 'Verify message';
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters for each batch
         validateParams(payload, [

--- a/src/js/core/methods/WipeDevice.js
+++ b/src/js/core/methods/WipeDevice.js
@@ -5,14 +5,11 @@ import AbstractMethod from './AbstractMethod';
 import * as UI from '../../constants/ui';
 import { UiMessage } from '../../message/builder';
 import { getFirmwareRange } from './helpers/paramsValidator';
-import type { CoreMessage } from '../../types';
 
-export default class WipeDevice extends AbstractMethod {
+export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
     confirmed: ?boolean;
 
-    constructor(message: CoreMessage) {
-        super(message);
-
+    init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];

--- a/src/js/core/methods/blockchain/BlockchainDisconnect.js
+++ b/src/js/core/methods/blockchain/BlockchainDisconnect.js
@@ -6,23 +6,22 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, findBackend } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainDisconnect extends AbstractMethod {
+export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisconnect'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = [];
         this.info = '';
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [{ name: 'coin', type: 'string', obligatory: true }]);

--- a/src/js/core/methods/blockchain/BlockchainEstimateFee.js
+++ b/src/js/core/methods/blockchain/BlockchainEstimateFee.js
@@ -7,7 +7,6 @@ import Fees from '../tx/Fees';
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
 import type {
-    CoreMessage,
     CoinInfo,
     BlockchainEstimateFee as BlockchainEstimateFeeParams,
 } from '../../../types';
@@ -19,15 +18,14 @@ type Params = {
     request: Request,
 };
 
-export default class BlockchainEstimateFee extends AbstractMethod {
+export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEstimateFee'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
+++ b/src/js/core/methods/blockchain/BlockchainGetAccountBalanceHistory.js
@@ -6,7 +6,7 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
@@ -18,15 +18,14 @@ type Params = {
     },
 };
 
-export default class BlockchainGetAccountBalanceHistory extends AbstractMethod {
+export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<'blockchainGetAccountBalanceHistory'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainGetCurrentFiatRates.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
     currencies?: string[],
 };
 
-export default class BlockchainGetCurrentFiatRates extends AbstractMethod {
+export default class BlockchainGetCurrentFiatRates extends AbstractMethod<'blockchainGetCurrentFiatRates'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
+++ b/src/js/core/methods/blockchain/BlockchainGetFiatRatesForTimestamps.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
     timestamps?: number[],
 };
 
-export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod {
+export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<'blockchainGetFiatRatesForTimestamps'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainGetTransactions.js
+++ b/src/js/core/methods/blockchain/BlockchainGetTransactions.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     txs: string[],
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainGetTransactions extends AbstractMethod {
+export default class BlockchainGetTransactions extends AbstractMethod<'blockchainGetTransactions'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainSetCustomBackend.js
+++ b/src/js/core/methods/blockchain/BlockchainSetCustomBackend.js
@@ -6,23 +6,22 @@ import { ERRORS } from '../../../constants';
 
 import { findBackend, setCustomBackend, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainSetCustomBackend extends AbstractMethod {
+export default class BlockchainSetCustomBackend extends AbstractMethod<'blockchainSetCustomBackend'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.requiredPermissions = [];
         this.info = '';
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainSubscribe.js
+++ b/src/js/core/methods/blockchain/BlockchainSubscribe.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo, BlockchainSubscribeAccount } from '../../../types';
+import type { CoinInfo, BlockchainSubscribeAccount } from '../../../types';
 
 type Params = {
     accounts?: BlockchainSubscribeAccount[],
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainSubscribe extends AbstractMethod {
+export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubscribe'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainSubscribeFiatRates.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     currency?: string,
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainSubscribeFiatRates extends AbstractMethod {
+export default class BlockchainSubscribeFiatRates extends AbstractMethod<'blockchainSubscribeFiatRates'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
+++ b/src/js/core/methods/blockchain/BlockchainUnsubscribe.js
@@ -6,22 +6,21 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo, BlockchainSubscribeAccount } from '../../../types';
+import type { CoinInfo, BlockchainSubscribeAccount } from '../../../types';
 
 type Params = {
     accounts?: BlockchainSubscribeAccount[],
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainUnsubscribe extends AbstractMethod {
+export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUnsubscribe'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [

--- a/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
+++ b/src/js/core/methods/blockchain/BlockchainUnsubscribeFiatRates.js
@@ -6,21 +6,20 @@ import { ERRORS } from '../../../constants';
 
 import { isBackendSupported, initBlockchain } from '../../../backend/BlockchainLink';
 import { getCoinInfo } from '../../../data/CoinInfo';
-import type { CoreMessage, CoinInfo } from '../../../types';
+import type { CoinInfo } from '../../../types';
 
 type Params = {
     coinInfo: CoinInfo,
 };
 
-export default class BlockchainUnsubscribeFiatRates extends AbstractMethod {
+export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<'blockchainUnsubscribeFiatRates'> {
     params: Params;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = false;
         this.useUi = false;
 
-        const { payload } = message;
+        const { payload } = this;
 
         // validate incoming parameters
         validateParams(payload, [{ name: 'coin', type: 'string', obligatory: true }]);

--- a/src/js/core/methods/debuglink/DebugLinkDecision.js
+++ b/src/js/core/methods/debuglink/DebugLinkDecision.js
@@ -3,20 +3,19 @@
 import AbstractMethod from '../AbstractMethod';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
-import type { CoreMessage } from '../../../types';
 import type { MessageType } from '../../../types/trezor/protobuf';
 
-export default class DebugLinkDecision extends AbstractMethod {
+// TODO: remove unused method
+export default class DebugLinkDecision extends AbstractMethod<any> {
     params: $ElementType<MessageType, 'DebugLinkDecision'>;
 
-    constructor(message: CoreMessage) {
-        super(message);
+    init() {
         this.useDevice = true;
         this.debugLink = true;
         this.useUi = false;
         this.requiredPermissions = ['management'];
 
-        const { payload } = message;
+        const { payload } = this;
         validateParams(payload, [
             { name: 'yes_no', type: 'boolean' },
             { name: 'up_down', type: 'boolean' },

--- a/src/js/core/methods/debuglink/DebugLinkGetState.js
+++ b/src/js/core/methods/debuglink/DebugLinkGetState.js
@@ -2,12 +2,11 @@
 
 import AbstractMethod from '../AbstractMethod';
 import { ERRORS } from '../../../constants';
-import type { CoreMessage } from '../../../types';
 import type { DebugLinkState } from '../../../types/trezor/protobuf';
 
-export default class DebugLinkGetState extends AbstractMethod {
-    constructor(message: CoreMessage) {
-        super(message);
+// TODO: remove unused method
+export default class DebugLinkGetState extends AbstractMethod<'debugLinkGetState'> {
+    init() {
         this.useDevice = true;
         this.debugLink = true;
         this.useUi = false;

--- a/src/js/core/methods/helpers/cardanoOutputs.js
+++ b/src/js/core/methods/helpers/cardanoOutputs.js
@@ -4,7 +4,7 @@ import { validateParams } from './paramsValidator';
 import type { CardanoTxOutput } from '../../../types/trezor/protobuf';
 import { addressParametersToProto, validateAddressParameters } from './cardanoAddressParameters';
 import type { AssetGroupWithTokens } from './cardanoTokenBundle';
-import { tokenBundleToProto, validateTokenBundle } from './cardanoTokenBundle';
+import { tokenBundleToProto } from './cardanoTokenBundle';
 
 export type OutputWithTokens = {
     output: CardanoTxOutput,
@@ -33,7 +33,6 @@ export const transformOutput = (output: any) => {
     }
 
     if (output.tokenBundle) {
-        validateTokenBundle(output.tokenBundle);
         result.tokenBundle = tokenBundleToProto(output.tokenBundle);
         result.output.asset_groups_count = result.tokenBundle.length;
     } else {

--- a/src/js/core/methods/helpers/cardanoSignTxLegacy.js
+++ b/src/js/core/methods/helpers/cardanoSignTxLegacy.js
@@ -60,13 +60,13 @@ type CardanoTxAuxiliaryDataTypeLegacy = {
 type CardanoSignTransactionLegacyParams = {
     auxiliary_data: void | CardanoTxAuxiliaryDataTypeLegacy,
     certificates: CardanoTxCertificateTypeLegacy[],
-    fee: number,
+    fee: string | number,
     inputs: CardanoTxInputType[],
     network_id: number,
     outputs: CardanoTxOutputType[],
     protocol_magic: number,
-    ttl: number,
-    validity_interval_start: number,
+    ttl?: string | number,
+    validity_interval_start?: string | number,
     withdrawals: CardanoTxWithdrawalType[],
 };
 

--- a/src/js/core/methods/helpers/cardanoTokenBundle.js
+++ b/src/js/core/methods/helpers/cardanoTokenBundle.js
@@ -19,7 +19,7 @@ const validateTokens = (tokenAmounts: CardanoToken[]) => {
     });
 };
 
-export const validateTokenBundle = (tokenBundle: CardanoAssetGroup[]) => {
+const validateTokenBundle = (tokenBundle: CardanoAssetGroup[]) => {
     tokenBundle.forEach(tokenGroup => {
         validateParams(tokenGroup, [
             { name: 'policyId', type: 'string', obligatory: true },
@@ -37,8 +37,10 @@ const tokenAmountsToProto = (tokenAmounts: CardanoToken[]): CardanoTokenProto[] 
         mint_amount: tokenAmount.mintAmount,
     }));
 
-export const tokenBundleToProto = (tokenBundle: CardanoAssetGroup[]): AssetGroupWithTokens[] =>
-    tokenBundle.map(tokenGroup => ({
+export const tokenBundleToProto = (tokenBundle: CardanoAssetGroup[]): AssetGroupWithTokens[] => {
+    validateTokenBundle(tokenBundle);
+    return tokenBundle.map(tokenGroup => ({
         policyId: tokenGroup.policyId,
         tokens: tokenAmountsToProto(tokenGroup.tokenAmounts),
     }));
+};

--- a/src/js/core/methods/index.js
+++ b/src/js/core/methods/index.js
@@ -135,7 +135,7 @@ const METHODS = {
     rebootToBootloader,
 };
 
-export const find = (message: CoreMessage): AbstractMethod => {
+export const find = (message: CoreMessage): AbstractMethod<any> => {
     if (!message.payload) {
         throw ERRORS.TypedError('Method_InvalidParameter', 'Message payload not found');
     }

--- a/src/js/core/methods/tx/TransactionComposer.js
+++ b/src/js/core/methods/tx/TransactionComposer.js
@@ -159,7 +159,7 @@ export default class TransactionComposer {
         if (!addresses) return { type: 'error', error: 'ADDRESSES-NOT-SET' };
         // find not used change address or fallback to the last in the list
         const changeAddress =
-            addresses.change.find(a => a.transfers < 1) ||
+            addresses.change.find(a => !a.transfers) ||
             addresses.change[addresses.change.length - 1];
         const changeId = getHDPath(changeAddress.path).slice(-1)[0]; // get address id from the path
         // const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;

--- a/src/js/core/methods/tx/outputs.js
+++ b/src/js/core/methods/tx/outputs.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import type { ComposeOutput, ComposedTxOutput } from '@trezor/utxo-lib';
+import type { ComposeOutput as UtxoLibOutput, ComposedTxOutput } from '@trezor/utxo-lib';
 import { getOutputScriptType, fixPath } from '../../../utils/pathUtils';
 import { isValidAddress } from '../../../utils/addressUtils';
 import { convertMultisigPubKey } from '../../../utils/hdnodeUtils';
 import { validateParams } from '../helpers/paramsValidator';
 import { ERRORS } from '../../../constants';
-import type { BitcoinNetworkInfo } from '../../../types';
+import type { BitcoinNetworkInfo, ComposeOutput } from '../../../types';
 import type { TxOutputType } from '../../../types/trezor/protobuf';
 
 /** *****
@@ -64,9 +64,9 @@ export const validateTrezorOutputs = (
 export const validateHDOutput = (
     output: ComposeOutput,
     coinInfo: BitcoinNetworkInfo,
-): ComposeOutput => {
+): UtxoLibOutput => {
     const validateAddress = address => {
-        if (!isValidAddress(address, coinInfo)) {
+        if (!address || !isValidAddress(address, coinInfo)) {
             throw ERRORS.TypedError(
                 'Method_InvalidParameter',
                 `Invalid ${coinInfo.label} output address format`,
@@ -110,6 +110,7 @@ export const validateHDOutput = (
             validateAddress(output.address);
             return {
                 type: 'complete',
+                // $FlowIssue missing address will fail in validation above
                 address: output.address,
                 amount: output.amount,
             };

--- a/src/js/types/__tests__/ethereum.js
+++ b/src/js/types/__tests__/ethereum.js
@@ -151,9 +151,9 @@ export const ethereumSignTransaction = async () => {
         },
     });
 
-    // $FlowExpectedError: combined gasPrice + maxFeePerGas
     TrezorConnect.ethereumSignTransaction({
         path: 'm/44',
+        // $FlowExpectedError: combined gasPrice + maxFeePerGas
         transaction: {
             nonce: '0x0',
             maxFeePerGas: '0x14',

--- a/src/js/types/__tests__/misc.js
+++ b/src/js/types/__tests__/misc.js
@@ -15,7 +15,9 @@ export const cipherKeyValue = async () => {
     }
 
     // bundle
-    const bundleKV = await TrezorConnect.cipherKeyValue({ bundle: [{ path: 'm/44', key: 'key' }] });
+    const bundleKV = await TrezorConnect.cipherKeyValue({
+        bundle: [{ path: 'm/44', key: 'key', value: 'hash' }],
+    });
     (bundleKV.success: boolean);
     if (bundleKV.success) {
         bundleKV.payload.forEach(item => {
@@ -60,11 +62,6 @@ export const requestLogin = async () => {
             challengeVisual: 'b',
         }),
     });
-    // const { success, payload } = a;
-    // if (success && payload.address) {
-    //     (payload.address: string);
-    // }
-    // (payload: { error: string });
     (a.success: boolean);
     if (a.success) {
         (a.payload.address: string);

--- a/src/js/types/account.js
+++ b/src/js/types/account.js
@@ -38,7 +38,7 @@ export type TokenInfo = {
 export type AccountAddress = {
     address: string,
     path: string,
-    transfers: number,
+    transfers?: number,
     balance?: string,
     sent?: string,
     received?: string,
@@ -173,12 +173,14 @@ export type AccountInfo = {
 export type RegularOutput = {
     type?: 'external',
     address: string,
+    address_n?: typeof undefined,
     amount: string,
     script_type?: 'PAYTOADDRESS',
 };
 
 export type InternalOutput = {
     type?: 'internal',
+    address?: typeof undefined,
     address_n: number[],
     amount: string,
     script_type?: string,
@@ -261,6 +263,9 @@ export type ComposeParams = {
     sequence?: number,
     account?: typeof undefined,
     feeLevels?: typeof undefined,
+    baseFee?: number,
+    floorBaseFee?: boolean,
+    skipPermutation?: boolean,
 };
 
 export type DiscoveryAccount = {

--- a/src/js/types/api.js
+++ b/src/js/types/api.js
@@ -22,7 +22,7 @@ import * as Events from './events';
 import * as Blockchain from './backend/blockchain';
 
 interface Bundled<Parm, Resp> {
-    (params: $Exact<{ ...$Exact<P.CommonParams>, ...$Exact<Parm> }>): P.Response<Resp>;
+    (params: $Exact<{ ...$Exact<P.CommonParams>, ...$Exact<P.NoBundle<Parm>> }>): P.Response<Resp>;
     (
         params: $Exact<{ ...$Exact<P.CommonParams>, ...$Exact<P.Bundle<Parm>> }>,
     ): P.BundledResponse<Resp>;
@@ -252,7 +252,7 @@ export type API = {
     // Ethereum and Ethereum-like
     ethereumGetAddress: Bundled<Ethereum.EthereumGetAddress, Ethereum.EthereumAddress>,
     ethereumGetPublicKey: Bundled<Ethereum.EthereumGetPublicKey, Bitcoin.HDNodeResponse>,
-    ethereumSignTransaction: Bundled<Ethereum.EthereumSignTransaction, Ethereum.EthereumSignedTx>,
+    ethereumSignTransaction: Method<Ethereum.EthereumSignTransaction, Ethereum.EthereumSignedTx>,
     ethereumSignMessage: Method<Ethereum.EthereumSignMessage, Protobuf.EthereumMessageSignature>,
     ethereumSignTypedData: Method<
         Ethereum.EthereumSignTypedData,
@@ -262,15 +262,15 @@ export type API = {
 
     // NEM
     nemGetAddress: Bundled<NEM.NEMGetAddress, NEM.NEMAddress>,
-    nemSignTransaction: Bundled<NEM.NEMSignTransaction, Protobuf.NEMSignedTx>,
+    nemSignTransaction: Method<NEM.NEMSignTransaction, Protobuf.NEMSignedTx>,
 
     // Ripple
     rippleGetAddress: Bundled<Ripple.RippleGetAddress, Ripple.RippleAddress>,
-    rippleSignTransaction: Bundled<Ripple.RippleSignTransaction, Ripple.RippleSignedTx>,
+    rippleSignTransaction: Method<Ripple.RippleSignTransaction, Ripple.RippleSignedTx>,
 
     // Stellar
     stellarGetAddress: Bundled<Stellar.StellarGetAddress, Stellar.StellarAddress>,
-    stellarSignTransaction: Bundled<Stellar.StellarSignTransaction, Stellar.StellarSignedTx>,
+    stellarSignTransaction: Method<Stellar.StellarSignTransaction, Stellar.StellarSignedTx>,
 
     // // Tezos
     tezosGetAddress: Bundled<Tezos.TezosGetAddress, Tezos.TezosAddress>,

--- a/src/js/types/misc.js
+++ b/src/js/types/misc.js
@@ -2,8 +2,8 @@
 
 export type CipherKeyValue = {
     path: string | number[],
-    key?: string,
-    value?: string | Buffer,
+    key: string,
+    value: string | Buffer,
     encrypt?: boolean,
     askOnEncrypt?: boolean,
     askOnDecrypt?: boolean,
@@ -17,9 +17,11 @@ export type CipheredValue = {
 export type LoginChallenge = {
     challengeHidden: string,
     challengeVisual: string,
+    callback?: typeof undefined,
+    asyncChallenge?: typeof undefined,
 };
 
-export type RequestLoginAsync = { callback: () => LoginChallenge };
+export type RequestLoginAsync = { callback: () => LoginChallenge, asyncChallenge?: boolean };
 
 export type Login = {
     address: string,

--- a/src/js/types/networks/binance.js
+++ b/src/js/types/networks/binance.js
@@ -6,6 +6,7 @@ export type BinanceGetAddress = {
     path: string | number[],
     address?: string,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type BinanceAddress = {

--- a/src/js/types/networks/bitcoin.js
+++ b/src/js/types/networks/bitcoin.js
@@ -6,7 +6,10 @@ import type {
     TxOutputType,
     TxOutputBinType,
     Address as ProtobufAddress,
+    InternalInputScriptType,
+    MultisigRedeemScriptType,
 } from '../trezor/protobuf';
+import type { AccountAddresses } from '../account';
 
 // getAddress params
 export type GetAddress = {
@@ -15,6 +18,9 @@ export type GetAddress = {
     showOnTrezor?: boolean,
     coin?: string,
     crossChain?: boolean,
+    multisig?: MultisigRedeemScriptType,
+    scriptType?: InternalInputScriptType,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 // getAddress response
@@ -28,6 +34,7 @@ export type GetPublicKey = {
     path: string | number[],
     coin?: string,
     crossChain?: boolean,
+    showOnTrezor?: boolean,
 };
 
 // combined Bitcoin.PublicKey and Bitcoin.HDNode
@@ -92,12 +99,7 @@ export type SignTransaction = {
     outputs: TxOutputType[],
     refTxs?: RefTransaction[],
     account?: {
-        // Partial account (addresses)
-        addresses: {
-            used: { path: string, address: string }[],
-            unused: { path: string, address: string }[],
-            change: { path: string, address: string }[],
-        },
+        addresses: AccountAddresses,
     },
     coin: string,
     locktime?: number,
@@ -132,6 +134,7 @@ export type SignMessage = {
     coin: string,
     message: string,
     hex?: boolean,
+    no_script_type?: boolean,
 };
 
 export type VerifyMessage = {

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -53,6 +53,7 @@ export type CardanoGetAddress = {
     address?: string,
     showOnTrezor?: boolean,
     derivationType?: CardanoDerivationType,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type CardanoAddress = {

--- a/src/js/types/networks/eos.js
+++ b/src/js/types/networks/eos.js
@@ -16,6 +16,7 @@ import type {
 export type EosGetPublicKey = {
     path: string | number[],
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type EosPublicKey = {

--- a/src/js/types/networks/ethereum.js
+++ b/src/js/types/networks/ethereum.js
@@ -8,6 +8,7 @@ export type EthereumGetAddress = {
     path: string | number[],
     address?: string,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type EthereumAddress = {

--- a/src/js/types/networks/nem.js
+++ b/src/js/types/networks/nem.js
@@ -114,6 +114,7 @@ export type NEMGetAddress = {
     address?: string,
     network: number,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type NEMAddress = {

--- a/src/js/types/networks/ripple.js
+++ b/src/js/types/networks/ripple.js
@@ -6,6 +6,7 @@ export type RippleGetAddress = {
     path: string | number[],
     address?: string,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type RippleAddress = {

--- a/src/js/types/networks/stellar.js
+++ b/src/js/types/networks/stellar.js
@@ -245,6 +245,7 @@ export type StellarGetAddress = {
     path: string | number[],
     address?: string,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type StellarAddress = {

--- a/src/js/types/networks/tezos.js
+++ b/src/js/types/networks/tezos.js
@@ -6,6 +6,7 @@ export type TezosGetAddress = {
     path: string | number[],
     address?: string,
     showOnTrezor?: boolean,
+    useEventListener?: boolean, // set automatically if UI.ADDRESS_VALIDATION listener is used
 };
 
 export type TezosAddress = {

--- a/src/js/types/params.js
+++ b/src/js/types/params.js
@@ -67,6 +67,11 @@ export type Bundle<T> = {
     bundle: T[],
 };
 
+export type NoBundle<T> = {
+    ...T,
+    bundle?: typeof undefined,
+};
+
 export type CoreMessage = {
     event: string,
     type: string,

--- a/src/js/types/trezor/management.js
+++ b/src/js/types/trezor/management.js
@@ -1,16 +1,17 @@
 /* @flow */
 
 export type ResetDevice = {
+    display_random?: boolean,
     strength?: number,
+    passphrase_protection?: boolean,
+    pin_protection?: boolean,
+    language?: string,
     label?: string,
     u2f_counter?: number,
-    pin_protection?: boolean,
-    passphrase_protection?: boolean,
     skip_backup?: boolean,
     no_backup?: boolean,
     backup_type?: 0 | 1,
 };
-
 export type ApplyFlags = {
     flags: number,
 };
@@ -21,8 +22,14 @@ export type ChangePin = {
 
 export type FirmwareUpdateBinary = {
     binary: ArrayBuffer,
+    version?: typeof undefined,
+    btcOnly?: typeof undefined,
+    baseUrl?: typeof undefined,
+    intermediary?: typeof undefined,
 };
+
 export type FirmwareUpdate = {
+    binary?: typeof undefined,
     version: number[],
     btcOnly?: boolean,
     baseUrl?: string,

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -767,7 +767,7 @@ export type CardanoTxCertificate = {
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
     path?: number[],
-    amount: number,
+    amount: string | number,
     script_hash?: string,
 };
 
@@ -869,7 +869,7 @@ export type CardanoTxCertificateType = {
 
 export type CardanoTxWithdrawalType = {
     path: number[],
-    amount: number,
+    amount: string | number,
 };
 
 export type CardanoTxAuxiliaryDataType = {
@@ -1674,7 +1674,7 @@ export type ResetDevice = {
     u2f_counter?: number,
     skip_backup?: boolean,
     no_backup?: boolean,
-    backup_type?: BackupType,
+    backup_type?: string | number,
 };
 
 // BackupDevice

--- a/src/ts/types/__tests__/misc.ts
+++ b/src/ts/types/__tests__/misc.ts
@@ -14,7 +14,9 @@ export const cipherKeyValue = async () => {
     }
 
     // bundle
-    const bundleKV = await TrezorConnect.cipherKeyValue({ bundle: [{ path: 'm/44', key: 'key' }] });
+    const bundleKV = await TrezorConnect.cipherKeyValue({
+        bundle: [{ path: 'm/44', key: 'key', value: 'hash' }],
+    });
 
     if (bundleKV.success) {
         bundleKV.payload.forEach(item => {

--- a/src/ts/types/account.d.ts
+++ b/src/ts/types/account.d.ts
@@ -37,7 +37,7 @@ export interface TokenInfo {
 export interface AccountAddress {
     address: string;
     path: string;
-    transfers: number;
+    transfers?: number;
     balance?: string;
     sent?: string;
     received?: string;
@@ -257,6 +257,9 @@ export interface ComposeParams {
     coin: string;
     push?: boolean;
     sequence?: number;
+    baseFee?: number;
+    floorBaseFee?: boolean;
+    skipPermutation?: boolean;
 }
 
 export interface DiscoveryAccount {

--- a/src/ts/types/misc.d.ts
+++ b/src/ts/types/misc.d.ts
@@ -1,7 +1,7 @@
 export interface CipherKeyValue {
     path: string | number[];
-    key?: string;
-    value?: string | Buffer;
+    key: string;
+    value: string | Buffer;
     encrypt?: boolean;
     askOnEncrypt?: boolean;
     askOnDecrypt?: boolean;

--- a/src/ts/types/networks/bitcoin.d.ts
+++ b/src/ts/types/networks/bitcoin.d.ts
@@ -1,11 +1,14 @@
-import {
+import type {
     PrevInput,
     TxInput as OrigTxInputType,
     TxInputType,
     TxOutputType,
     TxOutputBinType,
     Address as ProtobufAddress,
+    MultisigRedeemScriptType,
+    InternalInputScriptType,
 } from '../trezor/protobuf';
+import type { AccountAddresses } from '../account';
 
 // getAddress params
 export interface GetAddress {
@@ -14,6 +17,8 @@ export interface GetAddress {
     showOnTrezor?: boolean;
     coin?: string;
     crossChain?: boolean;
+    multisig?: MultisigRedeemScriptType;
+    scriptType?: InternalInputScriptType;
 }
 
 // getAddress response
@@ -27,6 +32,7 @@ export interface GetPublicKey {
     path: string | number[];
     coin?: string;
     crossChain?: boolean;
+    showOnTrezor?: boolean;
 }
 
 // combined Bitcoin.PublicKey and Bitcoin.HDNode
@@ -91,12 +97,7 @@ export interface SignTransaction {
     outputs: TxOutputType[];
     refTxs?: RefTransaction[];
     account?: {
-        // Partial account (addresses)
-        addresses: {
-            used: { path: string; address: string }[];
-            unused: { path: string; address: string }[];
-            change: { path: string; address: string }[];
-        };
+        addresses: AccountAddresses;
     };
     coin: string;
     locktime?: number;
@@ -131,6 +132,7 @@ export interface SignMessage {
     coin: string;
     message: string;
     hex?: boolean;
+    no_script_type?: boolean;
 }
 
 export interface VerifyMessage {

--- a/src/ts/types/trezor/management.d.ts
+++ b/src/ts/types/trezor/management.d.ts
@@ -1,11 +1,11 @@
-import type { SafetyCheckLevel } from './protobuf';
-
 export interface ResetDevice {
+    display_random?: boolean;
     strength?: number;
+    passphrase_protection?: boolean;
+    pin_protection?: boolean;
+    language?: string;
     label?: string;
     u2f_counter?: number;
-    pin_protection?: boolean;
-    passphrase_protection?: boolean;
     skip_backup?: boolean;
     no_backup?: boolean;
     backup_type?: 0 | 1;

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -744,7 +744,7 @@ export type CardanoTxCertificate = {
 // CardanoTxWithdrawal
 export type CardanoTxWithdrawal = {
     path?: number[];
-    amount: number;
+    amount: string | number;
     script_hash?: string;
 };
 
@@ -846,7 +846,7 @@ export type CardanoTxCertificateType = {
 
 export type CardanoTxWithdrawalType = {
     path: number[];
-    amount: number;
+    amount: string | number;
 };
 
 export type CardanoTxAuxiliaryDataType = {
@@ -1647,7 +1647,7 @@ export type ResetDevice = {
     u2f_counter?: number;
     skip_backup?: boolean;
     no_backup?: boolean;
-    backup_type?: BackupType;
+    backup_type?: string | number;
 };
 
 // BackupDevice


### PR DESCRIPTION
Resolving long term issue where `CoreMessage.payload` is not typed (any)

`AbstractMethod` requires generic type, key of API interface (key == method name) 
with this key it's now able to assign proper type to `payload` object and pass it typed to child (particular method)

`constructor` of each method is no longer required (processed by AbstractMethod) and it was replaced by `init` function (called in Core)

This refactor revealed some minor issues, mostly on type level: missing params in API but used in runtime, correct unions `xxx?: typeof undefined`

There are few runtime changes but nothing breaking

Other issues will be addressed later trezor/trezor-suite#4887
