### PR TITLE
fix: Fix ethSignTypedData MetaMask compatibility

### DIFF
--- a/src/js/core/methods/helpers/__fixtures__/ethereumSignTypedData.js
+++ b/src/js/core/methods/helpers/__fixtures__/ethereumSignTypedData.js
@@ -186,9 +186,34 @@ export const encodeData = [
         description: 'should remove leading `0x` from byte hex-string',
         input: {
             typeName: 'bytes',
-            data: '0x123456789abcdef',
+            data: '0x0123456789abcdef',
         },
-        output: '123456789abcdef',
+        output: '0123456789abcdef',
+    },
+    {
+        description: 'should pad hex to nearest byte',
+        input: {
+            typeName: 'bytes',
+            data: '0x1',
+        },
+        output: '01',
+    },
+    {
+        description: 'should encode bytes from Buffer',
+        // Required for MetaMask compatability
+        input: {
+            typeName: 'bytes',
+            data: Buffer.from('0123456789abcdef', 'hex'),
+        },
+        output: '0123456789abcdef',
+    },
+    {
+        description: 'should encode bytes from ArrayBuffer',
+        input: {
+            typeName: 'bytes',
+            data: new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]).buffer,
+        },
+        output: '0123456789abcdef',
     },
     {
         description: 'should remove leading `0x` from Ethereum address',
@@ -249,6 +274,14 @@ export const encodeData = [
             data: new BigNumber(2).pow(254).negated().plus(1),
         },
         // Python (-(2 ** 254) + 1).to_bytes(32, "big", signed=True).hex()
+        output: 'c000000000000000000000000000000000000000000000000000000000000001',
+    },
+    {
+        description: `should encode uint from hex-string`,
+        input: {
+            typeName: 'uint256',
+            data: '0xc000000000000000000000000000000000000000000000000000000000000001',
+        },
         output: 'c000000000000000000000000000000000000000000000000000000000000001',
     },
     {

--- a/src/js/core/methods/helpers/ethereumSignTypedData.js
+++ b/src/js/core/methods/helpers/ethereumSignTypedData.js
@@ -5,7 +5,7 @@ import type { EthereumSignTypedDataTypes } from '../../../types/networks/ethereu
 import type { EthereumFieldType } from '../../../types/trezor/protobuf';
 import { Enum_EthereumDataType } from '../../../types/trezor/protobuf';
 import { ERRORS } from '../../../constants';
-import { stripHexPrefix } from '../../../utils/formatUtils';
+import { messageToHex } from '../../../utils/formatUtils';
 
 // Copied from https://github.com/ethers-io/ethers.js/blob/v5.5.2/packages/abi/src.ts/fragments.ts#L249
 const paramTypeArray = new RegExp(/^(.*)\[([0-9]*)\]$/);
@@ -103,7 +103,7 @@ function intToHex(
  */
 export function encodeData(typeName: string, data: any): string {
     if (paramTypeBytes.test(typeName) || typeName === 'address') {
-        return stripHexPrefix(data);
+        return messageToHex(data);
     }
     if (typeName === 'string') {
         return Buffer.from(data, 'utf-8').toString('hex');


### PR DESCRIPTION
MetaMask supports passing `bytes` as a `Buffer` to `signTypedData`, and automatically 0-pads non-byte hex strings, so I tested and added support for that.

Ethereum's JSON RPC and MetaMask also supports passing int as hex, so I've added a test case for that, but luckily BigNumber already handles this.

I didn't bother to add a CHANGELOG.md entry, since it fixes a bug in #983, which hasn't been officially released in trezor-connect yet. Let me know if you want me to add an entry.