### PR TITLE
chore(nix): update to match trezor-suite

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
-# the last successful build of nixos-20.09 (stable) as of 2020-10-11
+# the last successful build of nixpkgs-unstable as of 2021-11-16 compatible to trezor-suite
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/0b8799ecaaf0dc6b4c11583a3c96ca5b40fcfdfb.tar.gz";
-    sha256 = "11m4aig6cv0zi3gbq2xn9by29cfvnsxgzf9qsvz67qr0yq29ryyz";
+    url = "https://github.com/NixOS/nixpkgs/archive/5cb226a06c49f7a2d02863d0b5786a310599df6b.tar.gz";
+    sha256 = "0dzz207swwm5m0dyibhxg5psccrcqfh1lzkmzzfns27wc4ria6z3";
   })
 { };
 


### PR DESCRIPTION
I have tested build and eslint and it seemed to work. In case @szymonlesisz is using it he should double-check.

Closes trezor/trezor-suite#4891.