### PR TITLE
chore: update @trezor/blockchain-link 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 8.2.7 (not released)
+
+### Changed
+- @trezor/blockchain-link 2.0.0 use workers as commonjs modules in nodejs and react-native env.
+
 # 8.2.6
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trezor Connect API version 8.2.6
+# Trezor Connect API version 8.2.7-beta.1
 [![Build Status](https://github.com/trezor/connect/actions/workflows/tests.yml/badge.svg)](https://github.com/trezor/connect/actions/workflows/tests.yml)
 [![NPM](https://img.shields.io/npm/v/trezor-connect.svg)](https://www.npmjs.org/package/trezor-connect)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/connect?targetFile=package.json)

--- a/karma.config.production.js
+++ b/karma.config.production.js
@@ -22,11 +22,12 @@ module.exports = config => {
 
         // include custom karma.plugin
         plugins: ['karma-*', path.resolve(__dirname, './tests/karma.plugin.js')],
-        frameworks: ['jasmine', 'webpack'],
+        frameworks: ['jasmine', 'webpack', 'WebsocketServer'], // use custom framework from karma.plugin
         preprocessors: {
             './tests/karma.setup.js': 'webpack',
             './tests/common.setup.js': 'webpack',
-            './tests/__txcache__/index.js': 'TrezorConnect', // use custom preprocessor from karma.plugin
+            './tests/__txcache__/index.js': 'TxCachePreprocessor', // use custom preprocessor from karma.plugin
+            './build/data/coins.json': 'WsCachePreprocessor', // use custom preprocessor from karma.plugin
             './tests/device/**/*.test.js': ['webpack'],
         },
         files: [
@@ -34,11 +35,11 @@ module.exports = config => {
             { pattern: './tests/common.setup.js', watched: false },
             { pattern: './tests/__txcache__/index.js', watched: false },
             {
-                pattern: 'build/**/*.*',
+                pattern: './build/**/*.*',
                 watched: false,
                 included: false,
                 served: true,
-                nocache: true,
+                nocache: false,
             },
             './tests/device/**/*.test.js',
         ],
@@ -96,7 +97,7 @@ module.exports = config => {
             ],
         },
 
-        reporters: ['progress', 'coverage', 'TrezorConnect'], // use custom reporter from karma.plugin
+        reporters: ['progress', 'coverage', 'CustomReporter'], // use custom reporter from karma.plugin
         coverageReporter: {
             dir: 'coverage',
             reporters: [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "@babel/plugin-transform-runtime": "^7.15.0",
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-flow": "^7.14.5",
-        "@trezor/blockchain-link": "1.1.0",
+        "@trezor/blockchain-link": "2.0.0",
         "@trezor/connect-common": "0.0.4",
         "@trezor/rollout": "^1.2.1",
         "@trezor/transport": "1.0.1",
@@ -112,7 +112,6 @@
         "stream-browserify": "^3.0.0",
         "style-loader": "3.2.1",
         "terser-webpack-plugin": "5.2.4",
-        "tiny-worker": "^2.3.0",
         "typescript": "^4.4.3",
         "uglify-es": "3.3.9",
         "util": "^0.12.3",
@@ -128,7 +127,7 @@
         "events": "^3.3.0"
     },
     "extendedDependencies": {
-        "@trezor/blockchain-link": "1.1.0",
+        "@trezor/blockchain-link": "2.0.0",
         "@trezor/connect-common": "0.0.4",
         "@trezor/rollout": "^1.2.1",
         "@trezor/transport": "1.0.1",
@@ -136,7 +135,6 @@
         "bignumber.js": "^9.0.1",
         "bowser": "^2.11.0",
         "cbor-web": "^7.0.6",
-        "parse-uri": "^1.0.3",
-        "tiny-worker": "^2.3.0"
+        "parse-uri": "^1.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-connect",
-    "version": "8.2.6",
+    "version": "8.2.7-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/src/js/data/ConnectSettings.js
+++ b/src/js/data/ConnectSettings.js
@@ -7,7 +7,7 @@ import type { Manifest, ConnectSettings } from '../types';
  * It could be changed by passing values into TrezorConnect.init(...) method
  */
 
-const VERSION = '8.2.6';
+const VERSION = '8.2.7-beta.1';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/src/js/device/AbortController.js
+++ b/src/js/device/AbortController.js
@@ -1,0 +1,58 @@
+/* @flow */
+/* eslint-disable max-classes-per-file */
+
+// inspired by https://github.com/southpolesteve/node-abort-controller/
+// nodejs AbortController is available since version 15, currently we are using 12.
+
+import EventEmitter from 'events';
+
+class AbortSignal {
+    eventEmitter: EventEmitter;
+
+    aborted: boolean = false;
+
+    constructor() {
+        this.eventEmitter = new EventEmitter();
+    }
+
+    toString() {
+        return '[object AbortSignal]';
+    }
+
+    removeEventListener(name: string, handler: any) {
+        this.eventEmitter.removeListener(name, handler);
+    }
+
+    addEventListener(name: string, handler: any) {
+        this.eventEmitter.on(name, handler);
+    }
+
+    dispatchEvent(type: string) {
+        this.eventEmitter.emit(type, { type, target: this });
+    }
+}
+
+class AbortControllerFallback {
+    signal: AbortSignal;
+
+    constructor() {
+        this.signal = new AbortSignal();
+    }
+
+    abort() {
+        if (this.signal.aborted) return;
+
+        this.signal.dispatchEvent('abort');
+        this.signal.aborted = true;
+    }
+
+    toString() {
+        return '[object AbortController]';
+    }
+}
+
+export type Controller = AbortController | AbortControllerFallback;
+
+// AbortController part of node since v15
+export const getAbortController = () =>
+    typeof AbortController !== 'undefined' ? new AbortController() : new AbortControllerFallback();

--- a/src/js/env/node/workers.js
+++ b/src/js/env/node/workers.js
@@ -1,27 +1,12 @@
 /* @flow */
-/* istanbul ignore next */
-import TinyWorker from 'tiny-worker';
+import BlockbookWorker from '@trezor/blockchain-link/lib/workers/blockbook';
+import RippleWorker from '@trezor/blockchain-link/lib/workers/ripple';
+import BlockfrostWorker from '@trezor/blockchain-link/lib/workers/blockfrost';
 import type { Transport } from '@trezor/transport';
 
 type TransportWrapper = () => Transport;
 
-export const WebUsbPlugin: TransportWrapper | typeof undefined = undefined;
-export const ReactNativeUsbPlugin: TransportWrapper | typeof undefined = undefined;
+const WebUsbPlugin: TransportWrapper | typeof undefined = undefined;
+const ReactNativeUsbPlugin: TransportWrapper | typeof undefined = undefined;
 
-export const BlockbookWorker = () =>
-    new TinyWorker(() => {
-        // $FlowIssue
-        require('@trezor/blockchain-link/lib/workers/blockbook'); // eslint-disable-line global-require
-    });
-
-export const RippleWorker = () =>
-    new TinyWorker(() => {
-        // $FlowIssue
-        require('@trezor/blockchain-link/lib/workers/ripple'); // eslint-disable-line global-require
-    });
-
-export const BlockfrostWorker = () =>
-    new TinyWorker(() => {
-        // $FlowIssue
-        require('@trezor/blockchain-link/lib/workers/blockfrost'); // eslint-disable-line global-require
-    });
+export { WebUsbPlugin, ReactNativeUsbPlugin, BlockbookWorker, RippleWorker, BlockfrostWorker };

--- a/src/js/env/react-native/workers.js
+++ b/src/js/env/react-native/workers.js
@@ -1,23 +1,15 @@
-/* eslint-disable import/extensions */
 /* @flow */
 
-// $FlowIssue
-import BlockbookWorkerWrapper from '@trezor/blockchain-link/build/module/blockbook-worker.js';
-// $FlowIssue
-import RippleWorkerWrapper from '@trezor/blockchain-link/build/module/ripple-worker.js';
-// $FlowIssue
-import BlockfrostWorkerWrapper from '@trezor/blockchain-link/build/module/blockfrost-worker.js';
+import BlockbookWorker from '@trezor/blockchain-link/lib/workers/blockbook';
+import RippleWorker from '@trezor/blockchain-link/lib/workers/ripple';
+import BlockfrostWorker from '@trezor/blockchain-link/lib/workers/blockfrost';
 
 import TrezorLink from '@trezor/transport';
 
 import RNUsbPlugin from './RNUsbPlugin';
 
-export const WebUsbPlugin = undefined;
+const WebUsbPlugin = undefined;
 
-export const ReactNativeUsbPlugin = () => new TrezorLink.Lowlevel(new RNUsbPlugin());
+const ReactNativeUsbPlugin = () => new TrezorLink.Lowlevel(new RNUsbPlugin());
 
-export const BlockbookWorker = () => new BlockbookWorkerWrapper();
-
-export const RippleWorker = () => new RippleWorkerWrapper();
-
-export const BlockfrostWorker = () => new BlockfrostWorkerWrapper();
+export { WebUsbPlugin, ReactNativeUsbPlugin, BlockbookWorker, RippleWorker, BlockfrostWorker };

--- a/src/js/plugins/webextension/trezor-usb-permissions.js
+++ b/src/js/plugins/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '8.2.6';
+const VERSION = '8.2.7-beta.1';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,9 +73,13 @@ Cached transactions are provided to test fixtures via [TX_CACHE](./__txcache__/i
 Missing tx json? use [this tool](./__txcache__/gen-reftx.js) to generate it.
 
 ## Websocket cache
-Similar to transaction cache. `@trezor/blockchain-link` module is conditionally mocked returning cached results from `tests/__wscache__`.
+Similar to transaction cache. If `process.env.TESTS_USE_WS_CACHE` is set to `true` then `@trezor/blockchain-link` is conditionally connected to a local websocket server returning cached results from `tests/__wscache__`.
 
-[See mock](./__wscache__/worker.js)
+[Server](./__wscache__/server.js)
+
+[WebSocketServer in Karma plugin](./karma.plugin.js)
+
+[WsCacheServer in jest.setup](./jest.setup.js)
 
 ## Karma production tests
 Testing `./build` directory in browser environment.

--- a/tests/__wscache__/blockbook.js
+++ b/tests/__wscache__/blockbook.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+export const blockbookFixtures = {
+    getInfo: params => ({
+        data: {
+            name: 'Blockbook',
+            shortcut: params.shortcut,
+            decimals: 8,
+            bestHeight: 7000000, // high block to make sure that utxos have enough confirmations (composeTransaction test)
+            bestHash: '',
+            block0Hash: '',
+            testnet: true,
+            version: '0.0.0-mocked',
+        },
+    }),
+    getAccountInfo: (params, message) => {
+        const file = path.resolve(__dirname, `./getAccountInfo/${message.params.descriptor}.json`);
+        const rawJson = fs.readFileSync(file);
+        const data = JSON.parse(rawJson);
+        return {
+            data,
+        };
+    },
+    estimateFee: (params, message) => ({
+        data: message.params.blocks.map(() => ({ feePerUnit: '1000' })),
+    }),
+};

--- a/tests/__wscache__/blockfrost.js
+++ b/tests/__wscache__/blockfrost.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+export const blockfrostFixtures = {
+    GET_SERVER_INFO: params => ({
+        data: {
+            name: 'Blockfrost',
+            shortcut: params.shortcut,
+            decimals: 6,
+            testnet: false,
+            version: '1.4.0',
+            blockHash: 'test_block_hash-hash',
+            blockHeight: 1,
+        },
+    }),
+    GET_ACCOUNT_INFO: (params, message) => {
+        const file = path.resolve(__dirname, `./getAccountInfo/${message.params.descriptor}.json`);
+        const rawJson = fs.readFileSync(file);
+        const data = JSON.parse(rawJson);
+        return {
+            data,
+        };
+    },
+};

--- a/tests/__wscache__/getAccountInfo/0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8.json
+++ b/tests/__wscache__/getAccountInfo/0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8.json
@@ -1,14 +1,9 @@
 {
-  "descriptor": "0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8",
-  "balance": "21000",
-  "availableBalance": "21000",
-  "empty": false,
-  "history": {
-    "total": 17,
-    "tokens": 0,
-    "unconfirmed": 0
-  },
-  "misc": {
-    "nonce": "9"
-  }
+  "address": "0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8",
+  "balance": "0",
+  "unconfirmedBalance": "0",
+  "unconfirmedTxs": 0,
+  "txs": 21,
+  "nonTokenTxs": 21,
+  "nonce": "12"
 }

--- a/tests/__wscache__/getAccountInfo/5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088.json
+++ b/tests/__wscache__/getAccountInfo/5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088.json
@@ -1,19 +1,24 @@
 {
-    "availableBalance": "0",
-    "balance": "0",
-    "descriptor": "5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088",
-    "empty": true,
-    "history": {
-        "total": 0,
-        "transactions": [],
-        "unconfirmed": 0
-    },
-    "misc": {
-        "staking": {
-            "address": "stake1ux32jdf5aqj763wrlpuv6sjrngt0987ggtz8x86kc8p432s09jcqh",
-            "isActive": false,
-            "poolId": null,
-            "rewards": "0"
-        }
+  "descriptor": "5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1f123474e140a2c360b01f0fa66f2f22e2e965a5b07a80358cf75f77abbd66088",
+  "empty": true,
+  "balance": "0",
+  "availableBalance": "0",
+  "tokens": [],
+  "history": {
+    "total": 0,
+    "unconfirmed": 0
+  },
+  "page": {
+    "index": 1,
+    "size": 25,
+    "total": 0
+  },
+  "misc": {
+    "staking": {
+      "address": "stake1ux32jdf5aqj763wrlpuv6sjrngt0987ggtz8x86kc8p432s09jcqh",
+      "rewards": "0",
+      "isActive": false,
+      "poolId": null
     }
+  }
 }

--- a/tests/__wscache__/getAccountInfo/rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj.json
+++ b/tests/__wscache__/getAccountInfo/rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj.json
@@ -1,14 +1,19 @@
 {
-  "descriptor": "rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj",
-  "balance": "20000000",
-  "availableBalance": "0",
-  "empty": false,
-  "history": {
-    "total": -1,
-    "unconfirmed": 0
-  },
-  "misc": {
-    "sequence": 2,
-    "reserve": "20000000"
-  }
+  "status": "success",
+  "type": "response",
+  "result": {
+    "account_data": {
+      "Account": "rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj",
+      "Balance": "10000000",
+      "Flags": 0,
+      "LedgerEntryType": "AccountRoot",
+      "OwnerCount": 0,
+      "PreviousTxnID": "1D73CC86D89BF736D6E0CF2B69BB352C931F0971F21CC052147E3C6F6D78D683",
+      "PreviousTxnLgrSeq": 66949474,
+      "Sequence": 3,
+      "index": "DA88187347B6A203ED9314A5BDFDB73D7C8DFC07CB42FC08B5D7A73B4E2F6E39"
+    },
+    "ledger_hash": "8F6CED94442B2E37DB6759868F31C1BDA3514946BCDCF1F43A67354882E811CA",
+    "ledger_index": 69113681
+  } 
 }

--- a/tests/__wscache__/getAccountInfo/rh5ZnEVySAy7oGd3nebT3wrohGDrsNS83E.json
+++ b/tests/__wscache__/getAccountInfo/rh5ZnEVySAy7oGd3nebT3wrohGDrsNS83E.json
@@ -1,14 +1,10 @@
 {
-  "descriptor": "rh5ZnEVySAy7oGd3nebT3wrohGDrsNS83E",
-  "balance": "0",
-  "availableBalance": "0",
-  "empty": true,
-  "history": {
-    "total": -1,
-    "unconfirmed": 0
-  },
-  "misc": {
-    "sequence": 0,
-    "reserve": "20000000"
-  }
+  "status": "error",
+  "type": "response",
+  "error": "actNotFound",
+  "error_code": 19,
+  "error_message": "Account not found.",
+  "ledger_hash": "FDFA9E459F54932F2713F6728A6102E8255C3C8441C717CD7689AD0C38F228AD",
+  "ledger_index": 48356306,
+  "validated": true
 }

--- a/tests/__wscache__/getAccountInfo/upub5Eo1frmiD2QQL6L5x5toFyJVZQuFijQTwiDK7S7KDkgCNykDJtG4TApkdv23L5MDLgRuxMJQEucxXVio2ciKCqfx6Y41skKTZhxNjSgJ6pU.json
+++ b/tests/__wscache__/getAccountInfo/upub5Eo1frmiD2QQL6L5x5toFyJVZQuFijQTwiDK7S7KDkgCNykDJtG4TApkdv23L5MDLgRuxMJQEucxXVio2ciKCqfx6Y41skKTZhxNjSgJ6pU.json
@@ -1,10 +1,9 @@
 {
-  "descriptor": "upub5Eo1frmiD2QQL6L5x5toFyJVZQuFijQTwiDK7S7KDkgCNykDJtG4TApkdv23L5MDLgRuxMJQEucxXVio2ciKCqfx6Y41skKTZhxNjSgJ6pU",
+  "address": "upub5Eo1frmiD2QQL6L5x5toFyJVZQuFijQTwiDK7S7KDkgCNykDJtG4TApkdv23L5MDLgRuxMJQEucxXVio2ciKCqfx6Y41skKTZhxNjSgJ6pU",
   "balance": "0",
-  "availableBalance": "0",
-  "empty": true,
-  "history": {
-    "total": 0,
-    "unconfirmed": 0
-  }
+  "totalReceived": "0",
+  "totalSent": "0",
+  "txs": 0,
+  "unconfirmedBalance": "0",
+  "unconfirmedTxs": 0
 }

--- a/tests/__wscache__/getAccountInfo/xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH.json
+++ b/tests/__wscache__/getAccountInfo/xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH.json
@@ -1,10 +1,9 @@
 {
-  "descriptor": "xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH",
+  "address": "xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH",
   "balance": "0",
-  "availableBalance": "0",
-  "empty": false,
-  "history": {
-    "total": 16,
-    "unconfirmed": 0
-  }
+  "totalReceived": "2725254",
+  "totalSent": "2725254",
+  "txs": 19,
+  "unconfirmedBalance": "0",
+  "unconfirmedTxs": 0
 }

--- a/tests/__wscache__/getAccountInfo/xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G.json
+++ b/tests/__wscache__/getAccountInfo/xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G.json
@@ -1,10 +1,9 @@
 {
-  "descriptor": "xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G",
+  "address": "xpub6DExuxjQ16sWy5TF4KkLV65YGqCJ5pyv7Ej7d9yJNAXz7C1M9intqszXfaNZG99KsDJdQ29wUKBTZHZFXUaPbKTZ5Z6f4yowNvAQ8fEJw2G",
   "balance": "0",
-  "availableBalance": "0",
-  "empty": true,
-  "history": {
-    "total": 0,
-    "unconfirmed": 0
-  }
+  "totalReceived": "0",
+  "totalSent": "0",
+  "txs": 0,
+  "unconfirmedBalance": "0",
+  "unconfirmedTxs": 0
 }

--- a/tests/__wscache__/getAccountInfo/ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt.json
+++ b/tests/__wscache__/getAccountInfo/ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt.json
@@ -1,10 +1,9 @@
 {
-  "descriptor": "ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt",
+  "address": "ypub6Y5EDdQK9nQzpNeMtgXxhBB3SoLk2SyR2MFLQYsBkAusAHpaQNxTTwefgnL9G3oFGrRS9VkVvyY1SaApFAzQPZ99wto5etdReeE3XFkkMZt",
   "balance": "0",
-  "availableBalance": "0",
-  "empty": false,
-  "history": {
-    "total": 8,
-    "unconfirmed": 0
-  }
+  "totalReceived": "400000",
+  "totalSent": "400000",
+  "txs": 8,
+  "unconfirmedBalance": "0",
+  "unconfirmedTxs": 0
 }

--- a/tests/__wscache__/ripple.js
+++ b/tests/__wscache__/ripple.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+export const rippleFixtures = {
+    server_info: () => ({
+        status: 'success',
+        type: 'response',
+        result: {
+            info: {
+                build_version: '1.4.0',
+                complete_ledgers: '32570-8819951',
+                hostid: 'localhost',
+                validated_ledger: {
+                    age: 7,
+                    base_fee_xrp: 0.00001,
+                    reserve_base_xrp: 20,
+                    reserve_inc_xrp: 5,
+                    hash: '1',
+                    seq: 1,
+                },
+                load_factor: 1,
+            },
+        },
+    }),
+    account_info: (params, message) => {
+        const file = path.resolve(__dirname, `./getAccountInfo/${message.account}.json`);
+        const rawJson = fs.readFileSync(file);
+        const data = JSON.parse(rawJson);
+        return data;
+    },
+    subscribe: () => ({
+        status: 'success',
+        type: 'response',
+        result: {
+            fee_base: 10,
+            fee_ref: 10,
+            hostid: 'NAP',
+            ledger_hash: '60EBABF55F6AB58864242CADA0B24FBEA027F2426917F39CA56576B335C0065A',
+            ledger_index: 8819951,
+            ledger_time: 463782770,
+            load_base: 256,
+            load_factor: 256,
+            pubkey_node: 'n9Lt7DgQmxjHF5mYJsV2U9anALHmPem8PWQHWGpw4XMz79HA5aJY',
+            random: 'EECFEE93BBB608914F190EC177B11DE52FC1D75D2C97DACBD26D2DFC6050E874',
+            reserve_base: 20000000,
+            reserve_inc: 5000000,
+            server_status: 'full',
+            validated_ledgers: '32570-8819951',
+        },
+    }),
+    ping: () => ({
+        status: 'success',
+        type: 'response',
+        result: {},
+    }),
+};

--- a/tests/__wscache__/server.js
+++ b/tests/__wscache__/server.js
@@ -1,0 +1,51 @@
+const WebSocket = require('ws');
+const { blockbookFixtures } = require('./blockbook');
+const { rippleFixtures } = require('./ripple');
+const { blockfrostFixtures } = require('./blockfrost');
+
+const DEFAULT_RESPONSES = {
+    blockbook: blockbookFixtures,
+    ripple: rippleFixtures,
+    blockfrost: blockfrostFixtures,
+};
+
+export const createServer = () => {
+    const server = new WebSocket.Server({ port: 18088, noServer: true });
+
+    const processRequest = (ws, params, message) => {
+        const request = JSON.parse(message);
+        if (!request) {
+            throw new Error('Unknown WsCacheServer request');
+        }
+        const serverResponses = DEFAULT_RESPONSES[params.type];
+        if (!serverResponses) {
+            throw new Error(`Unknown WsCacheServer responses for ${params.type}`);
+        }
+
+        const field = params.type === 'blockbook' ? 'method' : 'command';
+        const command = request[field];
+        if (!command) {
+            throw new Error(`Unknown WsCacheServer request without ${field}`);
+        }
+
+        const fn = serverResponses[command];
+        if (!fn) {
+            throw new Error(`Unknown WsCacheServer response for ${command}`);
+        }
+
+        const data = fn(params, request);
+        ws.send(JSON.stringify({ ...data, id: request.id }));
+    };
+
+    server.on('connection', (ws, request) => {
+        // request.url starts with /?
+        const query = new URLSearchParams(request.url.substring(2));
+        const params = { type: query.get('type'), shortcut: query.get('shortcut') };
+        ws.on('message', message => processRequest(ws, params, message));
+    });
+
+    return new Promise((resolve, reject) => {
+        server.on('listening', () => resolve(server));
+        server.on('error', error => reject(error));
+    });
+};

--- a/tests/device/methods.test.js
+++ b/tests/device/methods.test.js
@@ -7,11 +7,15 @@ let controller;
 let currentMnemonic;
 
 describe(`TrezorConnect methods`, () => {
-    // reset controller at the end
     afterAll(done => {
+        // reset controller at the end
         if (controller) {
             controller.dispose();
             controller = undefined;
+        }
+        // global.WsCacheServer is assigned in jest.setup.js
+        if (global.WsCacheServer) {
+            global.WsCacheServer.close();
         }
         done();
     });

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,19 +1,21 @@
 import { TX_CACHE } from './__txcache__';
-import { WS_CACHE } from './__wscache__';
-import { MockedWorker } from './__wscache__/worker';
+import { createServer } from './__wscache__';
 
 jest.setTimeout(20000);
 
 // Always mock blockchain-link worker unless it's explicitly required not to.
-if (process.env.TESTS_USE_WS_CACHE !== 'false') {
-    jest.mock('tiny-worker', () => ({
-        __esModule: true,
-        default: MockedWorker,
-    }));
+if (process.env.TESTS_USE_WS_CACHE === 'true') {
+    createServer().then(s => {
+        global.WsCacheServer = s;
+    });
+    jest.mock('../src/data/coins.json', () => {
+        const json = jest.requireActual('../src/data/coins.json');
+        const { transformCoinsJson } = jest.requireActual('./__wscache__');
+        return transformCoinsJson(json);
+    });
 }
 
 global.TestUtils = {
     ...global.TestUtils,
     TX_CACHE,
-    WS_CACHE,
 };

--- a/tests/karma.plugin.js
+++ b/tests/karma.plugin.js
@@ -1,9 +1,9 @@
 // Karma custom plugin
 
 const { CACHE } = require('./__txcache__');
-const { WS_CACHE } = require('./__wscache__');
+const { createServer, transformCoinsJson } = require('./__wscache__');
 
-const Reporter = (rootConfig, logger) => {
+const CustomReporter = (rootConfig, logger) => {
     const log = logger.create('reporter.TrezorConnect');
 
     return {
@@ -32,24 +32,46 @@ const Reporter = (rootConfig, logger) => {
         },
     };
 };
-
-Reporter.$inject = ['config', 'logger'];
+CustomReporter.$inject = ['config', 'logger'];
 
 // node.js "fs" package is not available in karma (browser) env.
 // stringify CACHE object and inject it into a browser global.TestUtils context, same as jest.setup
-const Preprocessor = logger => (content, file, done) => {
-    const log = logger.create('preprocessor.TrezorConnect');
-    log.info('Processing cache');
+const TxCachePreprocessor = logger => (content, file, done) => {
+    const log = logger.create('preprocessor.TxCachePreprocessor');
+    log.info('Processing cache...');
     done(
         `const CACHE = ${JSON.stringify(CACHE)};
         const TESTS_USE_TX_CACHE = ${process.env.TESTS_USE_TX_CACHE};
-        TestUtils.WS_CACHE = ${JSON.stringify(WS_CACHE)};
         TestUtils.TX_CACHE = (txs, force = false) => { if (TESTS_USE_TX_CACHE === false && !force) return []; return txs.map(hash => CACHE[hash]); };`,
     );
 };
-Preprocessor.$inject = ['logger'];
+TxCachePreprocessor.$inject = ['logger'];
+
+const WsCachePreprocessor = logger => (content, file, done) => {
+    if (process.env.TESTS_USE_WS_CACHE !== 'true') {
+        done(content);
+        return;
+    }
+    const log = logger.create('preprocessor.WsCachePreprocessor');
+    const json = transformCoinsJson(JSON.parse(content));
+    log.info('Processing coins.json...');
+    done(JSON.stringify(json));
+};
+WsCachePreprocessor.$inject = ['logger'];
+
+const WebSocketServer = (args, config, logger) => {
+    if (process.env.TESTS_USE_WS_CACHE !== 'true') return;
+    const log = logger.create('framework.WebSocketServer');
+
+    log.info('Starting websocket server...');
+    createServer().then(s => {
+        log.info('Server started...', s);
+    });
+};
 
 module.exports = {
-    'preprocessor:TrezorConnect': ['factory', Preprocessor],
-    'reporter:TrezorConnect': ['type', Reporter],
+    'preprocessor:TxCachePreprocessor': ['factory', TxCachePreprocessor],
+    'preprocessor:WsCachePreprocessor': ['factory', WsCachePreprocessor],
+    'reporter:CustomReporter': ['type', CustomReporter],
+    'framework:WebsocketServer': ['factory', WebSocketServer],
 };

--- a/tests/karma.setup.js
+++ b/tests/karma.setup.js
@@ -1,5 +1,3 @@
-import { MockedWorker } from './__wscache__/worker';
-
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
 // jasmine is missing "toMatchObject" matcher (deeply partial matching)
@@ -51,12 +49,3 @@ jasmine.getEnv().beforeAll(() => {
 
 // expect is missing "any" matcher
 expect.any = jasmine.any;
-
-// catch trezor-connect iframe handshake and override native Worker class with cached responses
-// this is possible ONLY because both connect and tests are running from the same origin
-window.addEventListener('message', event => {
-    // Always mock blockchain-link worker unless it's explicitly required not to.
-    if (event.data.type === 'iframe-bootstrap' && process.env.TESTS_USE_WS_CACHE !== 'false') {
-        event.currentTarget.Worker = MockedWorker;
-    }
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,16 +1775,14 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@trezor/blockchain-link@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@trezor/blockchain-link/-/blockchain-link-1.1.0.tgz#065d18d7c948c4de45437fc2178d9e26a7c2304b"
-  integrity sha512-tH3hLG54VZ52Y6Fxdw51kqORbuzUSt1VReISj/oZROMexmDDCRgFR14/wxasjHp94XRYrx8777Boa1qrpAos4w==
+"@trezor/blockchain-link@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@trezor/blockchain-link/-/blockchain-link-2.0.0.tgz#12d18bc96662dda999e8e5412ae3f24474eb4deb"
+  integrity sha512-Jx9nedFSduSMXpf8Z61rnbcFg0WoYNGA45a7iO15Z92/aIu4TqoQWCvTn7OWhLf+ibMA52NPSyMc1xsQicJpRg==
   dependencies:
     bignumber.js "^9.0.1"
-    es6-promise "^4.2.8"
-    events "^3.2.0"
+    events "^3.3.0"
     ripple-lib "1.10.0"
-    tiny-worker "^2.3.0"
     ws "^7.4.0"
 
 "@trezor/connect-common@0.0.4":
@@ -4364,7 +4362,7 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
-es6-promise@^4.2.2, es6-promise@^4.2.8:
+es6-promise@^4.2.2:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -4567,11 +4565,6 @@ eslint@^7.32.0:
     table "^6.0.9"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
-
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^7.3.0:
   version "7.3.0"
@@ -9580,13 +9573,6 @@ tiny-secp256k1@^1.1.6:
     create-hmac "^1.1.7"
     elliptic "^6.4.0"
     nan "^2.13.2"
-
-tiny-worker@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tiny-worker/-/tiny-worker-2.3.0.tgz#715ae34304c757a9af573ae9a8e3967177e6011e"
-  integrity sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==
-  dependencies:
-    esm "^3.2.25"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
based on https://github.com/trezor/trezor-suite/pull/4726
- use blockchain-link  modules in env/node and env/react-native
- remove 'tiny-worker' from extended dependencies (not used in runtime anymore)