### PR TITLE
Fix `getFirmwareRange()` for multiple matching firmware ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - `TrezorConnect.setProxy` method. Allow @trezor/blockchain-link using TOR proxy.
 
+### Fixed
+- Some methods not throwing `ui-device_firmware_unsupported` when the current device firmware didn't support the method.
+
 ### Changed
 - @trezor/blockchain-link 2.0.0 use workers as commonjs modules in nodejs and react-native env.
 

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -168,8 +168,8 @@
         },
         {
             "methods": ["ethereumSignTypedData"],
-            "min": ["0", "2.4.3"],
-            "comment": ["EIP-712 typed signing support added in 2.4.3"]
+            "min": ["1.10.5", "2.4.3"],
+            "comment": ["EIP-712 typed signing support added in 1.10.5/2.4.3"]
         }
     ]
 }

--- a/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
+++ b/src/js/core/methods/helpers/__fixtures__/paramsValidator.js
@@ -233,17 +233,18 @@ export const getFirmwareRange = [
         result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
     },
     {
-        description: 'range from config.json (by coinType)',
+        description: 'range from config.json (by coinType and coin as string)',
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { coinType: 'bitcoin', min: ['1.10.0', '2.4.0'] },
-                { coin: 'btc', min: ['1.11.0', '2.5.0'] },
+                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.12.0', '2.6.0'] },
+                // should merge both of these ranges together, since they both match
+                { coinType: 'bitcoin', min: ['1.10.0', '2.5.0'] },
+                { coin: 'btc', min: ['1.11.0', '2.4.0'] },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { '1': { min: '1.10.0', max: '0' }, '2': { min: '2.4.0', max: '0' } },
+        result: { '1': { min: '1.11.0', max: '0' }, '2': { min: '2.5.0', max: '0' } },
     },
     {
         description: 'range from config.json (by coin as string)',
@@ -362,6 +363,6 @@ export const getFirmwareRange = [
             { support: { trezor1: '1.6.2', trezor2: '2.1.0' }, shortcut: 'eth', type: 'ethereum' },
             DEFAULT_RANGE,
         ],
-        result: { '1': { min: '1.8.0', max: '0' }, '2': { min: '2.1.0', max: '0' } },
+        result: { '1': { min: '1.10.4', max: '0' }, '2': { min: '2.4.2', max: '0' } },
     },
 ];

--- a/src/js/core/methods/helpers/paramsValidator.js
+++ b/src/js/core/methods/helpers/paramsValidator.js
@@ -127,7 +127,7 @@ export const getFirmwareRange = (
     const shortcut = coinInfo ? coinInfo.shortcut.toLowerCase() : null;
     // find firmware range in config.json
     const { supportedFirmware } = DataManager.getConfig();
-    const range = supportedFirmware
+    const ranges = supportedFirmware
         .filter(rule => {
             // check if rule applies to requested method
             if (rule.methods) {
@@ -141,7 +141,7 @@ export const getFirmwareRange = (
             // it may be a global rule for coin or coinType
             return true;
         })
-        .find(c => {
+        .filter(c => {
             if (c.coinType) {
                 // rule for coin type
                 return c.coinType === coinType;
@@ -154,7 +154,7 @@ export const getFirmwareRange = (
             return c.methods || c.capabilities;
         });
 
-    if (range) {
+    for (const range of ranges) {
         const { min, max } = range;
         // override defaults
         // NOTE:

--- a/tests/__fixtures__/binanceSignTransaction.js
+++ b/tests/__fixtures__/binanceSignTransaction.js
@@ -1,7 +1,7 @@
 const legacyResults = [
     {
         // binanceSignTransaction not supported below this version
-        rules: ['<2.3.0'],
+        rules: ['<2.3.0', '1'],
         success: false,
     },
 ];

--- a/tests/__fixtures__/cardanoGetAddress.js
+++ b/tests/__fixtures__/cardanoGetAddress.js
@@ -4,7 +4,7 @@ import { Enum_CardanoAddressType as CardanoAddressType } from '../../src/js/type
 const legacyResults = [
     {
         // cardanoGetAddress not supported below this version
-        rules: ['<2.3.2'],
+        rules: ['<2.3.2', '1'],
         success: false,
     },
 ];
@@ -592,5 +592,5 @@ export default {
             },
             result: false,
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/cardanoGetNativeScriptHash.js
+++ b/tests/__fixtures__/cardanoGetNativeScriptHash.js
@@ -23,7 +23,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -42,7 +42,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -70,7 +70,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -98,7 +98,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -126,7 +126,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -154,7 +154,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -182,7 +182,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -215,7 +215,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -248,7 +248,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -276,7 +276,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -304,7 +304,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -374,7 +374,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],

--- a/tests/__fixtures__/cardanoGetPublicKey.js
+++ b/tests/__fixtures__/cardanoGetPublicKey.js
@@ -1,7 +1,7 @@
 const legacyResults = [
     {
         // cardanoGetPublicKey not supported below this version
-        rules: ['<2.3.2'],
+        rules: ['<2.3.2', '1'],
         success: false,
     },
 ];
@@ -74,5 +74,5 @@ export default {
             },
             legacyResults,
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -313,7 +313,7 @@ const VALIDITY_INTERVAL_START = '47';
 const legacyResults = [
     {
         // cardanoSignTransaction not supported below this version
-        rules: ['<2.3.2'],
+        rules: ['<2.3.2', '1'],
         success: false,
     },
 ];
@@ -1644,5 +1644,5 @@ export default {
                 },
             ],
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/eosGetPublicKey.js
+++ b/tests/__fixtures__/eosGetPublicKey.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // EOS not supported below this version
+        rules: ['<2.1.1', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'eosGetPublicKey',
     setup: {
@@ -63,5 +71,5 @@ export default {
                 },
             ],
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/eosSignTransaction.js
+++ b/tests/__fixtures__/eosSignTransaction.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // EOS not supported below this version
+        rules: ['<2.1.1', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'eosSignTransaction',
     setup: {
@@ -664,5 +672,5 @@ export default {
                     'SIG_K1_JvoJtrHpQJjHAZzEBhiQm75iimYabcAVNDvz8mkempLh6avSJgnXm5JzCCUEBjDtW3syByfXknmgr93Sw3P9RNLnwySmv6',
             },
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/rippleGetAddress.js
+++ b/tests/__fixtures__/rippleGetAddress.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // rippleGetAddress not supported below this version
+        rules: ['<2.1.0', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'rippleGetAddress',
     setup: {
@@ -39,5 +47,5 @@ export default {
                 address: 'rwrZ3agNYYJw4yi6v1r7Ui9AwX9KsWzghr',
             },
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/rippleSignTransaction.js
+++ b/tests/__fixtures__/rippleSignTransaction.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // rippleGetAddress not supported below this version
+        rules: ['<2.1.0', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'rippleSignTransaction',
     setup: {
@@ -84,5 +92,5 @@ export default {
             },
             result: false,
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/tezosGetAddress.js
+++ b/tests/__fixtures__/tezosGetAddress.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // Tezos not supported below this version
+        rules: ['<2.0.8', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'tezosGetAddress',
     setup: {
@@ -40,5 +48,5 @@ export default {
             },
             result: false,
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };

--- a/tests/__fixtures__/tezosGetPublicKey.js
+++ b/tests/__fixtures__/tezosGetPublicKey.js
@@ -1,3 +1,11 @@
+const legacyResults = [
+    {
+        // Tezos not supported below this version
+        rules: ['<2.0.8', '1'],
+        success: false,
+    },
+];
+
 export default {
     method: 'tezosGetPublicKey',
     setup: {
@@ -40,5 +48,5 @@ export default {
             },
             result: false,
         },
-    ],
+    ].map(fixture => ({ ...fixture, legacyResults })),
 };


### PR DESCRIPTION
Fixes a bug in the `getFirmwareRange()` function.

If there are multiple matching rules in [`src/data/config.json`](https://github.com/aloisklink/connect/blob/d0ee310534d15e9be2f436a1e35746ff6b29349a/src/data/config.json#L97-L101), `getFirmwareRange()` only uses the first rule.

Because there was a rule called `coin: ["eth", ` at the beginning of this file, all of the other Ethereum rules were being ignored. This meant that there was no `ui-device_firmware_unsupported` error thrown when a firmware didn't support EIP1559 or `ethereumSignTypedData`.

This PR changes `getFirmwareRange()` so that it goes through all matching rules in `src/data/config.json`.

### Test Results

- unit tests pass
- emulator tests:
  - **all pass** when running `./tests/run.sh -D 'podman' -f '2-master'`
  - **failures** on ethereumTypedData when running `./tests/run.sh -D 'podman'`
    - I'll fix in #1033
  - **failures** when running `./tests/run.sh -D 'podman' -f '1-master'`
    - I added `legacyResults` to the tests that were failing since the T1 firmware was unsupported in https://github.com/trezor/connect/commit/d0ee310534d15e9be2f436a1e35746ff6b29349a.
    - fails on ethereumTypedData (which I'll fix in #1033),
    - finally, a bunch of functions consistently fail in `signTransaction` (e.g. `Testnet (P2PKH)`) with errors:
      - `Device_CallInProgress`
      - `Async callback was not invoked within the 20000 ms timeout specified by jest.setTimeout.Error`

Edit: :facepalm: Forgot to run `yarn lint`, I'll force-push the changes since I don't think anybody would have reviewed the changes in the last few minutes.