### PR TITLE
Add CI tests for Ethereum plugin

### DIFF
--- a/.github/workflows/test_methods_nodejs.yml
+++ b/.github/workflows/test_methods_nodejs.yml
@@ -188,3 +188,26 @@ jobs:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: ./tests/run.sh -s 'yarn test:integration methods' -i binanceSignTransaction
+
+  ethereum-plugin:
+    name: Test Ethereum Plugin
+    needs: check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/js/plugins/ethereum
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: yarn
+        # cache by default looks at repo root only, not working-directory
+        cache-dependency-path: src/js/plugins/ethereum/yarn.lock
+    - name: Installing plugin dependencies
+      run: yarn install
+    - name: Test Unit
+      run: yarn test:unit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -299,3 +299,21 @@ node:
     - /trezor-user-env/run.sh &
     - sleep 10
     - nix-shell --run "yarn babel-node ./examples/node/index.js"
+
+test ethereum plugin:
+  stage: test
+  dependencies:
+    # we only need the submodules part of this, not the node_modules
+    - "setup environment"
+  # Required only to make the `nix-shell` command available
+  # Alternatively, we could replace with generic `image: nixos/nix:latest`
+  image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env:latest
+  script:
+    - nix-shell --run "cd src/js/plugins/ethereum/ && yarn install --cache-folder ./.yarn-cache"
+    - nix-shell --run "cd src/js/plugins/ethereum/ && yarn test:unit"
+  cache:
+    key:
+      files:
+        - src/js/plugins/ethereum/yarn.lock
+    paths:
+      - src/js/plugins/ethereum/.yarn-cache

--- a/src/js/plugins/ethereum/package.json
+++ b/src/js/plugins/ethereum/package.json
@@ -1,6 +1,7 @@
 {
     "name": "trezor-connect",
     "version": "1.0.0",
+    "private": "true",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/connect",
     "description": "Trezor 3rd party plugins",

--- a/src/js/plugins/ethereum/typedData.test.js
+++ b/src/js/plugins/ethereum/typedData.test.js
@@ -8,26 +8,28 @@ function messageToHex(string) {
 }
 
 describe('typedData', () => {
-    commonFixtures.tests
-        .filter(test => test.parameters.metamask_v4_compat)
-        .forEach(test => {
-            it('typedData to message_hash and domain_separator_hash', () => {
-                const transformed = typedData(
-                    test.parameters.data,
-                    test.parameters.metamask_v4_compat,
-                );
-                const { domain_separator_hash, message_hash } = transformed;
-
-                expect(messageToHex(domain_separator_hash)).toEqual(
-                    messageToHex(test.parameters.domain_separator_hash),
-                );
-                if (message_hash) {
-                    expect(messageToHex(message_hash)).toEqual(
-                        messageToHex(test.parameters.message_hash),
+    describe('should create message_hash and domain_separator_hash from typedData', () => {
+        commonFixtures.tests
+            .filter(test => test.parameters.metamask_v4_compat)
+            .forEach(test => {
+                it(test.name, () => {
+                    const transformed = typedData(
+                        test.parameters.data,
+                        test.parameters.metamask_v4_compat,
                     );
-                } else {
-                    expect(null).toEqual(test.parameters.message_hash);
-                }
+                    const { domain_separator_hash, message_hash } = transformed;
+
+                    expect(messageToHex(domain_separator_hash)).toEqual(
+                        messageToHex(test.parameters.domain_separator_hash),
+                    );
+                    if (message_hash) {
+                        expect(messageToHex(message_hash)).toEqual(
+                            messageToHex(test.parameters.message_hash),
+                        );
+                    } else {
+                        expect(null).toEqual(test.parameters.message_hash);
+                    }
+                });
             });
-        });
+    });
 });


### PR DESCRIPTION
Adds CI tests for the Ethereum plugin (as discussed in https://github.com/trezor/connect/pull/1033#issuecomment-1033421429)

I've added the test to both GitHub Actions and GitLab CI. However, I've never used GitLab CI before, so I'm not 100% sure if this would work.