### PR TITLE
Update coins.json

### DIFF
--- a/src/data/coins.json
+++ b/src/data/coins.json
@@ -1914,7 +1914,7 @@
             "blockchain_link": {
                 "type": "blockbook",
                 "url": [
-                    "https://sys1.bcfn.ca"
+                    "https://blockbook.elint.services"
                 ]
             },
             "blocktime_seconds": 60,


### PR DESCRIPTION
Update syscoin URL, our previous blockexplorer at sys1.bcfn.ca isn't operational any longer and that's making the trezor connection to syscoin fail.