### PR TITLE
feat(cardano): add support for plutus transactions

### DIFF
--- a/docs/methods/cardanoGetAddress.md
+++ b/docs/methods/cardanoGetAddress.md
@@ -18,7 +18,7 @@ TrezorConnect.cardanoGetAddress(params).then(function(result) {
 #### Exporting single address
 * `addressParameters` — *required* see description below
 * `address` — *optional* `string` address for validation (read `Handle button request` section below)
-* `protocolMagic` - *required* `Integer` 764824073 for Mainnet, 42 for Testnet
+* `protocolMagic` - *required* `Integer` 764824073 for Mainnet, 1097911063 for Testnet
 * `networkId` - *required* `Integer` 1 for Mainnet, 0 for Testnet
 * `showOnTrezor` — *optional* `boolean` determines if address will be displayed on device. Default is set to `true`
 * `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
@@ -217,7 +217,7 @@ TrezorConnect.cardanoGetAddress({
                 addressType: 8,
                 path: "m/44'/1815'/1'/0/2",
             },
-            protocolMagic: 42,
+            protocolMagic: 1097911063,
             networkId: 0,
             showOnTrezor: false
         },

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -22,7 +22,7 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `inputs` - *required* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L92)
 * `outputs` - *required* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L109)
 * `fee` - *required* `String`
-* `protocolMagic` - *required* `Integer` 764824073 for Mainnet, 42 for Testnet
+* `protocolMagic` - *required* `Integer` 764824073 for Mainnet, 1097911063 for Testnet
 * `networkId` - *required* `Integer` 1 for Mainnet, 0 for Testnet
 * `ttl` - *optional* `String`
 * `validityIntervalStart` - *optional* `String`

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -85,7 +85,6 @@ Represents a transactions containing Plutus script evaluation. The transaction w
 
 The transaction
 - *should* contain `scriptDataHash` and `collateralInputs`
-- *must not* contain output addresses given by parameters
 - *must not* contain a pool registration certificate
 - *may* contain only 1852, 1854 and 1855 required signers
 - *may* contain only 1852, 1854 and 1855 witness requests

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -28,11 +28,11 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `validityIntervalStart` - *optional* `String`
 * `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L158)
 * `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L166)
-* `auxiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#L181)
-* `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L172)
+* `auxiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#L194)
+* `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L174)
 * `scriptDataHash` - *optional* `String`
-* `collateralInputs` - *optional* `Array` of [CardanoCollateralInput](../../src/js/types/networks/cardano.js#L174)
-* `requiredSigners` - *optional* `Array` of [CardanoRequiredSigner](../../src/js/types/networks/cardano.js#L180)
+* `collateralInputs` - *optional* `Array` of [CardanoCollateralInput](../../src/js/types/networks/cardano.js#L176)
+* `requiredSigners` - *optional* `Array` of [CardanoRequiredSigner](../../src/js/types/networks/cardano.js#L182)
 * `additionalWitnessRequests` - *optional* `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 * `metadata` - *removed* - use `auxiliaryData` instead
 * `derivationType` — *optional* `CardanoDerivationType` enum. Determines used derivation type. Default is set to ICARUS_TREZOR=2.
@@ -50,6 +50,7 @@ The transaction
 - *should* have valid `path` property on all `inputs`
 - *must not* contain a pool registration certificate
 - *must not* contain `collateralInputs` and `requiredSigners`
+- *must* contain paths as stake credentials in certificates and withdrawals (no key hashes or script hashes)
 - *may* contain only 1852 and 1855 paths
 - *must not* contain 1855 witness requests when transaction is not minting/burning tokens
 
@@ -75,7 +76,7 @@ The transaction
 - *must not* contain output addresses given by parameters
 - *must not* contain a pool registration certificate
 - *must not* contain `collateralInputs` and `requiredSigners`
-- *must* contain script hash stake credentials in certificates and withdrawals (no paths)
+- *must* contain script hash stake credentials in certificates and withdrawals (no paths or key hashes)
 - *may* contain only 1854 and 1855 witness requests
 - *must not* contain 1855 witness requests when transaction is not minting/burning tokens
 
@@ -91,7 +92,7 @@ The transaction
 
 ### Stake pool registration certificate specifics
 
-Trezor supports signing of stake pool registration certificates as a pool owner. The transaction may contain external inputs (e.g. belonging to the pool operator) and Trezor is not able verify whether they are actually external or not, so if we allowed signing the transaction with a spending key, there is the risk of losing funds from an input that the user did not intend to spend from. Moreover there is the risk of inadvertedly signing a withdrawal in the transaction if there's any. To mitigate those risks, we introduced special validation rules for stake pool registration transactions which are validated on Trezor as well. The validation rules are the following:
+Trezor supports signing of stake pool registration certificates as a pool owner. The transaction may contain external inputs (e.g. belonging to the pool operator) and Trezor is not able to verify whether they are actually external or not, so if we allowed signing the transaction with a spending key, there is the risk of losing funds from an input that the user did not intend to spend from. Moreover there is the risk of inadvertedly signing a withdrawal in the transaction if there's any. To mitigate those risks, we introduced special validation rules for stake pool registration transactions which are validated on Trezor as well. The validation rules are the following:
 
 1. The transaction must not contain any other certificates, not even another stake pool registration
 2. The transaction must not contain any withdrawals
@@ -416,11 +417,11 @@ TrezorConnect.cardanoSignTransaction({
     certificates: [
         {
             type: CardanoCertificateType.STAKE_REGISTRATION,
-            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            path: "m/1852'/1815'/0'/2/0",
         },
         {
             type: CardanoCertificateType.STAKE_DEREGISTRATION,
-            scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+            keyHash: '3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711',
         },
         {
             type: CardanoCertificateType.STAKE_DELEGATION,
@@ -431,6 +432,14 @@ TrezorConnect.cardanoSignTransaction({
     withdrawals: [
         {
             path: "m/1852'/1815'/0'/2/0",
+            amount: "1000",
+        },
+        {
+            keyHash: "3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711",
+            amount: "1000",
+        },
+        {
+            scriptHash: "29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd",
             amount: "1000",
         }
     ],

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -32,7 +32,8 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L164)
 * `additionalWitnessRequests` - *optional* `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 * `metadata` - *removed* - use `auxiliaryData` instead
-* `derivationType` — *optional* `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
+* `derivationType` — *optional* `CardanoDerivationType` enum. Determines used derivation type. Default is set to ICARUS_TREZOR=2.
+* `includeNetworkId` — *optional* `Boolean`. Determines whether `networkId` should be explicitly serialized into the transaction body. Default is `false`.
 
 ### CardanoTxSigningMode
 
@@ -153,6 +154,7 @@ TrezorConnect.cardanoSignTransaction({
     },
     protocolMagic: 764824073,
     networkId: 1,
+    includeNetworkId: false,
 });
 ```
 
@@ -175,6 +177,7 @@ TrezorConnect.cardanoSignTransaction({
     ttl: "500000000",
     protocolMagic: 764824073,
     networkId: 1,
+    includeNetworkId: false,
     certificates: [
         {
             type: CardanoCertificateType.STAKE_POOL_REGISTRATION,
@@ -266,6 +269,7 @@ TrezorConnect.cardanoSignTransaction({
     },
     protocolMagic: 764824073,
     networkId: 1,
+    includeNetworkId: false,
 });
 ```
 
@@ -340,6 +344,7 @@ TrezorConnect.cardanoSignTransaction({
     ],
     protocolMagic: 764824073,
     networkId: 1,
+    includeNetworkId: false,
 });
 ```
 

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -17,19 +17,20 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 
 ### Params
 [****Optional common params****](commonParams.md)
-###### [flowtype](../../src/js/types/networks/cardano.js#L87-L211)
+###### [flowtype](../../src/js/types/networks/cardano.js#L90-L203)
 * `signingMode` - *required* [CardanoTxSigningMode](#CardanoTxSigningMode)
-* `inputs` - *required* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L87)
-* `outputs` - *required* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L103)
+* `inputs` - *required* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L92)
+* `outputs` - *required* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L109)
 * `fee` - *required* `String`
 * `protocolMagic` - *required* `Integer` 764824073 for Mainnet, 42 for Testnet
 * `networkId` - *required* `Integer` 1 for Mainnet, 0 for Testnet
 * `ttl` - *optional* `String`
 * `validityIntervalStart` - *optional* `String`
-* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L150)
-* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L158)
-* `auxiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#L173)
-* `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L164)
+* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L158)
+* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L166)
+* `auxiliaryData` - *optional* [CardanoAuxiliaryData](../../src/js/types/networks/cardano.js#L181)
+* `mint` - *optional* [CardanoMint](../../src/js/types/networks/cardano.js#L172)
+* `scriptDataHash` - *optional* `String`
 * `additionalWitnessRequests` - *optional* `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 * `metadata` - *removed* - use `auxiliaryData` instead
 * `derivationType` — *optional* `CardanoDerivationType` enum. Determines used derivation type. Default is set to ICARUS_TREZOR=2.
@@ -37,7 +38,7 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 
 ### CardanoTxSigningMode
 
-[Type definition](../../src/js/types/trezor/protobuf.js#L98)
+[Type definition](../../src/js/types/trezor/protobuf.js#L604)
 
 #### `ORDINARY_TRANSACTION`
 
@@ -123,6 +124,11 @@ TrezorConnect.cardanoSignTransaction({
                     ]
                 }
             ]
+        },
+        {
+            address: 'addr1w9rhu54nz94k9l5v6d9rzfs47h7dv7xffcwkekuxcx3evnqpvuxu0',
+            amount: '1',
+            datumHash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
         }
     ],
     fee: "42",
@@ -152,6 +158,7 @@ TrezorConnect.cardanoSignTransaction({
     auxiliaryData: {
         hash: "ea4c91860dd5ec5449f8f985d227946ff39086b17f10b5afb93d12ee87050b6a"
     },
+    scriptDataHash: "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02",
     protocolMagic: 764824073,
     networkId: 1,
     includeNetworkId: false,
@@ -352,7 +359,7 @@ TrezorConnect.cardanoSignTransaction({
 
 Since transaction streaming has been introduced to the Cardano implementation on Trezor because of memory constraints, Trezor no longer returns the whole serialized transaction as a result of the `CardanoSignTransaction` call. Instead the transaction hash, transaction witnesses and auxiliary data supplement are returned and the serialized transaction needs to be assembled by the client.
 
-###### [flowtype](../../src/js/types/networks/cardano.js#L175-L179)
+###### [flowtype](../../src/js/types/networks/cardano.js#L218-L222)
 ```javascript
 {
     success: true,

--- a/scripts/protobuf-patches/index.js
+++ b/scripts/protobuf-patches/index.js
@@ -18,6 +18,7 @@ const RULE_PATCH = {
     'CardanoTxWithdrawal.path': 'optional',
     'CardanoNativeScript.scripts': 'optional',
     'CardanoNativeScript.key_path': 'optional',
+    'CardanoTxRequiredSigner.key_path': 'optional',
     'Success.message': 'required', // didn't find use case where it's not sent
     'SignedIdentity.address': 'required',
     'EosAuthorizationKey.key': 'required', // its valid to be undefined according to implementation/tests

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1862,6 +1862,10 @@
           "options": {
             "default": false
           }
+        },
+        "script_data_hash": {
+          "type": "bytes",
+          "id": 16
         }
       }
     },
@@ -1898,6 +1902,10 @@
           "rule": "required",
           "type": "uint32",
           "id": 4
+        },
+        "datum_hash": {
+          "type": "bytes",
+          "id": 5
         }
       }
     },

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1855,6 +1855,13 @@
           "rule": "required",
           "type": "CardanoDerivationType",
           "id": 14
+        },
+        "include_network_id": {
+          "type": "bool",
+          "id": 15,
+          "options": {
+            "default": false
+          }
         }
       }
     },

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -2101,6 +2101,10 @@
         "script_hash": {
           "type": "bytes",
           "id": 5
+        },
+        "key_hash": {
+          "type": "bytes",
+          "id": 6
         }
       }
     },
@@ -2122,6 +2126,10 @@
         "script_hash": {
           "type": "bytes",
           "id": 3
+        },
+        "key_hash": {
+          "type": "bytes",
+          "id": 4
         }
       }
     },

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1576,7 +1576,8 @@
       "values": {
         "ORDINARY_TRANSACTION": 0,
         "POOL_REGISTRATION_AS_OWNER": 1,
-        "MULTISIG_TRANSACTION": 2
+        "MULTISIG_TRANSACTION": 2,
+        "PLUTUS_TRANSACTION": 3
       }
     },
     "CardanoTxWitnessType": {
@@ -1866,6 +1867,16 @@
         "script_data_hash": {
           "type": "bytes",
           "id": 16
+        },
+        "collateral_inputs_count": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 17
+        },
+        "required_signers_count": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 18
         }
       }
     },
@@ -2159,6 +2170,36 @@
           "rule": "required",
           "type": "uint32",
           "id": 1
+        }
+      }
+    },
+    "CardanoTxCollateralInput": {
+      "fields": {
+        "prev_hash": {
+          "rule": "required",
+          "type": "bytes",
+          "id": 1
+        },
+        "prev_index": {
+          "rule": "required",
+          "type": "uint32",
+          "id": 2
+        }
+      }
+    },
+    "CardanoTxRequiredSigner": {
+      "fields": {
+        "key_hash": {
+          "type": "bytes",
+          "id": 1
+        },
+        "key_path": {
+          "rule": "repeated",
+          "type": "uint32",
+          "id": 2,
+          "options": {
+            "packed": false
+          }
         }
       }
     },
@@ -6309,6 +6350,8 @@
         "MessageType_CardanoGetNativeScriptHash": 330,
         "MessageType_CardanoNativeScriptHash": 331,
         "MessageType_CardanoTxMint": 332,
+        "MessageType_CardanoTxCollateralInput": 333,
+        "MessageType_CardanoTxRequiredSigner": 334,
         "MessageType_RippleGetAddress": 400,
         "MessageType_RippleAddress": 401,
         "MessageType_RippleSignTx": 402,

--- a/src/js/constants/cardano.js
+++ b/src/js/constants/cardano.js
@@ -2,7 +2,7 @@
 
 export const PROTOCOL_MAGICS = Object.freeze({
     mainnet: 764824073,
-    testnet: 42,
+    testnet: 1097911063,
 });
 
 export const NETWORK_IDS = Object.freeze({

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -55,6 +55,7 @@ const CardanoSignTransactionFeatures = Object.freeze({
     OutputDatumHash: ['0', '2.4.4'],
     ScriptDataHash: ['0', '2.4.4'],
     Plutus: ['0', '2.4.4'],
+    KeyHashStakeCredential: ['0', '2.4.4'],
 });
 
 export type CardanoSignTransactionParams = {
@@ -145,11 +146,13 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
                 validateParams(withdrawal, [
                     { name: 'amount', type: 'uint', required: true },
                     { name: 'scriptHash', type: 'string' },
+                    { name: 'keyHash', type: 'string' },
                 ]);
                 return {
                     path: withdrawal.path ? validatePath(withdrawal.path, 5) : undefined,
                     amount: withdrawal.amount,
                     script_hash: withdrawal.scriptHash,
+                    key_hash: withdrawal.keyHash,
                 };
             });
         }
@@ -243,6 +246,10 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
             if (certificate.type === CardanoCertificateType.STAKE_POOL_REGISTRATION) {
                 this._ensureFeatureIsSupported('SignStakePoolRegistrationAsOwner');
             }
+
+            if (certificate.key_hash) {
+                this._ensureFeatureIsSupported('KeyHashStakeCredential');
+            }
         });
 
         if (params.validityIntervalStart != null) {
@@ -256,6 +263,12 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
 
             if (output.datum_hash) {
                 this._ensureFeatureIsSupported('OutputDatumHash');
+            }
+        });
+
+        params.withdrawals.forEach(withdrawal => {
+            if (withdrawal.key_hash) {
+                this._ensureFeatureIsSupported('KeyHashStakeCredential');
             }
         });
 

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -49,6 +49,7 @@ const CardanoSignTransactionFeatures = Object.freeze({
     AuxiliaryDataHash: ['0', '2.4.2'],
     TokenMinting: ['0', '2.4.3'],
     Multisig: ['0', '2.4.3'],
+    NetworkIdInTxBody: ['0', '2.4.4'],
 });
 
 export type Path = number[];
@@ -74,6 +75,7 @@ export type CardanoSignTransactionParams = {
     witnessPaths: Path[],
     additionalWitnessRequests: Path[],
     derivationType: CardanoDerivationType,
+    includeNetworkId?: boolean,
 };
 
 export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignTransaction'> {
@@ -121,6 +123,7 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
             { name: 'networkId', type: 'number', required: true },
             { name: 'additionalWitnessRequests', type: 'array', allowEmpty: true },
             { name: 'derivationType', type: 'number' },
+            { name: 'includeNetworkId', type: 'boolean' },
         ]);
 
         const inputsWithPath: InputWithPath[] = payload.inputs.map(input => {
@@ -201,6 +204,7 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
                 typeof payload.derivationType !== 'undefined'
                     ? payload.derivationType
                     : Enum_CardanoDerivationType.ICARUS_TREZOR,
+            includeNetworkId: payload.includeNetworkId,
         };
     }
 
@@ -262,6 +266,10 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
         ) {
             this._ensureFeatureIsSupported('Multisig');
         }
+
+        if (params.includeNetworkId) {
+            this._ensureFeatureIsSupported('NetworkIdInTxBody');
+        }
     }
 
     async _sign_tx(): Promise<CardanoSignedTxData> {
@@ -284,6 +292,7 @@ export default class CardanoSignTransaction extends AbstractMethod<'cardanoSignT
             witness_requests_count: this.params.witnessPaths.length,
             minting_asset_groups_count: this.params.mint.length,
             derivation_type: this.params.derivationType,
+            include_network_id: this.params.includeNetworkId,
         };
 
         // init

--- a/src/js/core/methods/helpers/cardanoCertificate.js
+++ b/src/js/core/methods/helpers/cardanoCertificate.js
@@ -18,7 +18,7 @@ import type {
 } from '../../../types/networks/cardano';
 
 import type {
-    CardanoTxCertificateType,
+    CardanoTxCertificate,
     CardanoPoolParametersType,
     CardanoPoolOwner as CardanoPoolOwnerProto,
     CardanoPoolRelayParameters as CardanoPoolRelayProto,
@@ -125,7 +125,7 @@ const validatePoolParameters = (poolParameters: CardanoPoolParameters) => {
 };
 
 export type CertificateWithPoolOwnersAndRelays = {
-    certificate: CardanoTxCertificateType,
+    certificate: CardanoTxCertificate,
     poolOwners: CardanoPoolOwnerProto[],
     poolRelays: CardanoPoolRelayProto[],
 };
@@ -184,6 +184,7 @@ export const transformCertificate = (
 
     if (certificate.type !== CardanoCertificateType.STAKE_POOL_REGISTRATION) {
         paramsToValidate.push({ name: 'scriptHash', type: 'string' });
+        paramsToValidate.push({ name: 'keyHash', type: 'string' });
     }
 
     if (certificate.type === CardanoCertificateType.STAKE_DELEGATION) {
@@ -205,6 +206,7 @@ export const transformCertificate = (
             type: certificate.type,
             path: certificate.path ? validatePath(certificate.path, 5) : undefined,
             script_hash: certificate.scriptHash,
+            key_hash: certificate.keyHash,
             pool: certificate.pool,
             pool_parameters: poolParameters,
         },

--- a/src/js/core/methods/helpers/cardanoInputs.js
+++ b/src/js/core/methods/helpers/cardanoInputs.js
@@ -1,0 +1,44 @@
+/* @flow */
+import { validateParams } from './paramsValidator';
+import { validatePath } from '../../../utils/pathUtils';
+import type { CardanoTxInput, CardanoTxCollateralInput } from '../../../types/trezor/protobuf';
+
+export type Path = number[];
+
+export type InputWithPath = {
+    input: CardanoTxInput,
+    path?: Path,
+};
+
+export type CollateralInputWithPath = {
+    collateralInput: CardanoTxCollateralInput,
+    path?: Path,
+};
+
+export const transformInput = (input: any): InputWithPath => {
+    validateParams(input, [
+        { name: 'prev_hash', type: 'string', required: true },
+        { name: 'prev_index', type: 'number', required: true },
+    ]);
+    return {
+        input: {
+            prev_hash: input.prev_hash,
+            prev_index: input.prev_index,
+        },
+        path: input.path ? validatePath(input.path, 5) : undefined,
+    };
+};
+
+export const transformCollateralInput = (collateralInput: any): CollateralInputWithPath => {
+    validateParams(collateralInput, [
+        { name: 'prev_hash', type: 'string', required: true },
+        { name: 'prev_index', type: 'number', required: true },
+    ]);
+    return {
+        collateralInput: {
+            prev_hash: collateralInput.prev_hash,
+            prev_index: collateralInput.prev_index,
+        },
+        path: collateralInput.path ? validatePath(collateralInput.path, 5) : undefined,
+    };
+};

--- a/src/js/core/methods/helpers/cardanoOutputs.js
+++ b/src/js/core/methods/helpers/cardanoOutputs.js
@@ -11,7 +11,7 @@ export type OutputWithTokens = {
     tokenBundle?: AssetGroupWithTokens[],
 };
 
-export const transformOutput = (output: any) => {
+export const transformOutput = (output: any): OutputWithTokens => {
     validateParams(output, [
         { name: 'address', type: 'string' },
         { name: 'amount', type: 'uint', required: true },

--- a/src/js/core/methods/helpers/cardanoOutputs.js
+++ b/src/js/core/methods/helpers/cardanoOutputs.js
@@ -16,12 +16,14 @@ export const transformOutput = (output: any) => {
         { name: 'address', type: 'string' },
         { name: 'amount', type: 'uint', required: true },
         { name: 'tokenBundle', type: 'array', allowEmpty: true },
+        { name: 'datumHash', type: 'string' },
     ]);
 
     const result: OutputWithTokens = {
         output: {
             amount: output.amount,
             asset_groups_count: 0,
+            datum_hash: output.datumHash,
         },
     };
 

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -323,9 +323,12 @@ export const cardanoSignTransaction = async () => {
                     },
                 },
                 scriptHash: 'aaff00..',
+                keyHash: 'aaff00..',
             },
         ],
-        withdrawals: [{ path: 'm/44', amount: '3003112', scriptHash: 'aaff00..' }],
+        withdrawals: [
+            { path: 'm/44', amount: '3003112', scriptHash: 'aaff00..', keyHash: 'aaff00..' },
+        ],
         mint: [
             {
                 policyId: 'aaff00..',

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -260,6 +260,7 @@ export const cardanoSignTransaction = async () => {
                         tokenAmounts: [{ assetNameBytes: 'aaff00..', amount: '3003112' }],
                     },
                 ],
+                datumHash: 'aaff00..',
             },
             {
                 addressParameters: {
@@ -280,6 +281,7 @@ export const cardanoSignTransaction = async () => {
                         tokenAmounts: [{ assetNameBytes: 'aaff00..', amount: '3003112' }],
                     },
                 ],
+                datumHash: 'aaff00..',
             },
         ],
         certificates: [
@@ -353,6 +355,7 @@ export const cardanoSignTransaction = async () => {
         fee: '42',
         ttl: '10',
         validityIntervalStart: '20',
+        scriptDataHash: 'aaff00..',
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -356,6 +356,19 @@ export const cardanoSignTransaction = async () => {
         ttl: '10',
         validityIntervalStart: '20',
         scriptDataHash: 'aaff00..',
+        collateralInputs: [
+            {
+                path: 'm/44',
+                prev_hash: '1af..',
+                prev_index: 0,
+            },
+        ],
+        requiredSigners: [
+            {
+                keyPath: 'm/44',
+                keyHash: '1af..',
+            },
+        ],
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -356,6 +356,7 @@ export const cardanoSignTransaction = async () => {
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+        includeNetworkId: false,
     });
 
     if (sign.success) {

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -111,11 +111,13 @@ export type CardanoOutput =
           addressParameters: CardanoAddressParameters,
           amount: string,
           tokenBundle?: CardanoAssetGroup[],
+          datumHash?: string,
       }
     | {
           address: string,
           amount: string,
           tokenBundle?: CardanoAssetGroup[],
+          datumHash?: string,
       };
 
 export type CardanoPoolOwner = {
@@ -191,6 +193,7 @@ export type CardanoSignTransaction = {
     validityIntervalStart?: string,
     auxiliaryData?: CardanoAuxiliaryData,
     mint?: CardanoMint,
+    scriptDataHash?: string,
     additionalWitnessRequests?: (string | number[])[],
     protocolMagic: number,
     networkId: number,

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -171,6 +171,17 @@ export type CardanoWithdrawal = {
 
 export type CardanoMint = CardanoAssetGroup[];
 
+export type CardanoCollateralInput = {
+    path?: string | number[],
+    prev_hash: string,
+    prev_index: number,
+};
+
+export type CardanoRequiredSigner = {
+    keyPath?: string | number[],
+    keyHash?: string,
+};
+
 export type CardanoCatalystRegistrationParameters = {
     votingPublicKey: string,
     stakingPath: string | number[],
@@ -194,6 +205,8 @@ export type CardanoSignTransaction = {
     auxiliaryData?: CardanoAuxiliaryData,
     mint?: CardanoMint,
     scriptDataHash?: string,
+    collateralInputs?: CardanoCollateralInput[],
+    requiredSigners?: CardanoRequiredSigner[],
     additionalWitnessRequests?: (string | number[])[],
     protocolMagic: number,
     networkId: number,

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -161,12 +161,14 @@ export type CardanoCertificate = {
     pool?: string,
     poolParameters?: CardanoPoolParameters,
     scriptHash?: string,
+    keyHash?: string,
 };
 
 export type CardanoWithdrawal = {
     path?: string | number[],
     amount: string,
     scriptHash?: string,
+    keyHash?: string,
 };
 
 export type CardanoMint = CardanoAssetGroup[];

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -196,6 +196,7 @@ export type CardanoSignTransaction = {
     networkId: number,
     signingMode: CardanoTxSigningMode,
     derivationType?: CardanoDerivationType,
+    includeNetworkId?: boolean,
 };
 
 export type CardanoSignedTxWitness = {

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -729,6 +729,7 @@ export type CardanoSignTxInit = {
     witness_requests_count: number,
     minting_asset_groups_count: number,
     derivation_type: CardanoDerivationType,
+    include_network_id?: boolean,
 };
 
 // CardanoTxInput

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -730,6 +730,7 @@ export type CardanoSignTxInit = {
     minting_asset_groups_count: number,
     derivation_type: CardanoDerivationType,
     include_network_id?: boolean,
+    script_data_hash?: string,
 };
 
 // CardanoTxInput
@@ -744,6 +745,7 @@ export type CardanoTxOutput = {
     address_parameters?: CardanoAddressParametersType,
     amount: UintType,
     asset_groups_count: number,
+    datum_hash?: string,
 };
 
 // CardanoAssetGroup

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -808,6 +808,7 @@ export type CardanoTxCertificate = {
     pool?: string,
     pool_parameters?: CardanoPoolParametersType,
     script_hash?: string,
+    key_hash?: string,
 };
 
 // CardanoTxWithdrawal
@@ -815,6 +816,7 @@ export type CardanoTxWithdrawal = {
     path?: number[],
     amount: UintType,
     script_hash?: string,
+    key_hash?: string,
 };
 
 // CardanoCatalystRegistrationParametersType

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -636,6 +636,7 @@ export const Enum_CardanoTxSigningMode = Object.freeze({
     ORDINARY_TRANSACTION: 0,
     POOL_REGISTRATION_AS_OWNER: 1,
     MULTISIG_TRANSACTION: 2,
+    PLUTUS_TRANSACTION: 3,
 });
 export type CardanoTxSigningMode = $Values<typeof Enum_CardanoTxSigningMode>;
 
@@ -731,6 +732,8 @@ export type CardanoSignTxInit = {
     derivation_type: CardanoDerivationType,
     include_network_id?: boolean,
     script_data_hash?: string,
+    collateral_inputs_count: number,
+    required_signers_count: number,
 };
 
 // CardanoTxInput
@@ -831,6 +834,18 @@ export type CardanoTxAuxiliaryData = {
 // CardanoTxMint
 export type CardanoTxMint = {
     asset_groups_count: number,
+};
+
+// CardanoTxCollateralInput
+export type CardanoTxCollateralInput = {
+    prev_hash: string,
+    prev_index: number,
+};
+
+// CardanoTxRequiredSigner
+export type CardanoTxRequiredSigner = {
+    key_hash?: string,
+    key_path?: number[],
 };
 
 // CardanoTxItemAck
@@ -2272,6 +2287,8 @@ export type MessageType = {
     CardanoCatalystRegistrationParametersType: $Exact<CardanoCatalystRegistrationParametersType>,
     CardanoTxAuxiliaryData: CardanoTxAuxiliaryData,
     CardanoTxMint: $Exact<CardanoTxMint>,
+    CardanoTxCollateralInput: $Exact<CardanoTxCollateralInput>,
+    CardanoTxRequiredSigner: CardanoTxRequiredSigner,
     CardanoTxItemAck: CardanoTxItemAck,
     CardanoTxAuxiliaryDataSupplement: $Exact<CardanoTxAuxiliaryDataSupplement>,
     CardanoTxWitnessRequest: CardanoTxWitnessRequest,

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -224,6 +224,7 @@ export const cardanoSignTransaction = async () => {
                         tokenAmounts: [{ assetNameBytes: 'aaff00..', amount: '3003112' }],
                     },
                 ],
+                datumHash: 'aaff00..',
             },
             {
                 addressParameters: {
@@ -244,6 +245,7 @@ export const cardanoSignTransaction = async () => {
                         tokenAmounts: [{ assetNameBytes: 'aaff00..', amount: '3003112' }],
                     },
                 ],
+                datumHash: 'aaff00..',
             },
         ],
         certificates: [
@@ -317,6 +319,7 @@ export const cardanoSignTransaction = async () => {
         fee: '42',
         ttl: '10',
         validityIntervalStart: '20',
+        scriptDataHash: 'aaff00..',
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -320,6 +320,7 @@ export const cardanoSignTransaction = async () => {
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+        includeNetworkId: false,
     });
 
     if (sign.success) {

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -287,9 +287,12 @@ export const cardanoSignTransaction = async () => {
                     },
                 },
                 scriptHash: 'aaff00..',
+                keyHash: 'aaff00..',
             },
         ],
-        withdrawals: [{ path: 'm/44', amount: '3003112', scriptHash: 'aaff00..' }],
+        withdrawals: [
+            { path: 'm/44', amount: '3003112', scriptHash: 'aaff00..', keyHash: 'aaff00..' },
+        ],
         mint: [
             {
                 policyId: 'aaff00..',

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -320,6 +320,19 @@ export const cardanoSignTransaction = async () => {
         ttl: '10',
         validityIntervalStart: '20',
         scriptDataHash: 'aaff00..',
+        collateralInputs: [
+            {
+                path: 'm/44',
+                prev_hash: '1af..',
+                prev_index: 0,
+            },
+        ],
+        requiredSigners: [
+            {
+                keyPath: 'm/44',
+                keyHash: '1af..',
+            },
+        ],
         protocolMagic: 0,
         networkId: 0,
         signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -146,7 +146,7 @@ export namespace UI {
 export namespace CARDANO {
     enum PROTOCOL_MAGICS {
         mainnet = 764824073,
-        testnet = 42,
+        testnet = 1097911063,
     }
 
     enum NETWORK_IDS {

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -88,7 +88,7 @@ export interface CardanoNativeScriptHash {
 // Sign transaction
 
 export interface CardanoInput {
-    path: string | number[];
+    path?: string | number[];
     prev_hash: string;
     prev_index: number;
 }

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -194,6 +194,7 @@ export interface CardanoSignTransaction {
     networkId: number;
     signingMode: CardanoTxSigningMode;
     derivationType?: CardanoDerivationType;
+    includeNetworkId?: boolean;
 }
 
 export type CardanoSignedTxWitness = {

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -169,6 +169,17 @@ export type CardanoWithdrawal = {
 
 export type CardanoMint = CardanoAssetGroup[];
 
+export type CardanoCollateralInput = {
+    path?: string | number[];
+    prev_hash: string;
+    prev_index: number;
+};
+
+export type CardanoRequiredSigner = {
+    keyPath?: string | number[];
+    keyHash?: string;
+};
+
 export type CardanoCatalystRegistrationParameters = {
     votingPublicKey: string;
     stakingPath: string | number[];
@@ -192,6 +203,8 @@ export interface CardanoSignTransaction {
     auxiliaryData?: CardanoAuxiliaryData;
     mint?: CardanoMint;
     scriptDataHash?: string;
+    collateralInputs?: CardanoCollateralInput[];
+    requiredSigners?: CardanoRequiredSigner[];
     additionalWitnessRequests?: (string | number[])[];
     protocolMagic: number;
     networkId: number;

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -159,12 +159,14 @@ export type CardanoCertificate = {
     pool?: string;
     poolParameters?: CardanoPoolParameters;
     scriptHash?: string;
+    keyHash?: string;
 };
 
 export type CardanoWithdrawal = {
     path?: string | number[];
     amount: string;
     scriptHash?: string;
+    keyHash?: string;
 };
 
 export type CardanoMint = CardanoAssetGroup[];

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -109,11 +109,13 @@ export type CardanoOutput =
           addressParameters: CardanoAddressParameters;
           amount: string;
           tokenBundle?: CardanoAssetGroup[];
+          datumHash?: string;
       }
     | {
           address: string;
           amount: string;
           tokenBundle?: CardanoAssetGroup[];
+          datumHash?: string;
       };
 
 export type CardanoPoolOwner = {
@@ -189,6 +191,7 @@ export interface CardanoSignTransaction {
     validityIntervalStart?: string;
     auxiliaryData?: CardanoAuxiliaryData;
     mint?: CardanoMint;
+    scriptDataHash?: string;
     additionalWitnessRequests?: (string | number[])[];
     protocolMagic: number;
     networkId: number;

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -706,6 +706,7 @@ export type CardanoSignTxInit = {
     witness_requests_count: number;
     minting_asset_groups_count: number;
     derivation_type: CardanoDerivationType;
+    include_network_id?: boolean;
 };
 
 // CardanoTxInput

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -785,6 +785,7 @@ export type CardanoTxCertificate = {
     pool?: string;
     pool_parameters?: CardanoPoolParametersType;
     script_hash?: string;
+    key_hash?: string;
 };
 
 // CardanoTxWithdrawal
@@ -792,6 +793,7 @@ export type CardanoTxWithdrawal = {
     path?: number[];
     amount: UintType;
     script_hash?: string;
+    key_hash?: string;
 };
 
 // CardanoCatalystRegistrationParametersType

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -615,6 +615,7 @@ export enum CardanoTxSigningMode {
     ORDINARY_TRANSACTION = 0,
     POOL_REGISTRATION_AS_OWNER = 1,
     MULTISIG_TRANSACTION = 2,
+    PLUTUS_TRANSACTION = 3,
 }
 
 export enum CardanoTxWitnessType {
@@ -708,6 +709,8 @@ export type CardanoSignTxInit = {
     derivation_type: CardanoDerivationType;
     include_network_id?: boolean;
     script_data_hash?: string;
+    collateral_inputs_count: number;
+    required_signers_count: number;
 };
 
 // CardanoTxInput
@@ -808,6 +811,18 @@ export type CardanoTxAuxiliaryData = {
 // CardanoTxMint
 export type CardanoTxMint = {
     asset_groups_count: number;
+};
+
+// CardanoTxCollateralInput
+export type CardanoTxCollateralInput = {
+    prev_hash: string;
+    prev_index: number;
+};
+
+// CardanoTxRequiredSigner
+export type CardanoTxRequiredSigner = {
+    key_hash?: string;
+    key_path?: number[];
 };
 
 // CardanoTxItemAck

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -707,6 +707,7 @@ export type CardanoSignTxInit = {
     minting_asset_groups_count: number;
     derivation_type: CardanoDerivationType;
     include_network_id?: boolean;
+    script_data_hash?: string;
 };
 
 // CardanoTxInput
@@ -721,6 +722,7 @@ export type CardanoTxOutput = {
     address_parameters?: CardanoAddressParametersType;
     amount: UintType;
     asset_groups_count: number;
+    datum_hash?: string;
 };
 
 // CardanoAssetGroup

--- a/tests/__fixtures__/cardanoGetAddress.js
+++ b/tests/__fixtures__/cardanoGetAddress.js
@@ -79,7 +79,7 @@ export default {
                     addressType: CardanoAddressType.BYRON,
                     path: "m/44'/1815'/0'/0/0",
                 },
-                protocolMagic: PROTOCOL_MAGICS.testnet,
+                protocolMagic: 42, // legacy testnet protocol magic
                 networkId: NETWORK_IDS.testnet,
             },
             result: {
@@ -94,7 +94,7 @@ export default {
                     addressType: CardanoAddressType.BYRON,
                     path: "m/44'/1815'/0'/0/1",
                 },
-                protocolMagic: PROTOCOL_MAGICS.testnet,
+                protocolMagic: 42, // legacy testnet protocol magic
                 networkId: NETWORK_IDS.testnet,
             },
             result: {
@@ -109,7 +109,7 @@ export default {
                     addressType: CardanoAddressType.BYRON,
                     path: "m/44'/1815'/0'/0/2",
                 },
-                protocolMagic: PROTOCOL_MAGICS.testnet,
+                protocolMagic: 42, // legacy testnet protocol magic
                 networkId: NETWORK_IDS.testnet,
             },
             result: {

--- a/tests/__fixtures__/cardanoGetAddress.js
+++ b/tests/__fixtures__/cardanoGetAddress.js
@@ -219,7 +219,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -241,7 +241,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -263,7 +263,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -285,7 +285,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -307,7 +307,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -329,7 +329,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -379,7 +379,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -399,7 +399,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -464,7 +464,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -489,7 +489,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -539,7 +539,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -559,7 +559,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -592,5 +592,5 @@ export default {
             },
             result: false,
         },
-    ].map(fixture => ({ ...fixture, legacyResults })),
+    ],
 };

--- a/tests/__fixtures__/cardanoGetPublicKey.js
+++ b/tests/__fixtures__/cardanoGetPublicKey.js
@@ -74,5 +74,5 @@ export default {
             },
             legacyResults,
         },
-    ].map(fixture => ({ ...fixture, legacyResults })),
+    ],
 };

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -807,7 +807,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support auxiliary data hash or auxiliary data at all
-                    rules: ['<2.4.2'],
+                    rules: ['<2.4.2', '1'],
                     payload: false,
                 },
             ],
@@ -858,7 +858,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support auxiliary data
-                    rules: ['<2.3.7'],
+                    rules: ['<2.3.7', '1'],
                     payload: false,
                 },
             ],
@@ -909,7 +909,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support auxiliary data
-                    rules: ['<2.3.7'],
+                    rules: ['<2.3.7', '1'],
                     payload: false,
                 },
             ],
@@ -1088,7 +1088,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support token minting
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1130,7 +1130,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1165,7 +1165,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1210,7 +1210,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1252,7 +1252,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1295,7 +1295,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1347,7 +1347,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support multisig
-                    rules: ['<2.4.3'],
+                    rules: ['<2.4.3', '1'],
                     payload: false,
                 },
             ],
@@ -1382,7 +1382,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support a zero ttl
-                    rules: ['<2.4.2'],
+                    rules: ['<2.4.2', '1'],
                     payload: false,
                 },
             ],
@@ -1419,7 +1419,7 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support a zero validityIntervalStart
-                    rules: ['<2.4.2'],
+                    rules: ['<2.4.2', '1'],
                     payload: false,
                 },
             ],
@@ -1642,5 +1642,5 @@ export default {
                 },
             ],
         },
-    ].map(fixture => ({ ...fixture, legacyResults })),
+    ],
 };

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -18,6 +18,11 @@ const SAMPLE_INPUTS = {
         prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
         prev_index: 0,
     },
+    shelley_input_2: {
+        path: "m/1852'/1815'/0'/0/1",
+        prev_hash: '991af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dc',
+        prev_index: 0,
+    },
     external_input: {
         path: undefined,
         prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
@@ -1025,6 +1030,7 @@ export default {
             },
             legacyResults,
         },
+
         {
             description: 'signStakePoolRegistration',
             params: {
@@ -1058,6 +1064,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'signStakePoolRegistrationNoMetadata',
             params: {
@@ -1091,6 +1098,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'signMaryWithValidityIntervalStart',
             params: {
@@ -1123,6 +1131,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'signMaryTokenSending',
             params: {
@@ -1154,6 +1163,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'ordinaryTransactionWithTokenMinting',
             params: {
@@ -1196,6 +1206,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'multisigTransactionWithTokenMinting',
             params: {
@@ -1471,6 +1482,7 @@ export default {
                 },
             ],
         },
+
         {
             description: 'signTtlIs0',
             params: {
@@ -1795,6 +1807,398 @@ export default {
             legacyResults: [
                 {
                     // older FW doesn't support network id in tx body
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusTransactionWithTokenMinting',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.token_output],
+                fee: FEE,
+                ttl: TTL,
+                validityIntervalStart: VALIDITY_INTERVAL_START,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                mint: SAMPLE_MINTS.basic,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1855'/1815'/0'"],
+            },
+            result: {
+                hash: '0bccf5125597d7459b3e19c807c0264b8e49864608ae271e3f37d602e28b5a5a',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '064c4876b3ddc6da4bc869f69b1a4408792469a7ba0f2646b7399f999bd76e2cb4d8da82e21b9b164ba56e14e5d8b78f3360ee52a29ca97ec4151368fbeb9f0d',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            'c31e0e311c9dd3cac3cfd3214c1cf8fb02537df8b56afde06c57e7d56029eef2aee18a4422a22e64894fad48aaf745c7b019dd42fe562575986a93ec25a6250f',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b75258e4f61eb7b313d8554c2fe10673cf214ca2d762bfd53ec3b7846e2ee872',
+                        signature:
+                            'd1f1727457d4905ad15b5f40756fd137647f09f7cafa36fd5de285193cf527dc36b4e403b64fd34ba0b9cad4f4a6a4906425d3d5f7fd07697ec3899598300e0a',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithStakeRegistration',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_registration_script],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0"],
+            },
+            result: {
+                hash: 'bb3641fac12c97ff6282030cc329865c9358891d75a4f4994592cbda3c17ad3d',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '929c5cf0ab54d17223391d635a984c52e0d208273ec2b1681dbbb5c5945b8a6f423caaa7b916beb2337e381bfb7a365abe71a218c84bd9c959b8c6a77608d201',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '1ed19c09e302c3f09b9209d25bdf4df067401db1fb2c4fd99a7d0a605092be854cab36ebcdd5ba72e5c42114f99621a3e521cc6a2327fd0c1eb735e73175a201',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithStakeRegistrationAndStakeDelegation',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [
+                    SAMPLE_CERTIFICATES.stake_registration_script,
+                    SAMPLE_CERTIFICATES.stake_delegation_script,
+                ],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '1508afe08c30bc41574f311752e62f6dea1e65970bc29efb33e296e7f160b433',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '438787bb03133652ae21d7e96c9affc87f8c567d57d487e8bb2a9a6ab46ec5d58d6fc83ea60c5be1d80a1b1daba049a8a9c911e53832d5ee94b897ed6b6d7305',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '728c37c2053a87ecede6c660cb50b2863bc50a9c7a63593f2b7e07a1e8b0787150cf48a8b836c83586b470b43bcad65f68522478b0a8aad94f6f124244cf4b07',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            'd570d163a74a9703a991ee74e7e50a67e1cd01290d879452a3ee1cb046a5a4711a1e89e90748f3bb11086d35b7f6343040886fcd3003fb1e8930258b6d06b60f',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithStakeDeregistration',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '077c9e912f66f69d78c939c8368b164a9734b05ce95a859ee95dbeea48819f45',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '4552cbea3af1224153a15ff0b99fd03a51f3cbd626205ad278e97b7e162428a6907ef68d2e4ca4740c6554f3b8df2e2035a72fd2652739bc713c163497c5760b',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '0c140e1f59b2c0a9f0573ddb51357387de9388c7acd920ffd99efe39cab21b90afeaf3ed576ab11d2350f94fe731c70e8b7a57a328ec0722720fa854e6acce0f',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            '35bc8f64f4a9d5200a5e363e7ec500ed718c5264c2d7aa51426c5cc19ba74259fe89a2c26f9120f3dd9fccb41a33efdede38d15bf02818866d663533efdc150b',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithStakeDeregistrationAndWithdrawal',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
+                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '978a642582aa183a26768e3d22ff964cb8c8db1fb94abb571355ad7bfc8d3020',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '6d04fcde8a22e2170d9639b4422737d784b7f11496374d8466a233b635274c84848697c891a5c687d35e304b57cf80af62d4f80badc2b62e07484583ed313c0c',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '9d16583fbb3bacbba6fa23e22133d449235cf56b5262a40df158b92311ee3319427496f0a0740382c9915ea41387ef71e6b6a9e0c1d836b478bfbca3d27e4b0f',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            'eb97a4bdde77feb6116bbfbd2dce81419e0fae77bb54ed6ed7ad3b23de054eb3ada57d35ec73307f761c807ddb87d88e3bd434f164d524b76174916665af2406',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithRequiredSigners',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input_2],
+                requiredSigners: [
+                    { keyPath: "m/1852'/1815'/0'/0/0" },
+                    { keyPath: "m/1854'/1815'/0'/0/0" },
+                    { keyHash: '3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711' },
+                ],
+            },
+            result: {
+                hash: 'a95ab5e64e225cef28ba889580ca55ec2d95c7154e3f970015f725c0489ba8f6',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'd6463e5436b97d06cffe8785fe2da73325b749279c10f56b69c1b1d66a2825ff9c943a57efdce35cf8e0172512635b3cde4d0058f376406f07000c13c4d4c600',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: '36a8ef21d5b98fdf23a27325cf643deaac35e912c835e35037f23d1061ae5b16',
+                        signature:
+                            '77d3a31d8ab3636eff7f6a92124635d6049b9e62adc83aca06afe1613159151361b4334a56e05385f83dd42cf43ab375cb96a31afa3c0085c07a48f61b41a400',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '0edd219618307ebf9be9618d35136f38efcefdc242ca3d42324c88199cdadb1e773bf76f0f731746ffc7b14a9ae92e692ab6a3886f19f7b28f148c2a08825e06',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'plutusWithManyWitnesses',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
+                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input_2],
+                requiredSigners: [
+                    { keyPath: "m/1852'/1815'/0'/0/2" },
+                    { keyPath: "m/1854'/1815'/0'/0/2" },
+                    { keyPath: "m/1855'/1815'/0'" },
+                ],
+                additionalWitnessRequests: ["m/1852'/1815'/0'/0/3", "m/1854'/1815'/0'/0/3"],
+            },
+            result: {
+                hash: '37face132b208b869d0c11fcab487648067e6978df37b5347bde2964902cc9da',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '21bb9cd8950b7fcb87a18fd061cc022e58de5f01f24d85c88148b84c4ce98cf646754a86c5bb70eae156a3b9e6676c9d817e2adcf47dd538dc54042a1fe2fc07',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: '36a8ef21d5b98fdf23a27325cf643deaac35e912c835e35037f23d1061ae5b16',
+                        signature:
+                            '7075c37f7ea5c2def45249792c36b97a787e9fe99bd85f0629d31e81a42e3c07754b231b197c53e4a86219782c356eb5efc8792319da25206e8ce151da01880c',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'e90d7b0a6cf831b0042d37961dd528842860e77914e715bcece676c75353b812',
+                        signature:
+                            '8725de956178b26539901d0f74a5094d7eacd482e3f7c62a48aac782ee89f25071f2ab9852ea876bdde3501e82e9978bc22ba672b16c25e65d2413ff6f74c00a',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'e03c8b809288457c44e6dac9bc03d7c91cc0b26b482ae370f6b58da7c1fa90ec',
+                        signature:
+                            'cfc5fc39fd2cacf0ed8ce628a3ef4976f36be33b35357b1cae91752490fc222615f936af858caeefa48b27be949f49c1e165510854f41bc44c6ee447647e3e0b',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b75258e4f61eb7b313d8554c2fe10673cf214ca2d762bfd53ec3b7846e2ee872',
+                        signature:
+                            '0a2934ab1262f829e63d83111db991d71a067e854dbbecd490c2f94331699213fb5b6da317eb9b9a20b6de20c3dc2512547603ba6838c872281604285a830101',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: '10ae189d1d30bef9214e006a0287fc5f2caf56576f04c9d3ef381f0f67856166',
+                        signature:
+                            '446ee208d7b5ac79509f1b6218c34929e382932cbb4d7278241fcf66fee2417d72bccc76d265828a525017aba9ee1ef08708a3a51162907023969eefa9ebee04',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: '6ca4df772965773f096792f45f5241e01aa065ccb6ac12091483e418a04721e9',
+                        signature:
+                            '2f5c120e60211d14cd47a405f79e59cae591bb83599972b62c0027c2864794cc1d2b3d5659f5e56c76f39b71f113f3b1ede12390f2fccc143c52d37606d02803',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support plutus
                     rules: ['<2.4.4', '1'],
                     payload: false,
                 },

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -1768,6 +1768,38 @@ export default {
         },
 
         {
+            description: 'plutusWithDeviceOwnedOutput',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [
+                    SAMPLE_OUTPUTS.simple_shelley_output,
+                    SAMPLE_OUTPUTS.base_address_change_output,
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+            },
+            result: {
+                hash: 'b201b4b2d889f931020fe0f3f637cd3fbe79fae460ab24fd61182e48e9bc975a',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'd84707a76565c5f748679cd3a46b93ba0c1aec37e49d8e87fbb6785738c19bd10b311af9eddc22e520b43ef0a4a6e934be7917ff87456522a6378d84e431d207',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [legacyResults.beforePlutus],
+        },
+
+        {
             description: 'plutusTransactionWithTokenMinting',
             params: {
                 inputs: [SAMPLE_INPUTS.external_input],

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -1016,7 +1016,7 @@ export default {
                 ],
                 fee: FEE,
                 ttl: TTL,
-                protocolMagic: PROTOCOL_MAGICS.testnet,
+                protocolMagic: 42,
                 networkId: NETWORK_IDS.testnet,
                 signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
             },

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -553,7 +553,13 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [
+                {
+                    // older FW doesn't support transactions with no outputs
+                    rules: ['<2.3.5', '1'],
+                    payload: false,
+                },
+            ],
         },
 
         {
@@ -595,7 +601,7 @@ export default {
                 ...legacyResults,
                 {
                     // witness are ordered differently
-                    rules: ['2.3.3-2.3.8'],
+                    rules: ['2.3.2-2.3.6'],
                     payload: {
                         hash: '439764b5f7e08839881536a3191faeaf111e75d9f00f83b102c5c1c6fa9fcaf9',
                         witnesses: [
@@ -656,7 +662,7 @@ export default {
                 ...legacyResults,
                 {
                     // witness are ordered differently
-                    rules: ['2.3.3-2.3.8'],
+                    rules: ['2.3.2-2.3.6'],
                     payload: {
                         hash: '3aca1784d151dc75bdbb80fae71bda3f4b26af3f5fd71bd5e9e9bbcdd2b64ad1',
                         witnesses: [
@@ -718,7 +724,7 @@ export default {
                 ...legacyResults,
                 {
                     // witness are ordered differently
-                    rules: ['2.3.3-2.3.8'],
+                    rules: ['2.3.2-2.3.6'],
                     payload: {
                         hash: '22c67f12e6f6aa0f2f09fd27d472b19c7208ccd7c3af4b09604fd5d462c1de2b',
                         witnesses: [
@@ -971,7 +977,13 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [
+                {
+                    // older FW doesn't support stake pool registration as owner
+                    rules: ['<2.3.5', '1'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: 'signStakePoolRegistrationNoMetadata',
@@ -998,7 +1010,13 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [
+                {
+                    // older FW doesn't support stake pool registration as owner
+                    rules: ['<2.3.5', '1'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: 'signMaryWithValidityIntervalStart',
@@ -1024,7 +1042,13 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [
+                {
+                    // older FW doesn't support validity interval start
+                    rules: ['<2.3.5', '1'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: 'signMaryTokenSending',
@@ -1049,7 +1073,13 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [
+                {
+                    // older FW doesn't support multiasset outputs
+                    rules: ['<2.3.5', '1'],
+                    payload: false,
+                },
+            ],
         },
         {
             description: 'ordinaryTransactionWithTokenMinting',
@@ -1595,10 +1625,14 @@ export default {
                 },
             },
             legacyResults: [
-                ...legacyResults,
+                {
+                    // older FW doesn't support auxiliary data
+                    rules: ['<2.3.7', '1'],
+                    payload: false,
+                },
                 {
                     // witnesses are ordered differently since they are parsed from the tx body
-                    rules: ['2.2.1-2.4.1'],
+                    rules: ['2.3.7-2.4.1'],
                     payload: {
                         hash: 'ee0dfef8b97857ebe7aa8935af50e9f8f608ff4054c0c034600750d722d90631',
                         witnesses: [
@@ -1639,6 +1673,41 @@ export default {
                                 '74f27d877bbb4a5fc4f7c56869905c11f70bad0af3de24b23afaa1d024e750930f434ecc4b73e5d1723c2cb8548e8bf6098ac876487b3a6ed0891cb76994d409',
                         },
                     },
+                },
+            ],
+        },
+
+        {
+            description: 'signWithIncludeNetworkId',
+            params: {
+                inputs: [SAMPLE_INPUTS.byron_input],
+                outputs: [SAMPLE_OUTPUTS.simple_byron_output],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+                includeNetworkId: true,
+            },
+            result: {
+                hash: '4fcd4532bb0a9dfff2368e60be80d46819a92a9acfb2c64a7bf5975040789bac',
+                witnesses: [
+                    {
+                        type: 0,
+                        pubKey: '89053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea',
+                        signature:
+                            '7223909207fc1fa0c6125ffd4fbf7e1d845b7ca77078de7705aa34e4b6f416bb2efaaadfa022a91437ba4f33875b9a688f78d6fb30542b59417650a169afde01',
+                        chainCode:
+                            '26308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a635',
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support network id in tx body
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
                 },
             ],
         },

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -143,6 +143,11 @@ const SAMPLE_OUTPUTS = {
             },
         ],
     },
+    output_with_datum_hash: {
+        address: 'addr1w9rhu54nz94k9l5v6d9rzfs47h7dv7xffcwkekuxcx3evnqpvuxu0',
+        amount: '1',
+        datumHash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+    },
 };
 
 const SAMPLE_CERTIFICATES = {
@@ -309,6 +314,7 @@ const SAMPLE_MINTS = {
 const FEE = '42';
 const TTL = '10';
 const VALIDITY_INTERVAL_START = '47';
+const SCRIPT_DATA_HASH = 'd593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02';
 
 const legacyResults = [
     {
@@ -922,6 +928,73 @@ export default {
         },
 
         {
+            description: 'signOutputWithDatumHash',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.output_with_datum_hash],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+            },
+            result: {
+                hash: '8ea2765f1e46d84f02d8b25a5f0cf445aaeaadcab913e17e59388a4f898ca812',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'ccc4e3c2adbf63561881212c8dffd42a02850460256da9b393aaed2cbd131fbb2798a92a2adf59c31d22e1e33c3dad011d91e09aa2d5b15ba64fa995bf241900',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support output datum hash
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
+            description: 'signScriptDataHash',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+            },
+            result: {
+                hash: '8606e5b69b5c40bd359d7bad6ed6f77810b8e8acba6cbca298c13f92b11178d4',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'c8676cf593554f347e2d6a5ffc6a1371638156eaaddb3e7f94ae9a7488a6adb01c3660d8aff1da08e01c4899615158e69c5c797841ef7747740ab56d3b452f0c',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [
+                {
+                    // older FW doesn't support script data hash
+                    rules: ['<2.4.4', '1'],
+                    payload: false,
+                },
+            ],
+        },
+
+        {
             description: 'signTestnet',
             params: {
                 inputs: [SAMPLE_INPUTS.byron_input],
@@ -1335,7 +1408,10 @@ export default {
             description: 'multisigWithMostElementsFilledAndSharedWithLedger',
             params: {
                 inputs: [SAMPLE_INPUTS.external_input],
-                outputs: [SAMPLE_OUTPUTS.output_common_with_ledger],
+                outputs: [
+                    SAMPLE_OUTPUTS.output_common_with_ledger,
+                    SAMPLE_OUTPUTS.output_with_datum_hash,
+                ],
                 fee: FEE,
                 ttl: TTL,
                 validityIntervalStart: VALIDITY_INTERVAL_START,
@@ -1349,26 +1425,39 @@ export default {
                     hash: '58ec01578fcdfdc376f09631a7b2adc608eaf57e3720484c7ff37c13cff90fdf',
                 },
                 mint: SAMPLE_MINTS.common_with_ledger,
+                scriptDataHash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
                 signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
-                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+                additionalWitnessRequests: [
+                    "m/1854'/1815'/0'/0/0",
+                    "m/1854'/1815'/0'/2/0",
+                    "m/1855'/1815'/0'",
+                ],
+                includeNetworkId: true,
             },
             result: {
-                hash: '2be64c04ea3f5bac3c224ec47a4157ade91fc6ab4fd6b83ce3d57b2e9186720b',
+                hash: 'c3637e34529fae17dbbb90c58307df0cf3b818f4c034860fff362d1ea864cca4',
                 witnesses: [
                     {
                         type: 1,
                         pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
                         signature:
-                            '38a56a46b21caef91742ffafdec202ed96809c3070c9bfd51db5c750d77edbfb8514d9cd2255ab5a857dd8a63706ae0ca29e390fba6af7a906b186aed117b809',
+                            '58bc9f1c39f2cd4248ad79a5f6a4733a6e751e86b09163e468b92ec1079590f6052f30f9a782812ba1b553f1c5f22cad807af97494cf8a0a26bf123bc2f60202',
                         chainCode: null,
                     },
                     {
                         type: 1,
                         pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
                         signature:
-                            '0c9071c421fe207ac1d9102643eac8ddf5ff29238782956b5706b9f1f084dfc5c087b4ceda6d079f8bb6438d3b556d3ac97565a87a8ec33f11856408b0480400',
+                            '8b3e5b1b013d7456c1b0d67a334af725e3e1d3ea9a4a8ff05889314691f797cb49fff2cc10764133bce154db5e0eb91e4c1982cf53e6578648cf1f251f37020a',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b75258e4f61eb7b313d8554c2fe10673cf214ca2d762bfd53ec3b7846e2ee872',
+                        signature:
+                            'cb3daca29e217a9f0c7e5ad47b0d07827ce8937d252ba6e32415f4613e8e6675e1b3964d28b354d338bae623bba1c30bf47a37818b56602a6e7ba7ff081aa605',
                         chainCode: null,
                     },
                 ],
@@ -1376,8 +1465,8 @@ export default {
             },
             legacyResults: [
                 {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
+                    // older FW doesn't support output datum hash and script data hash
+                    rules: ['<2.4.4', '1'],
                     payload: false,
                 },
             ],

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -172,6 +172,10 @@ const SAMPLE_CERTIFICATES = {
         type: CardanoCertificateType.STAKE_DEREGISTRATION,
         scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
     },
+    stake_deregistration_key_hash: {
+        type: CardanoCertificateType.STAKE_DEREGISTRATION,
+        keyHash: '3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711',
+    },
     stake_delegation: {
         type: CardanoCertificateType.STAKE_DELEGATION,
         path: "m/1852'/1815'/0'/2/0",
@@ -260,14 +264,19 @@ const SAMPLE_CERTIFICATES = {
     },
 };
 
-const SAMPLE_WITHDRAWAL = {
-    path: "m/1852'/1815'/0'/2/0",
-    amount: '1000',
-};
-
-const SAMPLE_WITHDRAWAL_SCRIPT = {
-    scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
-    amount: '1000',
+const SAMPLE_WITHDRAWALS = {
+    basic: {
+        path: "m/1852'/1815'/0'/2/0",
+        amount: '1000',
+    },
+    script: {
+        scriptHash: '29fb5fd4aa8cadd6705acc8263cee0fc62edca5ac38db593fec2f9fd',
+        amount: '1000',
+    },
+    key_hash: {
+        keyHash: '3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711',
+        amount: '1000',
+    },
 };
 
 const SAMPLE_MINTS = {
@@ -321,13 +330,34 @@ const TTL = '10';
 const VALIDITY_INTERVAL_START = '47';
 const SCRIPT_DATA_HASH = 'd593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02';
 
-const legacyResults = [
-    {
+const legacyResults = {
+    beforeSignTx: {
         // cardanoSignTransaction not supported below this version
         rules: ['<2.3.2', '1'],
         success: false,
     },
-];
+    beforeStakePoolRegistrationAsOwner: {
+        // older FW doesn't support stake pool registration as owner
+        rules: ['<2.3.5', '1'],
+        payload: false,
+    },
+    beforeAuxiliaryData: {
+        // older FW doesn't support auxiliary data
+        rules: ['<2.3.7', '1'],
+        payload: false,
+    },
+    beforeMultisig: {
+        // older FW doesn't support multisig
+        rules: ['<2.4.3', '1'],
+        payload: false,
+    },
+    beforePlutus: {
+        // older FW doesn't support plutus-related features (OutputDatumHash, ScriptDataHash,
+        // Plutus, KeyHashStakeCredential)
+        rules: ['<2.4.4', '1'],
+        payload: false,
+    },
+};
 
 export default {
     method: 'cardanoSignTransaction',
@@ -360,7 +390,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -388,7 +418,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -418,7 +448,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -448,7 +478,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -478,7 +508,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -508,7 +538,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -536,7 +566,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -609,7 +639,7 @@ export default {
                 auxiliaryDataSupplement: undefined,
             },
             legacyResults: [
-                ...legacyResults,
+                legacyResults.beforeSignTx,
                 {
                     // witness are ordered differently
                     rules: ['2.3.2-2.3.6'],
@@ -670,7 +700,7 @@ export default {
                 auxiliaryDataSupplement: undefined,
             },
             legacyResults: [
-                ...legacyResults,
+                legacyResults.beforeSignTx,
                 {
                     // witness are ordered differently
                     rules: ['2.3.2-2.3.6'],
@@ -706,7 +736,7 @@ export default {
                 fee: FEE,
                 ttl: TTL,
                 certificates: [SAMPLE_CERTIFICATES.stake_deregistration],
-                withdrawals: [SAMPLE_WITHDRAWAL],
+                withdrawals: [SAMPLE_WITHDRAWALS.basic],
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
                 signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
@@ -732,7 +762,7 @@ export default {
                 auxiliaryDataSupplement: undefined,
             },
             legacyResults: [
-                ...legacyResults,
+                legacyResults.beforeSignTx,
                 {
                     // witness are ordered differently
                     rules: ['2.3.2-2.3.6'],
@@ -823,7 +853,7 @@ export default {
             },
             legacyResults: [
                 {
-                    // older FW doesn't support auxiliary data hash or auxiliary data at all
+                    // older FW doesn't support auxiliary data hash
                     rules: ['<2.4.2', '1'],
                     payload: false,
                 },
@@ -872,13 +902,7 @@ export default {
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support auxiliary data
-                    rules: ['<2.3.7', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeAuxiliaryData],
         },
 
         {
@@ -923,13 +947,7 @@ export default {
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support auxiliary data
-                    rules: ['<2.3.7', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeAuxiliaryData],
         },
 
         {
@@ -956,13 +974,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support output datum hash
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -990,13 +1002,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support script data hash
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1028,7 +1034,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults,
+            legacyResults: [legacyResults.beforeSignTx],
         },
 
         {
@@ -1056,13 +1062,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support stake pool registration as owner
-                    rules: ['<2.3.5', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeStakePoolRegistrationAsOwner],
         },
 
         {
@@ -1090,13 +1090,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support stake pool registration as owner
-                    rules: ['<2.3.5', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeStakePoolRegistrationAsOwner],
         },
 
         {
@@ -1241,13 +1235,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1276,13 +1264,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1321,13 +1303,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1363,13 +1339,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1380,7 +1350,7 @@ export default {
                 fee: FEE,
                 ttl: TTL,
                 certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
-                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                withdrawals: [SAMPLE_WITHDRAWALS.script],
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
                 signingMode: CardanoTxSigningMode.MULTISIG_TRANSACTION,
@@ -1406,13 +1376,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support multisig
-                    rules: ['<2.4.3', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforeMultisig],
         },
 
         {
@@ -1431,7 +1395,7 @@ export default {
                     SAMPLE_CERTIFICATES.stake_deregistration_script,
                     SAMPLE_CERTIFICATES.stake_delegation_script,
                 ],
-                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                withdrawals: [SAMPLE_WITHDRAWALS.script],
                 auxiliaryData: {
                     hash: '58ec01578fcdfdc376f09631a7b2adc608eaf57e3720484c7ff37c13cff90fdf',
                 },
@@ -1474,13 +1438,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support output datum hash and script data hash
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1667,7 +1625,7 @@ export default {
                     SAMPLE_CERTIFICATES.stake_delegation,
                     SAMPLE_CERTIFICATES.stake_deregistration,
                 ],
-                withdrawals: [SAMPLE_WITHDRAWAL],
+                withdrawals: [SAMPLE_WITHDRAWALS.basic],
                 auxiliaryData: {
                     catalystRegistrationParameters: {
                         votingPublicKey:
@@ -1726,11 +1684,7 @@ export default {
                 },
             },
             legacyResults: [
-                {
-                    // older FW doesn't support auxiliary data
-                    rules: ['<2.3.7', '1'],
-                    payload: false,
-                },
+                legacyResults.beforeAuxiliaryData,
                 {
                     // witnesses are ordered differently since they are parsed from the tx body
                     rules: ['2.3.7-2.4.1'],
@@ -1856,13 +1810,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1900,13 +1848,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -1954,13 +1896,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2005,13 +1941,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2022,7 +1952,7 @@ export default {
                 fee: FEE,
                 ttl: TTL,
                 certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
-                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                withdrawals: [SAMPLE_WITHDRAWALS.script],
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
                 signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
@@ -2057,13 +1987,106 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
+        },
+
+        {
+            description: 'plutusWithPathStakeCredentials',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration],
+                withdrawals: [SAMPLE_WITHDRAWALS.basic],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: '782d27250d487d1feec96a44aeda4e796f3f97cbeedc9eaf0f4cd2ec6f399106',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: 'bc65be1b0b9d7531778a1317c2aa6de936963c3f9ac7d5ee9e9eda25e0c97c5e',
+                        signature:
+                            '03a62ab84cbc9f3f1819b7fd68f2bfeca545a97967d824644f3362488763d8d88597cf19661e4c200eccf9a1e747666916099b604e849ae94a286dc935de8a0d',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            'b00848c888bdad1036335bf3f085af00080e448a223187475c6e898aa2a0a6587a28234ac6c7c918847ea00e497b515854ce86471d5860e014d4336fa171fd0d',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '8abf56dadd52259a404563eda52a39631875e36cadd2050829cf755906c5dba91a99834ef3c0e6e507fdc36ed7e8c4880fb8d8834a48dc2315d7201dd6308c00',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            '0b045abaa864a00badd747bdcbc67870336cd94b83f58a5d84cfbfac9e9ba53f8e18175eb630928696072831d9697c1fa33b745a12d6dde2cc6722dd0bed3409',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [legacyResults.beforePlutus],
+        },
+
+        {
+            description: 'plutusWithKeyHashStakeCredentials',
+            params: {
+                inputs: [SAMPLE_INPUTS.external_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES.stake_deregistration_key_hash],
+                withdrawals: [SAMPLE_WITHDRAWALS.key_hash],
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
+                scriptDataHash: SCRIPT_DATA_HASH,
+                collateralInputs: [SAMPLE_INPUTS.shelley_input],
+                additionalWitnessRequests: ["m/1854'/1815'/0'/0/0", "m/1854'/1815'/0'/2/0"],
+            },
+            result: {
+                hash: 'fdcfc5a84caaf8b4ee5efbafb0bc0118eb4e0fec88312429de60ebf34f60e44f',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '9a69dbfb8b61ae7269f3d17c7821b670697382a77584a2fde58bb5cd5b15e8cd08c04a9baaa416b45498649961f1362641e5d2e01dee6f949ac5809ecb0ede02',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'b10be5c0d11ad8292bbe69e220ca0cfbe154610b3041a8e72f9d515c226ab3b1',
+                        signature:
+                            '79a4671f3703f6fe1d67768eed906cf1fdd230655be54360d5e512dd040f5f27022cff99d0ddb073ac58c72d1aecdccc3dff29d49b274214367475767fdd1c0e',
+                        chainCode: null,
+                    },
+                    {
+                        type: 1,
+                        pubKey: 'f2ef4ecd21ad28a8d270ca7be7e96c87f60dc821e13c0d0c5870344e9693637c',
+                        signature:
+                            'c8fc1809c122e6040e564b9226fcdf215075ffa418fc21c74fd04a8d804a989fc005963f1803fcb2fc1b017ff20c5d1bc0fe7a8d20b284210ed89405f5269c02',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: undefined,
+            },
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2111,13 +2134,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
 
         {
@@ -2128,7 +2145,7 @@ export default {
                 fee: FEE,
                 ttl: TTL,
                 certificates: [SAMPLE_CERTIFICATES.stake_deregistration_script],
-                withdrawals: [SAMPLE_WITHDRAWAL_SCRIPT],
+                withdrawals: [SAMPLE_WITHDRAWALS.script],
                 protocolMagic: PROTOCOL_MAGICS.mainnet,
                 networkId: NETWORK_IDS.mainnet,
                 signingMode: CardanoTxSigningMode.PLUTUS_TRANSACTION,
@@ -2196,13 +2213,7 @@ export default {
                 ],
                 auxiliaryDataSupplement: undefined,
             },
-            legacyResults: [
-                {
-                    // older FW doesn't support plutus
-                    rules: ['<2.4.4', '1'],
-                    payload: false,
-                },
-            ],
+            legacyResults: [legacyResults.beforePlutus],
         },
     ],
 };


### PR DESCRIPTION
This PR adds support for Cardano Plutus transactions. Relevant firmware PR [here](https://github.com/trezor/trezor-firmware/pull/2114).

There should be no breaking changes. New features (for details, see the updated [docs](https://github.com/trezor/connect/blob/71a20d42575b964bccd8efd8c27511167341c464/docs/methods/cardanoSignTransaction.md)):
- A new signing mode `PLUTUS_TRANSACTION` that is to be used with transactions involving Plutus script evaluation.
- New tx items `collateralInputs` and `requiredSigners` that can be used in `PLUTUS_TRANSACTION`.
- New tx item `scriptDataHash` and an output item `datumHash` which are used when attaching datums to a tx (when sending funds to a script address).
- Stake credentials in certificates and withdrawals may be given as keyHash in `PLUTUS_TRANSACTION`.
- The network id may be serialized into tx body by setting `includeNetworkId: true`.
- Minor fixes, e.g. a new value for testnet protocol magic.