### PR TITLE
fix: don't spoof headers in browser

### DIFF
--- a/jest.config.integration.js
+++ b/jest.config.integration.js
@@ -28,4 +28,5 @@ module.exports = {
     collectCoverageFrom: ['./src/js/**/*.{js}', '!**/node_modules/**'],
     verbose: true,
     bail: true,
+    testEnvironment: 'node',
 };


### PR DESCRIPTION
- 8b5333327b4b81a8138ac7e3ae24b5661ebe0a52 improved setFetch, setFetch with AbortController 
- 2184f1561a350797aa529a532ed72ef3f827376d  fixed tests to run in "node" environement. prior to this change jest stubbed "window" object