### PR TITLE
readme and deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # :warning: Maintenance Mode
 
-Trezor Connect v8 is under maintenance mode, all new development efforts are focused on v9. New integrations are recommended to start with v9, currently in beta.
+Trezor Connect v8 is under maintenance mode, all new development efforts are focused on v9. New integrations are recommended to start with v9.
 
-* [Trezor Connect v9 BETA](https://github.com/trezor/trezor-suite/tree/develop/packages/connect)
+* [Trezor Connect](https://github.com/trezor/trezor-suite/tree/develop/packages/connect)
 * [@trezor/connect NPM](https://www.npmjs.com/package/@trezor/connect)
 
 ## New NPM package

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-flow": "^7.14.5",
         "@trezor/blockchain-link": "^2.1.3",
-        "@trezor/connect-common": "^0.0.9",
+        "@trezor/connect-common": "^0.0.10",
         "@trezor/rollout": "^1.3.2",
         "@trezor/transport": "1.1.2",
         "@trezor/utxo-lib": "^1.0.0",
@@ -129,7 +129,7 @@
     },
     "extendedDependencies": {
         "@trezor/blockchain-link": "^2.1.3",
-        "@trezor/connect-common": "^0.0.9",
+        "@trezor/connect-common": "^0.0.10",
         "@trezor/rollout": "^1.3.2",
         "@trezor/transport": "1.1.2",
         "@trezor/utxo-lib": "^1.0.0",

--- a/src/js/env/browser/index.js
+++ b/src/js/env/browser/index.js
@@ -133,6 +133,10 @@ const handleMessage = (messageEvent: $T.PostMessageEvent) => {
 };
 
 export const init = async (settings: $Shape<$T.ConnectSettings> = {}): Promise<void> => {
+    console.warn(
+        'trezor-connect version 8 has been deprecated. Please start using @trezor/connect version 9 https://www.npmjs.com/package/@trezor/connect',
+    );
+
     if (iframe.instance) {
         throw ERRORS.TypedError('Init_AlreadyInitialized');
     }

--- a/src/js/env/node/index.js
+++ b/src/js/env/node/index.js
@@ -122,6 +122,10 @@ const postMessage = (message: any, usePromise: boolean = true) => {
 };
 
 export const init = async (settings: $Shape<$T.ConnectSettings> = {}) => {
+    console.warn(
+        'trezor-connect version 8 has been deprecated. Please start using @trezor/connect version 9 https://www.npmjs.com/package/@trezor/connect',
+    );
+
     if (_core) {
         throw ERRORS.TypedError('Init_AlreadyInitialized');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,10 +2002,10 @@
     socks-proxy-agent "6.1.1"
     ws "7.4.6"
 
-"@trezor/connect-common@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.9.tgz#22478585dac463d376f74c54510887516936850f"
-  integrity sha512-sV7HE10lWZ9D3JB8kDwLpNEieRCWpEjSb+Wul9f3oQVHzB0qbVblP/w6Av9sVm99fSqgZX9jjLVlV9kpKl9yzQ==
+"@trezor/connect-common@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.10.tgz#cf5ff55f97c7b0093598ed56f444c67e5c0b59d8"
+  integrity sha512-bwqB5J6IrLBZ/tGQw/C/EoYZW6Jpjf6ch9sYUog4EVTNIqh5nCLP+g8ShSyco9lvrKInMDXDWwU6OsEZE5gcPQ==
 
 "@trezor/rollout@^1.3.2":
   version "1.3.2"


### PR DESCRIPTION
- update readme
- add depracation messages into runtime
- update @trezor/connect-common to get the latest firmware prompt

next steps: 
consider more aggressive approach using https://doc.codingdict.com/npm-ref/cli/deprecate.html 

resolve
- https://github.com/trezor/trezor-suite/issues/7122
- https://github.com/trezor/trezor-suite/issues/6977

needs to be released