### PR TITLE
Fix typo in ethereumSignTypedData.md

### DIFF
--- a/docs/methods/ethereumSignTypedData.md
+++ b/docs/methods/ethereumSignTypedData.md
@@ -33,7 +33,7 @@ TrezorConnect.ethereumSignTypedData(params).then(function(result) {
 ### Example
 
 ```javascript
-TrezorConnect.ethereumSignMessage({
+TrezorConnect.ethereumSignTypedData({
     path: "m/44'/60'/0'",
     data: {
         types: {


### PR DESCRIPTION
Changes `ethereumSignMessage` to `ethereumSignTypedData` in example.