### PR TITLE
fix(native): Rename RN Native plugin

### DIFF
--- a/src/js/env/react-native/RNUsbPlugin.js
+++ b/src/js/env/react-native/RNUsbPlugin.js
@@ -8,7 +8,7 @@ type TrezorDeviceInfoDebug = {
     debug: boolean,
 };
 
-interface RNBridge {
+interface TrezorTransport {
     enumerate(): Promise<TrezorDeviceInfoDebug[]>;
     acquire(path: string, debugLink: boolean): Promise<void>;
     release(path: string, debugLink: boolean, closePort: boolean): Promise<void>;
@@ -42,10 +42,10 @@ export default class ReactNativePlugin {
 
     requestNeeded = false;
 
-    usb: RNBridge;
+    usb: TrezorTransport;
 
     constructor() {
-        this.usb = NativeModules.RNBridge;
+        this.usb = NativeModules.TrezorTransport;
     }
 
     init(debug: ?boolean) {


### PR DESCRIPTION
Rename RN Native Module to name to correspond with `transport-native` package in suite monorepo. Also old name was could be really confusing because react-native use class `RNBridge` in native code for communication.

After this part will be migrated to monorepo, it should use directly package `transport-native` instead of `react-native.NativeModules`.